### PR TITLE
Add tests for interoperability between different sets of features

### DIFF
--- a/.github/workflows/interop_tests.yml
+++ b/.github/workflows/interop_tests.yml
@@ -10,15 +10,38 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
         path: mls
     - name: Start test MLS client
       working-directory: mls-rs/test_harness_integration 
-      run: cargo run &
+      run: |
+        cargo run -- --port 50001 &
+        cargo run --no-default-features -- --port 50002 &
+        
+        # no tree_index
+        cargo run --no-default-features --features private_message,prior_epoch,out_of_order,psk,custom_proposal,by_ref_proposal -- --port 50003 &
+        
+        # no private_message
+        cargo run --no-default-features --features tree_index,prior_epoch,out_of_order,psk,custom_proposal,by_ref_proposal -- --port 50004 &
+        
+        # no prior_epoch
+        cargo run --no-default-features --features tree_index,private_message,out_of_order,psk,custom_proposal,by_ref_proposal -- --port 50005 &
+        
+        # no out_of_order
+        cargo run --no-default-features --features tree_index,private_message,prior_epoch,psk,custom_proposal,by_ref_proposal -- --port 50006 &
+        
+        # no psk
+        cargo run --no-default-features --features tree_index,private_message,prior_epoch,out_of_order,custom_proposal,by_ref_proposal -- --port 50007 &
+        
+        # no custom_proposal
+        cargo run --no-default-features --features tree_index,private_message,prior_epoch,out_of_order,psk,by_ref_proposal -- --port 50008 &
+        
+        # no by_ref_proposal
+        cargo run --no-default-features --features tree_index,private_message,prior_epoch,out_of_order,psk,custom_proposal -- --port 50009 &
     - name: Clone test runner
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         repository: mlswg/mls-implementations
         ref: 3d338d341b1b02c5a2a1a631c60985ce844d2def
@@ -30,6 +53,7 @@ jobs:
     - name: Run tests
       working-directory: interop/interop
       run: |
+        cp -r ../../mls-rs/test_harness_integration/configs mls-rs-configs
         go env -w GOPROXY=direct
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
         go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
@@ -38,4 +62,30 @@ jobs:
         export PATH=$PATH:$GOROOT:$GOPATH:$GOBIN
         GOFLAGS=-mod=mod go generate ./...
         make test-runner/test-runner
-        for config in `ls configs | grep -v deep | sed -e "s/configs\///"`; do test-runner/test-runner --client localhost:50002 --config configs/$config ; done
+
+        # all features with itself
+        for config in `ls mls-rs-configs | sed -e "s/mls-rs-configs\///"`; do test-runner/test-runner --client localhost:50001 --config mls-rs-configs/$config ; done
+        
+        # all features with no features
+        test-runner/test-runner --client localhost:50001 --client localhost:50002 --suite 1 --public --config mls-rs-configs/bare_bones.json
+
+        # all features with "no tree_index"
+        for config in `ls mls-rs-configs | sed -e "s/mls-rs-configs\///"`; do test-runner/test-runner --client localhost:50001 --client localhost:50003 --suite 1 --config mls-rs-configs/$config ; done
+
+        # all features with "no private_message"
+        for config in `ls mls-rs-configs | grep -v "application"  | sed -e "s/mls-rs-configs\///"`; do test-runner/test-runner --client localhost:50001 --client localhost:50004 --public --suite 1 --config mls-rs-configs/$config ; done
+
+        # all features with "no prior_epoch"
+        for config in `ls mls-rs-configs | grep -Ev "(application_out_of_order_across)|(psk)" | sed -e "s/mls-rs-configs\///"`; do test-runner/test-runner --client localhost:50001 --client localhost:50005 --suite 1 --config mls-rs-configs/$config ; done
+
+        # all features with "no out_of_order"
+        for config in `ls mls-rs-configs | grep -v "application_out_of_order" | sed -e "s/mls-rs-configs\///"`; do test-runner/test-runner --client localhost:50001 --client localhost:50006 --suite 1 --config mls-rs-configs/$config ; done
+
+        # all features with "no psk"
+        for config in `ls mls-rs-configs | grep -Ev "(psk)|(branch)|(reinit)" | sed -e "s/mls-rs-configs\///"`; do test-runner/test-runner --client localhost:50001 --client localhost:50007 --suite 1 --config mls-rs-configs/$config ; done
+
+         # all features with "no custom_proposal"
+        for config in `ls mls-rs-configs | sed -e "s/mls-rs-configs\///"`; do test-runner/test-runner --client localhost:50001 --client localhost:50008 --suite 1 --config mls-rs-configs/$config ; done
+
+         # all features with "no by_ref_proposal"
+        for config in `ls mls-rs-configs | grep -E "(application)|(commit_by_value)|(branch)|(welcome_join)" | sed -e "s/mls-rs-configs\///"`; do test-runner/test-runner --client localhost:50001 --client localhost:50009 --suite 1 --config mls-rs-configs/$config ; done

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Test Bare Bones
       run: cargo test --no-default-features --features std,test_util  --verbose --workspace
     - name: Test Async Full RFC
-      run: RUSTFLAGS='--cfg mls_build_async' cargo test --lib --test '*' --verbose --features test_util --workspace --exclude mls-rs-provider-sqlite --exclude fuzz --exclude mls-rs-ffi
+      run: RUSTFLAGS='--cfg mls_build_async' cargo test --lib --test '*' --verbose --features test_util -p mls-rs
     - name: Test Async Bare Bones 
-      run: RUSTFLAGS='--cfg mls_build_async' cargo test --no-default-features --lib --test '*' --features std,test_util --verbose --workspace --exclude mls-rs-provider-sqlite --exclude fuzz --exclude mls-rs-ffi
+      run: RUSTFLAGS='--cfg mls_build_async' cargo test --no-default-features --lib --test '*' --features std,test_util --verbose -p mls-rs
     - name: Examples
       working-directory: mls-rs
       run: cargo run --example basic_usage

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -23,6 +23,7 @@ use crate::identity::SigningIdentity;
 use crate::key_package::{KeyPackage, KeyPackageRef};
 use crate::protocol_version::ProtocolVersion;
 use crate::psk::secret::PskSecret;
+use crate::psk::PreSharedKeyID;
 use crate::signer::Signable;
 use crate::tree_kem::hpke_encryption::HpkeEncryptable;
 use crate::tree_kem::kem::TreeKem;
@@ -51,8 +52,8 @@ pub use self::resumption::ReinitClient;
 
 #[cfg(feature = "psk")]
 use crate::psk::{
-    resolver::PskResolver, secret::PskSecretInput, ExternalPskId, JustPreSharedKeyID,
-    PreSharedKeyID, PskGroupId, PskNonce, ResumptionPSKUsage, ResumptionPsk,
+    resolver::PskResolver, secret::PskSecretInput, ExternalPskId, JustPreSharedKeyID, PskGroupId,
+    PskNonce, ResumptionPSKUsage, ResumptionPsk,
 };
 
 #[cfg(all(feature = "std", feature = "by_ref_proposal"))]
@@ -169,7 +170,6 @@ mod interop_test_vectors;
 struct GroupSecrets {
     joiner_secret: JoinerSecret,
     path_secret: Option<PathSecret>,
-    #[cfg(feature = "psk")]
     psks: Vec<PreSharedKeyID>,
 }
 
@@ -783,10 +783,12 @@ where
             })
             .transpose()?;
 
+        #[cfg(not(feature = "psk"))]
+        let psks = Vec::new();
+
         let group_secrets = GroupSecrets {
             joiner_secret: joiner_secret.clone(),
             path_secret,
-            #[cfg(feature = "psk")]
             psks,
         };
 
@@ -1098,7 +1100,7 @@ where
             MlsMessagePayload::Plain(self.create_plaintext(content).await?)
         };
         #[cfg(not(feature = "private_message"))]
