### PR TITLE
Use rayon when generating welcome message

### DIFF
--- a/mls-rs/benches/group_add.rs
+++ b/mls-rs/benches/group_add.rs
@@ -9,6 +9,7 @@ use mls_rs::{
         basic::{BasicCredential, BasicIdentityProvider},
         SigningIdentity,
     },
+    mls_rules::{CommitOptions, DefaultMlsRules},
     CipherSuite, CipherSuiteProvider, Client, CryptoProvider,
 };
 use mls_rs_crypto_openssl::OpensslCryptoProvider;
@@ -70,6 +71,10 @@ fn make_client(name: &str) -> Client<impl MlsConfig> {
     Client::builder()
         .crypto_provider(crypto_provider)
         .identity_provider(BasicIdentityProvider)
+        .mls_rules(
+            DefaultMlsRules::new()
+                .with_commit_options(CommitOptions::new().with_ratchet_tree_extension(false)),
+        )
         .signing_identity(
             SigningIdentity::new(
                 BasicCredential::new(name.as_bytes().to_vec()).into_credential(),

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2176,9 +2176,6 @@ mod tests {
         (test_group, commit)
     }
 
-    // This test actually compiles without the by_ref_proposal feature, but it fails at runtime
-    // because the group context extensions seem to be updated only when this feature is enabled.
-    #[cfg(feature = "by_ref_proposal")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn test_group_context_ext_proposal_commit() {
         let mut extension_list = ExtensionList::new();

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mls-rs = { path = "..", default-features = false, features = ["std", "external_client", "external_commit", "state_update", "all_extensions"]}
+mls-rs = { path = "..", default-features = false, features = ["std", "external_client", "state_update"]}
 tonic = "0.7"
 prost = "0.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
@@ -22,7 +22,7 @@ prior_epoch = [ "mls-rs/prior_epoch" ]
 out_of_order = [ "mls-rs/out_of_order", "private_message" ]
 psk = [ "mls-rs/psk" ]
 custom_proposal = [ "mls-rs/custom_proposal" ]
-by_ref_proposal = [ "mls-rs/by_ref_proposal", "mls-rs/external_proposal" ]
+by_ref_proposal = [ "mls-rs/by_ref_proposal" ]
 default = ["tree_index", "private_message", "prior_epoch", "out_of_order", "psk", "custom_proposal", "by_ref_proposal"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
### Description of changes:

* Group secrets are encrypted in parallel.
* The group_add benchmark doesn't encrypt the tree in the welcome message, which is a more common use case.
* The group_add benchmark is added to CI.

### Testing:

Run `cargo bench --features benchmark_util --bench group_add` locally on an M1 MAC. For 1000 adds the result is
* main : `419.84 ms`
* after this PR but encrypting the tree : `174.00 ms` (`= 42%` of `419.84ms`)
* after this PR : `155.88ms`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