-        let payload = MlsMessagePayload::Plain(self.create_plaintext(content)?);
+        let payload = MlsMessagePayload::Plain(self.create_plaintext(content).await?);
 
         Ok(MlsMessage::new(self.protocol_version(), payload))
     }

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -262,12 +262,8 @@ impl GroupState {
         let mut group_context = self.context.clone();
         group_context.epoch += 1;
 
-        #[cfg(feature = "by_ref_proposal")]
-        if let Some(ext) = applier_output
-            .applied_proposals
-            .group_context_extensions_proposal()
-        {
-            group_context.extensions = ext.proposal.clone();
+        if let Some(ext) = applier_output.new_context_extensions {
+            group_context.extensions = ext;
         }
 
         #[cfg(feature = "by_ref_proposal")]

--- a/mls-rs/src/group/proposal_filter/filtering.rs
+++ b/mls-rs/src/group/proposal_filter/filtering.rs
@@ -175,12 +175,17 @@ where
             )
             .await?;
 
+        let new_context_extensions = applied_proposals
+            .group_context_extensions_proposal()
+            .map(|gce| gce.proposal.clone());
+
         Ok(ApplyProposalsOutput {
             applied_proposals,
             new_tree,
             indexes_of_added_kpkgs: added,
             #[cfg(feature = "external_commit")]
             external_init_index: None,
+            new_context_extensions,
         })
     }
 

--- a/mls-rs/src/group/proposal_filter/filtering_common.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_common.rs
@@ -78,6 +78,7 @@ pub(crate) struct ApplyProposalsOutput {
     pub(crate) external_init_index: Option<LeafIndex>,
     #[cfg(feature = "by_ref_proposal")]
     pub(crate) applied_proposals: ProposalBundle,
+    pub(crate) new_context_extensions: Option<ExtensionList>,
 }
 
 impl<'a, C, P, CSP> ProposalApplier<'a, C, P, CSP>

--- a/mls-rs/src/group/proposal_filter/filtering_lite.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_lite.rs
@@ -122,11 +122,17 @@ where
             )
             .await?;
 
+        let new_context_extensions = proposals
+            .group_context_extensions
+            .first()
+            .map(|gce| gce.proposal.clone());
+
         Ok(ApplyProposalsOutput {
             new_tree,
             indexes_of_added_kpkgs: added,
             #[cfg(feature = "external_commit")]
             external_init_index: None,
+            new_context_extensions,
         })
     }
 

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -152,12 +152,11 @@ pub use mls_rs_core::{
 /// Dependencies of [`MlsRules`].
 pub mod mls_rules {
     pub use crate::group::{
-        mls_rules::{CommitDirection, CommitOptions, CommitSource, DefaultMlsRules},
+        mls_rules::{
+            CommitDirection, CommitOptions, CommitSource, DefaultMlsRules, EncryptionOptions,
+        },
         proposal_filter::{ProposalBundle, ProposalInfo, ProposalSource},
     };
-
-    #[cfg(feature = "private_message")]
-    pub use crate::group::mls_rules::EncryptionOptions;
 }
 
 pub use crate::group::mls_rules::MlsRules;

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -6,13 +6,24 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mls-rs = { path = "..", features = ["external_client", "rfc_compliant"]}
+mls-rs = { path = "..", default-features = false, features = ["std", "external_client", "external_commit", "state_update", "all_extensions"]}
 tonic = "0.7"
 prost = "0.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 clap = { version = "3", features = ["derive"] }
 thiserror = "1"
 futures = "0.3.25"
+hex = "0.4"
+
+[features]
+tree_index = [ "mls-rs/tree_index" ]
+private_message = [ "mls-rs/private_message" ]
+prior_epoch = [ "mls-rs/prior_epoch" ]
+out_of_order = [ "mls-rs/out_of_order", "private_message" ]
+psk = [ "mls-rs/psk" ]
+custom_proposal = [ "mls-rs/custom_proposal" ]
+by_ref_proposal = [ "mls-rs/by_ref_proposal", "mls-rs/external_proposal" ]
+default = ["tree_index", "private_message", "prior_epoch", "out_of_order", "psk", "custom_proposal", "by_ref_proposal"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features = ["browser"], version = "*" }

--- a/mls-rs/test_harness_integration/configs/application_in_order.json
+++ b/mls-rs/test_harness_integration/configs/application_in_order.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "in_order": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw1", "plaintext": "hello world 1"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw2", "plaintext": "hello world 2"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw3", "plaintext": "hello world 3"},
+
+      {"action": "unprotect", "actor": "bob", "ciphertext": 2 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 3 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 4 }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/application_out_of_order_across_epochs.json
+++ b/mls-rs/test_harness_integration/configs/application_out_of_order_across_epochs.json
@@ -1,0 +1,21 @@
+{
+  "scripts": {
+    "out_of_order_across_epochs": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw1", "plaintext": "hello world 1"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw2", "plaintext": "hello world 2"},
+
+      {"action": "fullCommit", "actor": "alice", "members": ["bob"]},
+
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw3", "plaintext": "hello world 3"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw4", "plaintext": "hello world 4"},
+
+      {"action": "unprotect", "actor": "bob", "ciphertext": 6 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 5 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 3 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 2 }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/application_out_of_order_within_epoch.json
+++ b/mls-rs/test_harness_integration/configs/application_out_of_order_within_epoch.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "out_of_order_within_epoch": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw1", "plaintext": "hello world 1"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw2", "plaintext": "hello world 2"},
+      {"action": "protect", "actor": "alice", "authenticatedData": "btw3", "plaintext": "hello world 3"},
+
+      {"action": "unprotect", "actor": "bob", "ciphertext": 4 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 3 },
+      {"action": "unprotect", "actor": "bob", "ciphertext": 2 }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/bare_bones.json
+++ b/mls-rs/test_harness_integration/configs/bare_bones.json
@@ -1,0 +1,98 @@
+{
+  "scripts": {
+    "empty": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "fullCommit", "actor": "alice", "members": ["bob"]}
+    ],
+
+    "add": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+
+      {"action": "createKeyPackage", "actor": "charlie1"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [{"proposalType": "add", "keyPackage": 2}],
+        "members": ["bob"],
+        "joiners": ["charlie1"],
+        "force_path": true
+      },
+
+      {"action": "createKeyPackage", "actor": "charlie2"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [{"proposalType": "add", "keyPackage": 4}],
+        "members": ["bob", "charlie1"],
+        "joiners": ["charlie2"],
+        "force_path": false
+      }
+    ],
+
+    "remove": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+
+      {"action": "createKeyPackage", "actor": "charlie1"},
+      {"action": "createKeyPackage", "actor": "charlie2"},
+      {"action": "createKeyPackage", "actor": "charlie3"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [{"proposalType": "add", "keyPackage": 2}, {"proposalType": "add", "keyPackage": 3}, {"proposalType": "add", "keyPackage": 4}],
+        "members": ["bob"],
+        "joiners": ["charlie1", "charlie2", "charlie3"],
+        "force_path": true
+      },
+
+      {
+        "action": "fullCommit", "actor": "charlie1",
+        "byValue": [{"proposalType": "remove", "removed": "alice"}, {"proposalType": "remove", "removed": "charlie2"}, {"proposalType": "remove", "removed": "charlie3"}],
+        "members": ["bob"]}
+    ],
+
+    "group_context_extensions": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [
+          {
+            "proposalType": "groupContextExtensions",
+            "extensions": [{"extension_type": 3, "extension_data": "AAAA"}]
+          }
+        ],
+        "members": ["bob"]
+      }
+    ],
+
+    "all_together": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "createKeyPackage", "actor": "charlie"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [{"proposalType": "add", "keyPackage": 2}],
+        "members": ["bob"],
+        "joiners": ["charlie"]
+      },
+
+      {"action": "createKeyPackage", "actor": "dave"}, 
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [
+        {"proposalType": "add", "keyPackage": 4},
+        {"proposalType": "remove", "removed": "charlie"},
+        {"proposalType": "groupContextExtensions", "extensions": [{"extension_type": 3, "extension_data": "AAAA"}]}
+        ],
+        "members": ["bob"]
+      }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/branch.json
+++ b/mls-rs/test_harness_integration/configs/branch.json
@@ -1,0 +1,40 @@
+{
+  "scripts": {
+    "base": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {"action": "branch", "actor": "alice", "members": ["bob", "charlie", "diana", "eliza"]}
+    ],
+
+    "with_extensions": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {"action": "branch", "actor": "alice", "members": ["bob", "charlie", "diana", "eliza"],
+       "extensions": [{"extension_type": 3, "extension_data": "AAAA"}, {"extension_type": 5, "extension_data": "AA=="} ]}
+    ],
+    
+    "external_tree": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {"action": "branch", "actor": "alice", "members": ["bob", "charlie", "diana", "eliza"], "externalTree": true}
+    ],
+    
+    "force_path": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {"action": "branch", "actor": "alice", "members": ["bob", "charlie", "diana", "eliza"], "forcePath": true}
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/commit.json
+++ b/mls-rs/test_harness_integration/configs/commit.json
@@ -1,0 +1,153 @@
+{
+  "scripts": {
+    "empty": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "fullCommit", "actor": "alice", "members": ["bob"]}
+    ],
+
+    "add": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+
+      {"action": "createKeyPackage", "actor": "charlie1"},
+      {"action": "createKeyPackage", "actor": "charlie2"},
+      {"action": "createKeyPackage", "actor": "charlie3"},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 2},
+      {"action": "addProposal", "actor": "bob", "keyPackage": 3},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byReference": [5, 6],
+        "byValue": [{"proposalType": "add", "keyPackage": 4}],
+        "members": ["bob"],
+        "joiners": ["charlie1", "charlie2", "charlie3"],
+        "force_path": true
+      },
+
+      {"action": "createKeyPackage", "actor": "charlie4"},
+      {"action": "createKeyPackage", "actor": "charlie5"},
+      {"action": "createKeyPackage", "actor": "charlie6"},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 8},
+      {"action": "addProposal", "actor": "bob", "keyPackage": 9},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byReference": [11, 12],
+        "byValue": [{"proposalType": "add", "keyPackage": 10}],
+        "members": ["bob", "charlie1", "charlie2"],
+        "joiners": ["charlie4", "charlie5", "charlie6"],
+        "force_path": false
+      }
+    ],
+
+    "remove": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+
+      {"action": "createKeyPackage", "actor": "charlie1"},
+      {"action": "createKeyPackage", "actor": "charlie2"},
+      {"action": "createKeyPackage", "actor": "charlie3"},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 2},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 3},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 4},
+      {"action": "fullCommit", "actor": "alice", "byReference": [5, 6, 7], "members": ["bob"], "joiners": ["charlie1", "charlie2", "charlie3"]},
+
+      {"action": "removeProposal", "actor": "alice", "removed": "charlie1"},
+      {"action": "removeProposal", "actor": "bob", "removed": "charlie2"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [9, 10], "byValue": [{"proposalType": "remove", "removed": "charlie3"}], "members": ["bob"]}
+    ],
+
+    "update": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "updateProposal", "actor": "bob"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [2], "members": ["bob"]}
+    ],
+
+    "group_context_extensions": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+
+      {"action": "groupContextExtensionsProposal", "actor": "alice", "extensions": [
+        {"extension_type": 3, "extension_data": "AAAA"},
+        {"extension_type": 5, "extension_data": "AA=="}
+      ]},
+      {"action": "fullCommit", "actor": "alice", "byReference": [2], "members": ["bob"]},
+
+      {"action": "groupContextExtensionsProposal", "actor": "bob", "extensions": []},
+      {"action": "fullCommit", "actor": "alice", "byReference": [4], "members": ["bob"]},
+
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [
+          {
+            "proposalType": "groupContextExtensions",
+            "extensions": [{"extension_type": 3, "extension_data": "AAAA"}]
+          }
+        ],
+        "members": ["bob"]
+      }
+    ],
+
+    "all_together_alice_proposes": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "createKeyPackage", "actor": "charlie1"},
+      {"action": "createKeyPackage", "actor": "charlie2"},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 2},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 3},
+      {"action": "fullCommit", "actor": "alice", "byReference": [4, 5], "members": ["bob"], "joiners": ["charlie1", "charlie2"]},
+
+      {"action": "createKeyPackage", "actor": "charlie3"},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 7},
+      {"action": "removeProposal", "actor": "alice", "removed": "charlie1"},
+      {"action": "groupContextExtensionsProposal", "actor": "alice", "extensions": [
+        {"extension_type": 3, "extension_data": "AAAA"},
+        {"extension_type": 5, "extension_data": "AA=="}
+      ]},
+      {"action": "createKeyPackage", "actor": "charlie4"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byReference": [8, 9, 10],
+        "byValue": [
+          {"proposalType": "add", "keyPackage": 11},
+          {"proposalType": "remove", "removed": "charlie2"}
+        ],
+        "members": ["bob"]
+      }
+    ],
+
+    "all_together_bob_proposes": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "createKeyPackage", "actor": "charlie1"},
+      {"action": "createKeyPackage", "actor": "charlie2"},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 2},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 3},
+      {"action": "fullCommit", "actor": "alice", "byReference": [4, 5], "members": ["bob"], "joiners": ["charlie1", "charlie2"]},
+
+      {"action": "createKeyPackage", "actor": "charlie3"},
+      {"action": "addProposal", "actor": "bob", "keyPackage": 7},
+      {"action": "removeProposal", "actor": "bob", "removed": "charlie1"},
+      {"action": "groupContextExtensionsProposal", "actor": "bob", "extensions": [
+        {"extension_type": 3, "extension_data": "AAAA"},
+        {"extension_type": 5, "extension_data": "AA=="}
+      ]},
+      {"action": "updateProposal", "actor": "bob"},
+      {"action": "createKeyPackage", "actor": "charlie4"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byReference": [8, 9, 10, 11],
+        "byValue": [
+          {"proposalType": "add", "keyPackage": 12},
+          {"proposalType": "remove", "removed": "charlie2"}
+        ],
+        "members": ["bob"]
+      }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/commit_by_value.json
+++ b/mls-rs/test_harness_integration/configs/commit_by_value.json
@@ -1,0 +1,98 @@
+{
+  "scripts": {
+    "empty": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "fullCommit", "actor": "alice", "members": ["bob"]}
+    ],
+
+    "add": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+
+      {"action": "createKeyPackage", "actor": "charlie1"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [{"proposalType": "add", "keyPackage": 2}],
+        "members": ["bob"],
+        "joiners": ["charlie1"],
+        "force_path": true
+      },
+
+      {"action": "createKeyPackage", "actor": "charlie2"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [{"proposalType": "add", "keyPackage": 4}],
+        "members": ["bob", "charlie1"],
+        "joiners": ["charlie2"],
+        "force_path": false
+      }
+    ],
+
+    "remove": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+
+      {"action": "createKeyPackage", "actor": "charlie1"},
+      {"action": "createKeyPackage", "actor": "charlie2"},
+      {"action": "createKeyPackage", "actor": "charlie3"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [{"proposalType": "add", "keyPackage": 2}, {"proposalType": "add", "keyPackage": 3}, {"proposalType": "add", "keyPackage": 4}],
+        "members": ["bob"],
+        "joiners": ["charlie1", "charlie2", "charlie3"],
+        "force_path": true
+      },
+
+      {
+        "action": "fullCommit", "actor": "charlie1",
+        "byValue": [{"proposalType": "remove", "removed": "alice"}, {"proposalType": "remove", "removed": "charlie2"}, {"proposalType": "remove", "removed": "charlie3"}],
+        "members": ["bob"]}
+    ],
+
+    "group_context_extensions": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [
+          {
+            "proposalType": "groupContextExtensions",
+            "extensions": [{"extension_type": 3, "extension_data": "AAAA"}]
+          }
+        ],
+        "members": ["bob"]
+      }
+    ],
+
+    "all_together": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "createKeyPackage", "actor": "charlie"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [{"proposalType": "add", "keyPackage": 2}],
+        "members": ["bob"],
+        "joiners": ["charlie"]
+      },
+
+      {"action": "createKeyPackage", "actor": "david"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [
+        {"proposalType": "add", "keyPackage": 4},
+        {"proposalType": "remove", "removed": "charlie"},
+        {"proposalType": "groupContextExtensions", "extensions": [{"extension_type": 3, "extension_data": "AAAA"}]}
+        ],
+        "members": ["bob"]
+      }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/commit_by_value_with_psk.json
+++ b/mls-rs/test_harness_integration/configs/commit_by_value_with_psk.json
@@ -1,0 +1,61 @@
+{
+  "scripts": {
+    "external_psk": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+      {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [{"proposalType": "externalPSK", "pskID": 2}, {"proposalType": "externalPSK", "pskID": 3}],
+        "members": ["bob"],
+        "force_path": true
+      }
+    ],
+
+    "resumption_psk": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "fullCommit", "actor": "alice", "members": ["bob"]},
+      {"action": "fullCommit", "actor": "alice", "members": ["bob"]},
+
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [{"proposalType": "resumptionPSK", "epochID": 3}],
+        "members": ["bob"],
+        "force_path": true
+      }
+    ],
+
+    "all_together": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "createKeyPackage", "actor": "charlie"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [{"proposalType": "add", "keyPackage": 2}],
+        "members": ["bob"],
+        "joiners": ["charlie"]
+      },
+
+      {"action": "createKeyPackage", "actor": "david"},
+      {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byValue": [
+        {"proposalType": "add", "keyPackage": 4},
+        {"proposalType": "remove", "removed": "charlie"},
+        {"proposalType": "externalPSK", "pskID": 5},
+        {"proposalType": "resumptionPSK", "epochID": 2},
+        {"proposalType": "groupContextExtensions", "extensions": [{"extension_type": 3, "extension_data": "AAAA"}]}
+        ],
+        "members": ["bob"]
+      }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/commit_with_psk.json
+++ b/mls-rs/test_harness_integration/configs/commit_with_psk.json
@@ -1,0 +1,133 @@
+{
+  "scripts": {
+    "external_psk": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+      {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+      {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+
+      {"action": "externalPSKProposal", "pskID": 2, "actor": "alice"},
+      {"action": "externalPSKProposal", "pskID": 3, "actor": "bob"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byReference": [5, 6],
+        "byValue": [{"proposalType": "externalPSK", "pskID": 4}],
+        "members": ["bob"],
+        "force_path": true
+      },
+
+      {"action": "externalPSKProposal", "pskID": 2, "actor": "alice"},
+      {"action": "externalPSKProposal", "pskID": 3, "actor": "bob"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byReference": [8, 9],
+        "byValue": [{"proposalType": "externalPSK", "pskID": 4}],
+        "members": ["bob"],
+        "force_path": false
+      }
+    ],
+
+    "resumption_psk": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "fullCommit", "actor": "alice", "members": ["bob"]},
+      {"action": "fullCommit", "actor": "alice", "members": ["bob"]},
+
+      {"action": "resumptionPSKProposal", "epochID": 1, "actor": "alice"},
+      {"action": "resumptionPSKProposal", "epochID": 2, "actor": "bob"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byReference": [4, 5],
+        "byValue": [{"proposalType": "resumptionPSK", "epochID": 3}],
+        "members": ["bob"],
+        "force_path": true
+      },
+
+      {"action": "resumptionPSKProposal", "epochID": 2, "actor": "alice"},
+      {"action": "resumptionPSKProposal", "epochID": 3, "actor": "bob"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byReference": [7, 8],
+        "byValue": [{"proposalType": "resumptionPSK", "epochID": 4}],
+        "members": ["bob"],
+        "force_path": true
+      }
+    ],
+
+    "all_together_alice_proposes": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "createKeyPackage", "actor": "charlie1"},
+      {"action": "createKeyPackage", "actor": "charlie2"},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 2},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 3},
+      {"action": "fullCommit", "actor": "alice", "byReference": [4, 5], "members": ["bob"], "joiners": ["charlie1", "charlie2"]},
+      {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+      {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+
+      {"action": "createKeyPackage", "actor": "charlie3"},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 9},
+      {"action": "removeProposal", "actor": "alice", "removed": "charlie1"},
+      {"action": "groupContextExtensionsProposal", "actor": "alice", "extensions": [
+        {"extension_type": 3, "extension_data": "AAAA"},
+        {"extension_type": 5, "extension_data": "AA=="}
+      ]},
+      {"action": "externalPSKProposal", "pskID": 7, "actor": "alice"},
+      {"action": "resumptionPSKProposal", "epochID": 1, "actor": "alice"},
+      {"action": "createKeyPackage", "actor": "charlie4"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byReference": [10, 11, 12, 13, 14],
+        "byValue": [
+          {"proposalType": "add", "keyPackage": 15},
+          {"proposalType": "remove", "removed": "charlie2"},
+          {"proposalType": "externalPSK", "pskID": 8},
+          {"proposalType": "resumptionPSK", "epochID": 2}
+        ],
+        "members": ["bob"]
+      }
+    ],
+
+    "all_together_bob_proposes": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "createKeyPackage", "actor": "charlie1"},
+      {"action": "createKeyPackage", "actor": "charlie2"},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 2},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 3},
+      {"action": "fullCommit", "actor": "alice", "byReference": [4, 5], "members": ["bob"], "joiners": ["charlie1", "charlie2"]},
+      {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+      {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+
+      {"action": "createKeyPackage", "actor": "charlie3"},
+      {"action": "addProposal", "actor": "bob", "keyPackage": 9},
+      {"action": "removeProposal", "actor": "bob", "removed": "charlie1"},
+      {"action": "groupContextExtensionsProposal", "actor": "bob", "extensions": [
+        {"extension_type": 3, "extension_data": "AAAA"},
+        {"extension_type": 5, "extension_data": "AA=="}
+      ]},
+      {"action": "externalPSKProposal", "pskID": 7, "actor": "bob"},
+      {"action": "resumptionPSKProposal", "epochID": 1, "actor": "bob"},
+      {"action": "updateProposal", "actor": "bob"},
+      {"action": "createKeyPackage", "actor": "charlie4"},
+      {
+        "action": "fullCommit",
+        "actor": "alice",
+        "byReference": [10, 11, 12, 13, 14, 15],
+        "byValue": [
+          {"proposalType": "add", "keyPackage": 16},
+          {"proposalType": "remove", "removed": "charlie2"},
+          {"proposalType": "externalPSK", "pskID": 8},
+          {"proposalType": "resumptionPSK", "epochID": 2}
+        ],
+        "members": ["bob"]
+      }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/external_join.json
+++ b/mls-rs/test_harness_integration/configs/external_join.json
@@ -1,0 +1,37 @@
+{
+  "scripts": {
+    "normal": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"}
+    ],
+
+    "with_psk": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "installExternalPSK", "clients": ["alice"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "psks": [1]}
+    ],
+
+    "removing_prior": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "removePrior": true}
+    ],
+
+    "with_external_tree": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "externalTree": true}
+    ],
+
+    "with_more_members": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "createKeyPackage", "actor": "bob"},
+      {"action": "createKeyPackage", "actor": "charlie"},
+      {"action": "createKeyPackage", "actor": "diana"},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 1},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 2},
+      {"action": "addProposal", "actor": "alice", "keyPackage": 3},
+      {"action": "fullCommit", "actor": "alice", "byReference": [4, 5, 6], "joiners": ["bob", "charlie", "diana"]},
+      {"action": "externalJoin", "actor": "diana", "joiner": "ellen", "members": ["alice", "bob", "charlie"]}
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/external_proposals.json
+++ b/mls-rs/test_harness_integration/configs/external_proposals.json
@@ -1,0 +1,69 @@
+{
+  "scripts": {
+    "joiner_signed_add": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "newMemberAddProposal", "actor": "alice", "joiner": "bob" },
+      {"action": "fullCommit", "actor": "alice", "byReference": [1], "joiners": ["bob"] }
+    ],
+
+    "external_add": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+
+      {"action": "addExternalSigner", "actor": "alice", "signer": "ds"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [2], "members": ["bob"]},
+
+      {"action": "createKeyPackage", "actor": "charlie" },
+      {"action": "externalSignerProposal", "actor": "ds", "member": "alice",
+       "description": { "proposalType": "add", "keyPackage": 4 } },
+      {"action": "fullCommit", "actor": "alice", "byReference": [5], "members": ["bob"], 
+       "joiners": ["charlie"] }
+    ],
+
+    "external_remove": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+
+      {"action": "addExternalSigner", "actor": "alice", "signer": "ds"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [3], "members": ["bob", "charlie"]},
+
+      {"action": "externalSignerProposal", "actor": "ds", "member": "alice",
+       "description": { "proposalType": "remove", "removed": "bob" } },
+      {"action": "fullCommit", "actor": "alice", "byReference": [5], "members": ["charlie"] }
+    ],
+
+    "group_context_extensions": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+
+      {"action": "addExternalSigner", "actor": "alice", "signer": "ds"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [3], "members": ["bob", "charlie"]},
+      
+      {"action": "externalSignerProposal", "actor": "ds", "member": "alice", "description": {
+        "proposalType": "groupContextExtensions", "extensions": [ {"extension_type": 3, "extension_data": "AAAA"} ] } },
+      {"action": "fullCommit", "actor": "alice", "byReference": [5], "members": ["bob", "charlie"] }
+    ],
+    
+    "multiple_external": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "createKeyPackage", "actor": "dave" },
+      {"action": "createKeyPackage", "actor": "edward" },
+
+      {"action": "addExternalSigner", "actor": "alice", "signer": "ds1"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [5], "members": ["bob", "charlie"]},
+      
+      {"action": "addExternalSigner", "actor": "alice", "signer": "ds2"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [7], "members": ["bob", "charlie"]},
+      
+      {"action": "externalSignerProposal", "actor": "ds1", "member": "alice",
+       "description": { "proposalType": "add", "keyPackage": 3 } },
+      {"action": "externalSignerProposal", "actor": "ds1", "member": "alice",
+       "description": { "proposalType": "add", "keyPackage": 4 } },
+      {"action": "fullCommit", "actor": "alice", "byReference": [9, 10], "members": ["bob", "charlie"] }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/external_proposals_with_psk.json
+++ b/mls-rs/test_harness_integration/configs/external_proposals_with_psk.json
@@ -1,0 +1,52 @@
+{
+  "scripts": {
+    "external_psk": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "installExternalPSK", "clients": ["alice", "bob", "charlie"]},
+      
+      {"action": "addExternalSigner", "actor": "alice", "signer": "ds"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [4], "members": ["bob", "charlie"]},
+      
+      {"action": "externalSignerProposal", "actor": "ds", "member": "alice",
+       "description": { "proposalType": "externalPSK", "pskID": 3 } },
+      {"action": "fullCommit", "actor": "alice", "byReference": [6], "members": ["bob", "charlie"] }
+    ],
+
+    "resumption_psk": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+
+      {"action": "addExternalSigner", "actor": "alice", "signer": "ds"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [3], "members": ["bob", "charlie"]},
+      
+      {"action": "externalSignerProposal", "actor": "ds", "member": "alice",
+       "description": { "proposalType": "resumptionPSK", "epochID": 2 } },
+      {"action": "fullCommit", "actor": "alice", "byReference": [5], "members": ["bob", "charlie"] }
+    ],
+
+    "external_reinit": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+
+      {"action": "addExternalSigner", "actor": "alice", "signer": "ds"},
+      {"action": "fullCommit", "actor": "alice", "byReference": [3], "members": ["bob", "charlie"]},
+
+      {"action": "externalSignerProposal", "actor": "ds", "member": "alice",
+       "description": {"proposalType": "reinit", "changeGroupID": true, "changeCipherSuite": true,
+       "extensions": [ {"extension_type": 3, "extension_data": "AAAA"} ]}},
+
+      {
+        "action": "reinit", 
+        "externalReinitProposal": 5,
+        "committer": "alice",
+        "welcomer": "bob", 
+        "members": ["charlie"],
+        "forcePath": true
+      }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/reinit.json
+++ b/mls-rs/test_harness_integration/configs/reinit.json
@@ -1,0 +1,104 @@
+{
+  "scripts": {
+    "change_ciphersuite": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "bob",
+        "welcomer": "charlie", 
+        "members": ["diana", "eliza"],
+        "changeCiphersuite": true
+      }
+    ],
+    
+    "change_group_id": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "bob",
+        "welcomer": "charlie", 
+        "members": ["diana", "eliza"],
+        "changeGroupID": true
+      }
+    ],
+    
+    "change_extensions": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "bob",
+        "welcomer": "charlie", 
+        "members": ["diana", "eliza"],
+        "extensions": [
+          {"extension_type": 3, "extension_data": "AAAA"},
+          {"extension_type": 5, "extension_data": "AA=="}
+        ]
+      }
+    ],
+    
+    "all_same_actor": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "alice",
+        "welcomer": "alice", 
+        "members": ["bob", "charlie", "diana", "eliza"],
+        "changeGroupID": true
+      }
+    ],
+    
+    "external_tree": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "bob",
+        "welcomer": "charlie", 
+        "members": ["diana", "eliza"],
+        "changeGroupID": true,
+        "externalTree": true
+      }
+    ],
+    
+    "force_path": [
+      {"action": "createGroup", "actor": "alice"},
+      {"action": "externalJoin", "actor": "alice", "joiner": "bob", "members": []},
+      {"action": "externalJoin", "actor": "alice", "joiner": "charlie", "members": ["bob"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "diana", "members": ["bob", "charlie"]},
+      {"action": "externalJoin", "actor": "alice", "joiner": "eliza", "members": ["bob", "charlie", "diana"]},
+      {
+        "action": "reinit", 
+        "proposer": "alice",
+        "committer": "bob",
+        "welcomer": "charlie", 
+        "members": ["diana", "eliza"],
+        "changeGroupID": true,
+        "forcePath": true
+      }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/welcome_join.json
+++ b/mls-rs/test_harness_integration/configs/welcome_join.json
@@ -1,0 +1,21 @@
+{
+  "scripts": {
+    "no_path_secret": [
+          {"action": "createGroup", "actor": "alice"},
+          {"action": "createKeyPackage", "actor": "bob"},
+          {"action": "fullCommit", "actor": "alice", "byValue": [{"proposalType": "add", "keyPackage": 1}], "joiners": ["bob"]}
+    ],
+
+    "with_path_secret": [
+          {"action": "createGroup", "actor": "alice"},
+          {"action": "createKeyPackage", "actor": "bob"},
+          {"action": "fullCommit", "actor": "alice", "byValue": [{"proposalType": "add", "keyPackage": 1}], "joiners": ["bob"], "force_path": true}
+    ],
+
+    "with_external_tree": [
+          {"action": "createGroup", "actor": "alice"},
+          {"action": "createKeyPackage", "actor": "bob"},
+          {"action": "fullCommit", "actor": "alice", "byValue": [{"proposalType": "add", "keyPackage": 1}], "joiners": ["bob"], "external_tree": true}
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/configs/welcome_join_with_psk.json
+++ b/mls-rs/test_harness_integration/configs/welcome_join_with_psk.json
@@ -1,0 +1,15 @@
+{
+  "scripts": {
+    "with_psk": [
+          {"action": "createGroup", "actor": "alice"},
+          {"action": "createKeyPackage", "actor": "bob"},
+          {"action": "installExternalPSK", "clients": ["alice", "bob"]},
+          {
+            "action": "fullCommit",
+            "actor": "alice",
+            "byValue": [{"proposalType": "add", "keyPackage": 1}, {"proposalType": "externalPSK", "pskID": 2}],
+            "joiners": ["bob"]
+          }
+    ]
+  }
+}

--- a/mls-rs/test_harness_integration/src/branch_reinit.rs
+++ b/mls-rs/test_harness_integration/src/branch_reinit.rs
@@ -1,0 +1,317 @@
+#[cfg(feature = "psk")]
+pub(crate) mod inner {
+    use mls_rs::{
+        group::StateUpdate, identity::SigningIdentity, CipherSuiteProvider, CryptoProvider,
+        MlsMessage,
+    };
+    use mls_rs_crypto_openssl::OpensslCryptoProvider;
+    use tonic::{Request, Response, Status};
+
+    use crate::{
+        abort, get_tree,
+        mls_client::{
+            CreateSubgroupResponse, HandleBranchRequest, HandleBranchResponse,
+            HandleCommitResponse, HandlePendingCommitRequest, HandleReInitCommitResponse,
+            HandleReInitWelcomeRequest, JoinGroupResponse,
+        },
+        MlsClientImpl,
+    };
+
+    impl MlsClientImpl {
+        pub(crate) async fn handle_pending_re_init_commit(
+            &self,
+            request: Request<HandlePendingCommitRequest>,
+        ) -> Result<Response<HandleReInitCommitResponse>, Status> {
+            let request = request.into_inner();
+
+            let (resp, update) = {
+                let clients = &mut self.clients.lock().await;
+
+                let group = clients
+                    .get_mut(request.state_id as usize)
+                    .ok_or_else(|| Status::aborted("no group with such index."))?
+                    .group
+                    .as_mut()
+                    .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+                let update = group.apply_pending_commit().map_err(abort)?;
+
+                let resp = HandleCommitResponse {
+                    state_id: request.state_id,
+                    epoch_authenticator: group.epoch_authenticator().map_err(abort)?.to_vec(),
+                };
+
+                (resp, update)
+            };
+
+            self.handle_re_init_commit(Response::new(resp), update.state_update)
+                .await
+        }
+
+        pub(crate) async fn handle_re_init_welcome(
+            &self,
+            request: Request<HandleReInitWelcomeRequest>,
+        ) -> Result<Response<JoinGroupResponse>, Status> {
+            let request = request.into_inner();
+            let clients = &mut self.clients.lock().await;
+
+            let client = clients
+                .get_mut(request.reinit_id as usize)
+                .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+            let group = client
+                .group
+                .as_mut()
+                .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+            let welcome = MlsMessage::from_bytes(&request.welcome).map_err(abort)?;
+
+            let reinit_client = group
+                .clone()
+                .get_reinit_client(
+                    Some(client.signer.clone()),
+                    Some(client.signing_identity.clone()),
+                )
+                .map_err(abort)?;
+
+            let (group, _info) = reinit_client
+                .join(welcome, get_tree(&request.ratchet_tree))
+                .map_err(abort)?;
+
+            let resp = JoinGroupResponse {
+                epoch_authenticator: group.epoch_authenticator().map_err(abort)?.to_vec(),
+                state_id: request.reinit_id,
+            };
+
+            client.group = Some(group);
+
+            Ok(Response::new(resp))
+        }
+
+        pub(crate) async fn handle_branch(
+            &self,
+            request: Request<HandleBranchRequest>,
+        ) -> Result<Response<HandleBranchResponse>, Status> {
+            let request = request.into_inner();
+            let clients = &mut self.clients.lock().await;
+
+            // Find the key package generated earlier based on the transaction_id
+            let (id, key_package_data) = {
+                let key_package_client = clients
+                    .get(request.transaction_id as usize)
+                    .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+                key_package_client.key_package_repo.key_packages()[0].clone()
+            };
+
+            let client = clients
+                .get_mut(request.state_id as usize)
+                .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+            // Insert the previously created key package
+            client.key_package_repo.insert(id, key_package_data);
+
+            let group = client
+                .group
+                .as_mut()
+                .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+            let tree = get_tree(&request.ratchet_tree);
+            let welcome = MlsMessage::from_bytes(&request.welcome).map_err(abort)?;
+
+            let (new_group, _info) = group.join_subgroup(welcome, tree).map_err(abort)?;
+
+            let resp = HandleBranchResponse {
+                state_id: request.state_id,
+                epoch_authenticator: new_group.epoch_authenticator().map_err(abort)?.to_vec(),
+            };
+
+            client.group = Some(new_group);
+
+            Ok(Response::new(resp))
+        }
+
+        pub(crate) async fn branch_or_reinit(
+            &self,
+            client_id: u32,
+            key_packages: &[Vec<u8>],
+            force_path: bool,
+            external_tree: bool,
+            subgroup_id: Option<Vec<u8>>,
+        ) -> Result<Response<CreateSubgroupResponse>, Status> {
+            let clients = &mut self.clients.lock().await;
+
+            let client = clients
+                .get_mut(client_id as usize)
+                .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+            let group = client
+                .group
+                .as_mut()
+                .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+            let new_key_pkgs = key_packages
+                .iter()
+                .map(|kp| MlsMessage::from_bytes(kp))
+                .collect::<Result<_, _>>()
+                .map_err(abort)?;
+
+            {
+                let mut mls_rules = client.mls_rules.commit_options.lock().unwrap();
+                mls_rules.path_required = force_path;
+                mls_rules.ratchet_tree_extension = !external_tree;
+            };
+
+            let (new_group, welcome) = if let Some(id) = subgroup_id {
+                group.branch(id, new_key_pkgs).map_err(abort)?
+            } else {
+                let client = group
+                    .clone()
+                    .get_reinit_client(
+                        Some(client.signer.clone()),
+                        Some(client.signing_identity.clone()),
+                    )
+                    .map_err(abort)?;
+
+                client.commit(new_key_pkgs).map_err(abort)?
+            };
+
+            let welcome = welcome
+                .first()
+                .map(|msg| msg.to_bytes())
+                .transpose()
+                .map_err(abort)?
+                .unwrap_or_default();
+
+            let ratchet_tree = if external_tree {
+                new_group.export_tree().unwrap()
+            } else {
+                vec![]
+            };
+
+            let resp = CreateSubgroupResponse {
+                epoch_authenticator: new_group.epoch_authenticator().map_err(abort)?.to_vec(),
+                state_id: client_id,
+                welcome,
+                ratchet_tree,
+            };
+
+            client.group = Some(new_group);
+
+            Ok(Response::new(resp))
+        }
+
+        pub(crate) async fn handle_re_init_commit(
+            &self,
+            commit_resp: Response<HandleCommitResponse>,
+            update: StateUpdate,
+        ) -> Result<Response<HandleReInitCommitResponse>, Status> {
+            let commit_resp = commit_resp.into_inner();
+            let mut clients = self.clients.lock().await;
+
+            let client = clients
+                .get_mut(commit_resp.state_id as usize)
+                .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+            let group = client
+                .group
+                .as_ref()
+                .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+            // Generate a signing identity for the possibly new ciphersuite after reinit
+            let cipher_suite = update
+                .pending_reinit_ciphersuite()
+                .ok_or_else(|| Status::aborted("reinit not found in commit"))?;
+
+            let provider = OpensslCryptoProvider::new()
+                .cipher_suite_provider(cipher_suite)
+                .ok_or_else(|| Status::aborted("ciphersuite not supported"))?;
+
+            let (secret_key, public_key) = provider.signature_key_generate().map_err(abort)?;
+
+            let credential = group
+                .current_member_signing_identity()
+                .map_err(abort)?
+                .credential
+                .clone();
+
+            let signing_identity = SigningIdentity::new(credential, public_key);
+
+            // Generate a key packge used to join the new group after reinit
+            let reinit_client = group
+                .clone()
+                .get_reinit_client(Some(secret_key.clone()), Some(signing_identity.clone()))
+                .map_err(abort)?;
+
+            let key_package = reinit_client.generate_key_package().map_err(abort)?;
+
+            let resp = HandleReInitCommitResponse {
+                epoch_authenticator: commit_resp.epoch_authenticator,
+                key_package: key_package.to_bytes().map_err(abort)?,
+                reinit_id: commit_resp.state_id,
+            };
+
+            client.signing_identity = signing_identity;
+            client.signer = secret_key;
+
+            Ok(Response::new(resp))
+        }
+    }
+}
+
+#[cfg(not(feature = "psk"))]
+pub(crate) mod inner {
+    use mls_rs::group::StateUpdate;
+    use tonic::{Request, Response, Status};
+
+    use crate::{
+        mls_client::{
+            CreateSubgroupResponse, HandleBranchRequest, HandleBranchResponse,
+            HandleCommitResponse, HandlePendingCommitRequest, HandleReInitCommitResponse,
+            HandleReInitWelcomeRequest, JoinGroupResponse,
+        },
+        MlsClientImpl,
+    };
+
+    impl MlsClientImpl {
+        pub(crate) async fn handle_pending_re_init_commit(
+            &self,
+            _: Request<HandlePendingCommitRequest>,
+        ) -> Result<Response<HandleReInitCommitResponse>, Status> {
+            Err(Status::aborted("Unsupported"))
+        }
+
+        pub(crate) async fn handle_re_init_welcome(
+            &self,
+            _: Request<HandleReInitWelcomeRequest>,
+        ) -> Result<Response<JoinGroupResponse>, Status> {
+            Err(Status::aborted("Unsupported"))
+        }
+
+        pub(crate) async fn handle_branch(
+            &self,
+            _: Request<HandleBranchRequest>,
+        ) -> Result<Response<HandleBranchResponse>, Status> {
+            Err(Status::aborted("Unsupported"))
+        }
+
+        pub(crate) async fn handle_re_init_commit(
+            &self,
+            _: Response<HandleCommitResponse>,
+            _: StateUpdate,
+        ) -> Result<Response<HandleReInitCommitResponse>, Status> {
+            Err(Status::aborted("Unsupported"))
+        }
+
+        pub(crate) async fn branch_or_reinit(
+            &self,
+            _: u32,
+            _: &[Vec<u8>],
+            _: bool,
+            _: bool,
+            _: Option<Vec<u8>>,
+        ) -> Result<Response<CreateSubgroupResponse>, Status> {
+            Err(Status::aborted("Unsupported"))
+        }
+    }
+}

--- a/mls-rs/test_harness_integration/src/by_ref_proposal.rs
+++ b/mls-rs/test_harness_integration/src/by_ref_proposal.rs
@@ -1,0 +1,458 @@
+use tonic::{Request, Response, Status};
+
+use crate::mls_client::ProposalResponse;
+
+#[tonic::async_trait]
+pub(crate) trait ByRefProposalSender<T> {
+    async fn propose(&self, request: Request<T>) -> Result<Response<ProposalResponse>, Status>;
+}
+
+#[cfg(feature = "by_ref_proposal")]
+pub(crate) mod inner {
+    use mls_rs::{
+        extension::built_in::ExternalSendersExt,
+        identity::{basic::BasicCredential, Credential, SigningIdentity},
+        mls_rs_codec::MlsDecode,
+        psk::ExternalPskId,
+        Group, MlsMessage, ProtocolVersion,
+    };
+    use tonic::{Request, Response, Status};
+
+    use crate::{
+        abort, find_member, get_tree,
+        mls_client::{
+            AddExternalSignerRequest, AddProposalRequest, ExternalPskProposalRequest,
+            ExternalSignerProposalRequest, GroupContextExtensionsProposalRequest, ProposalResponse,
+            ReInitProposalRequest, RemoveProposalRequest, ResumptionPskProposalRequest,
+            UpdateProposalRequest,
+        },
+        parse_extensions, MlsClientImpl, TestClientConfig, PROPOSAL_DESC_ADD, PROPOSAL_DESC_GCE,
+        PROPOSAL_DESC_REMOVE,
+    };
+
+    #[cfg(feature = "psk")]
+    use crate::{PROPOSAL_DESC_EXTERNAL_PSK, PROPOSAL_DESC_REINIT, PROPOSAL_DESC_RESUMPTION_PSK};
+
+    use super::ByRefProposalSender;
+
+    impl MlsClientImpl {
+        pub(crate) async fn send_proposal<F>(
+            &self,
+            index: u32,
+            propose: F,
+        ) -> Result<Response<ProposalResponse>, Status>
+        where
+            F: FnOnce(&mut Group<TestClientConfig>) -> Result<MlsMessage, Status>,
+        {
+            let mut clients = self.clients.lock().await;
+
+            let group = clients
+                .get_mut(index as usize)
+                .ok_or_else(|| Status::aborted("no group with such index."))?
+                .group
+                .as_mut()
+                .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+            let proposal = propose(group).and_then(|p| p.to_bytes().map_err(abort))?;
+
+            Ok(Response::new(ProposalResponse { proposal }))
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ByRefProposalSender<GroupContextExtensionsProposalRequest> for MlsClientImpl {
+        async fn propose(
+            &self,
+            request: Request<GroupContextExtensionsProposalRequest>,
+        ) -> Result<Response<ProposalResponse>, Status> {
+            let request = request.into_inner();
+
+            self.send_proposal(request.state_id, move |group| {
+                let ext = parse_extensions(request.extensions);
+
+                group
+                    .propose_group_context_extensions(ext, vec![])
+                    .map_err(abort)
+            })
+            .await
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ByRefProposalSender<ReInitProposalRequest> for MlsClientImpl {
+        async fn propose(
+            &self,
+            request: Request<ReInitProposalRequest>,
+        ) -> Result<Response<ProposalResponse>, Status> {
+            let request = request.into_inner();
+
+            self.send_proposal(request.state_id, move |group| {
+                group
+                    .propose_reinit(
+                        Some(request.group_id),
+                        ProtocolVersion::MLS_10,
+                        (request.cipher_suite as u16).into(),
+                        parse_extensions(request.extensions),
+                        vec![],
+                    )
+                    .map_err(abort)
+            })
+            .await
+        }
+    }
+
+    #[cfg(feature = "psk")]
+    #[tonic::async_trait]
+    impl ByRefProposalSender<ResumptionPskProposalRequest> for MlsClientImpl {
+        async fn propose(
+            &self,
+            request: Request<ResumptionPskProposalRequest>,
+        ) -> Result<Response<ProposalResponse>, Status> {
+            let request = request.into_inner();
+
+            self.send_proposal(request.state_id, move |group| {
+                let epoch_id = request.epoch_id;
+
+                group
+                    .propose_resumption_psk(epoch_id, vec![])
+                    .map_err(abort)
+            })
+            .await
+        }
+    }
+
+    #[cfg(not(feature = "psk"))]
+    #[tonic::async_trait]
+    impl ByRefProposalSender<ResumptionPskProposalRequest> for MlsClientImpl {
+        async fn propose(
+            &self,
+            _: Request<ResumptionPskProposalRequest>,
+        ) -> Result<Response<ProposalResponse>, Status> {
+            Err(Status::aborted("Unsupported"))
+        }
+    }
+
+    #[cfg(feature = "psk")]
+    #[tonic::async_trait]
+    impl ByRefProposalSender<ExternalPskProposalRequest> for MlsClientImpl {
+        async fn propose(
+            &self,
+            request: Request<ExternalPskProposalRequest>,
+        ) -> Result<Response<ProposalResponse>, Status> {
+            let request = request.into_inner();
+
+            self.send_proposal(request.state_id, move |group| {
+                let psk_id = ExternalPskId::new(request.psk_id);
+                group.propose_external_psk(psk_id, vec![]).map_err(abort)
+            })
+            .await
+        }
+    }
+
+    #[cfg(not(feature = "psk"))]
+    #[tonic::async_trait]
+    impl ByRefProposalSender<ExternalPskProposalRequest> for MlsClientImpl {
+        async fn propose(
+            &self,
+            _: Request<ExternalPskProposalRequest>,
+        ) -> Result<Response<ProposalResponse>, Status> {
+            Err(Status::aborted("Unsupported"))
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ByRefProposalSender<RemoveProposalRequest> for MlsClientImpl {
+        async fn propose(
+            &self,
+            request: Request<RemoveProposalRequest>,
+        ) -> Result<Response<ProposalResponse>, Status> {
+            let request = request.into_inner();
+
+            self.send_proposal(request.state_id, move |group| {
+                let removed_cred = Credential::Basic(BasicCredential::new(request.removed_id));
+                let removed_index = find_member(&group.roster().members(), &removed_cred)?;
+
+                group.propose_remove(removed_index, vec![]).map_err(abort)
+            })
+            .await
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ByRefProposalSender<UpdateProposalRequest> for MlsClientImpl {
+        async fn propose(
+            &self,
+            request: Request<UpdateProposalRequest>,
+        ) -> Result<Response<ProposalResponse>, Status> {
+            let request = request.into_inner();
+
+            self.send_proposal(request.state_id, move |group| {
+                group.propose_update(vec![]).map_err(abort)
+            })
+            .await
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ByRefProposalSender<AddProposalRequest> for MlsClientImpl {
+        async fn propose(
+            &self,
+            request: Request<AddProposalRequest>,
+        ) -> Result<Response<ProposalResponse>, Status> {
+            let request = request.into_inner();
+            let key_package = MlsMessage::from_bytes(&request.key_package).map_err(abort)?;
+
+            self.send_proposal(request.state_id, move |group| {
+                group.propose_add(key_package, vec![]).map_err(abort)
+            })
+            .await
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ByRefProposalSender<AddExternalSignerRequest> for MlsClientImpl {
+        async fn propose(
+            &self,
+            request: Request<AddExternalSignerRequest>,
+        ) -> Result<Response<ProposalResponse>, Status> {
+            let request = request.into_inner();
+
+            self.send_proposal(request.state_id, move |group| {
+                let mut extensions = group.context_extensions().clone();
+
+                let ext_sender =
+                    SigningIdentity::mls_decode(&mut &*request.external_sender).map_err(abort)?;
+
+                let mut ext_senders = extensions
+                    .get_as::<ExternalSendersExt>()
+                    .map_err(abort)?
+                    .unwrap_or(ExternalSendersExt::new(vec![]))
+                    .allowed_senders()
+                    .to_vec();
+
+                ext_senders.push(ext_sender);
+
+                extensions
+                    .set_from(ExternalSendersExt::new(ext_senders))
+                    .map_err(abort)?;
+
+                group
+                    .propose_group_context_extensions(extensions, vec![])
+                    .map_err(abort)
+            })
+            .await
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ByRefProposalSender<ExternalSignerProposalRequest> for MlsClientImpl {
+        async fn propose(
+            &self,
+            request: Request<ExternalSignerProposalRequest>,
+        ) -> Result<Response<ProposalResponse>, Status> {
+            let request = request.into_inner();
+            let ext_clients = &mut self.external_clients.lock().await;
+
+            let ext_client = ext_clients
+                .get_mut(request.signer_id as usize)
+                .ok_or_else(|| Status::aborted("no group with such index."))?;
+
+            let group_info = MlsMessage::from_bytes(&request.group_info).map_err(abort)?;
+
+            let mut server = ext_client
+                .ext_client
+                .observe_group(group_info, get_tree(&request.ratchet_tree))
+                .map_err(abort)?;
+
+            let proposal = request
+                .description
+                .ok_or_else(|| Status::aborted("proposal not found"))?;
+
+            let proposal = match proposal.proposal_type.as_slice() {
+                PROPOSAL_DESC_ADD => {
+                    let key_package =
+                        MlsMessage::from_bytes(&proposal.key_package).map_err(abort)?;
+
+                    server.propose_add(key_package, vec![]).map_err(abort)
+                }
+                PROPOSAL_DESC_REMOVE => {
+                    let cred = Credential::Basic(BasicCredential::new(proposal.removed_id.clone()));
+                    let removed_index = find_member(&server.roster().members(), &cred)?;
+
+                    server.propose_remove(removed_index, vec![]).map_err(abort)
+                }
+                #[cfg(feature = "psk")]
+                PROPOSAL_DESC_EXTERNAL_PSK => server
+                    .propose_external_psk(ExternalPskId::new(proposal.psk_id), vec![])
+                    .map_err(abort),
+                #[cfg(feature = "psk")]
+                PROPOSAL_DESC_RESUMPTION_PSK => server
+                    .propose_resumption_psk(proposal.epoch_id, vec![])
+                    .map_err(abort),
+                PROPOSAL_DESC_GCE => server
+                    .propose_group_context_extensions(parse_extensions(proposal.extensions), vec![])
+                    .map_err(abort),
+                #[cfg(feature = "psk")]
+                PROPOSAL_DESC_REINIT => server
+                    .propose_reinit(
+                        Some(proposal.group_id),
+                        ProtocolVersion::MLS_10,
+                        (proposal.ciphersuite as u16).into(),
+                        parse_extensions(proposal.extensions),
+                        vec![],
+                    )
+                    .map_err(abort),
+                _ => Err(Status::aborted("unsupported proposal type")),
+            }?;
+
+            let resp = ProposalResponse {
+                proposal: proposal.to_bytes().map_err(abort)?,
+            };
+
+            Ok(Response::new(resp))
+        }
+    }
+}
+
+#[cfg(not(feature = "by_ref_proposal"))]
+pub(crate) mod inner {
+    use crate::MlsClientImpl;
+
+    use super::*;
+
+    #[tonic::async_trait]
+    impl<T: Send + Sync + 'static> ByRefProposalSender<T> for MlsClientImpl {
+        async fn propose(&self, _: Request<T>) -> Result<Response<ProposalResponse>, Status> {
+            Err(Status::aborted("Unsupported"))
+        }
+    }
+}
+
+#[cfg(feature = "by_ref_proposal")]
+pub(crate) mod external_proposal {
+    use mls_rs_crypto_openssl::OpensslCryptoProvider;
+    use tonic::{Request, Response, Status};
+
+    use mls_rs::{
+        external_client::builder::ExternalClientBuilder,
+        identity::{
+            basic::{BasicCredential, BasicIdentityProvider},
+            SigningIdentity,
+        },
+        mls_rs_codec::MlsEncode,
+        CipherSuiteProvider, CryptoProvider, MlsMessage,
+    };
+
+    use crate::{
+        abort, create_client,
+        mls_client::{
+            CreateExternalSignerRequest, CreateExternalSignerResponse, NewMemberAddProposalRequest,
+            NewMemberAddProposalResponse,
+        },
+        ExternalClientDetails,
+    };
+
+    use crate::MlsClientImpl;
+
+    impl MlsClientImpl {
+        pub(crate) async fn new_member_add_proposal(
+            &self,
+            request: Request<NewMemberAddProposalRequest>,
+        ) -> Result<Response<NewMemberAddProposalResponse>, Status> {
+            let request = request.into_inner();
+
+            let group_info = MlsMessage::from_bytes(&request.group_info).map_err(abort)?;
+
+            let cipher_suite = group_info
+                .cipher_suite()
+                .ok_or(Status::aborted("message not group info"))?;
+
+            let client = create_client(cipher_suite.into(), &request.identity).await?;
+
+            let proposal = client
+                .client
+                .external_add_proposal(group_info, None, vec![])
+                .map_err(abort)?
+                .to_bytes()
+                .map_err(abort)?;
+
+            let (_, key_pckg_secrets) = client.key_package_repo.key_packages()[0].clone();
+            let signature_priv = client.signer.to_vec();
+
+            let mut clients = self.clients.lock().await;
+            clients.push(client);
+
+            let resp = NewMemberAddProposalResponse {
+                transaction_id: clients.len() as u32 - 1,
+                proposal,
+                init_priv: key_pckg_secrets.init_key.to_vec(),
+                encryption_priv: key_pckg_secrets.leaf_node_key.to_vec(),
+                signature_priv,
+            };
+
+            Ok(Response::new(resp))
+        }
+
+        pub(crate) async fn create_external_signer(
+            &self,
+            request: Request<CreateExternalSignerRequest>,
+        ) -> Result<Response<CreateExternalSignerResponse>, Status> {
+            let request = request.into_inner();
+
+            let cs = OpensslCryptoProvider::new()
+                .cipher_suite_provider((request.cipher_suite as u16).into())
+                .ok_or_else(|| Status::aborted("ciphersuite not supported"))?;
+
+            let (secret_key, public_key) = cs.signature_key_generate().map_err(abort)?;
+            let credential = BasicCredential::new(request.identity).into_credential();
+            let signing_identity = SigningIdentity::new(credential, public_key);
+
+            let external_sender = signing_identity.mls_encode_to_vec().map_err(abort)?;
+
+            let mut ext_clients = self.external_clients.lock().await;
+
+            let ext_client = ExternalClientBuilder::new()
+                .crypto_provider(OpensslCryptoProvider::default())
+                .identity_provider(BasicIdentityProvider::new())
+                .signer(secret_key, signing_identity)
+                .build();
+
+            ext_clients.push(ExternalClientDetails { ext_client });
+
+            let resp = CreateExternalSignerResponse {
+                signer_id: ext_clients.len() as u32 - 1,
+                external_sender,
+            };
+
+            Ok(Response::new(resp))
+        }
+    }
+}
+
+#[cfg(not(feature = "by_ref_proposal"))]
+pub(crate) mod external_proposal {
+    use tonic::{Request, Response, Status};
+
+    use crate::mls_client::{
+        CreateExternalSignerRequest, CreateExternalSignerResponse, NewMemberAddProposalRequest,
+        NewMemberAddProposalResponse,
+    };
+
+    use crate::MlsClientImpl;
+
+    impl MlsClientImpl {
+        pub(crate) async fn new_member_add_proposal(
+            &self,
+            _: Request<NewMemberAddProposalRequest>,
+        ) -> Result<Response<NewMemberAddProposalResponse>, Status> {
+            Err(Status::aborted("Unsupported"))
+        }
+
+        pub(crate) async fn create_external_signer(
+            &self,
+            _: Request<CreateExternalSignerRequest>,
+        ) -> Result<Response<CreateExternalSignerResponse>, Status> {
+            Err(Status::aborted("Unsupported"))
+        }
+    }
+}


### PR DESCRIPTION
### Description of changes:

Also fix 2 bugs found by the tests:
* The context extensions were not updated without the by_ref_proposal feature
* The `GroupSecrets` struct was serialized incorrectly without the psk feature -- the `psks` list was omitted instead of set to empty list. (Trying to process a commit/welcome with PSKs while not using the psk feature will always fail, at latest with "invalid confirmation tag".)

`configs` were adjusted from https://github.com/mlswg/mls-implementations/tree/main/interop/configs to work with all feature sets.

### Testing:

The CI runs the new tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
