### PR TITLE
Update docs.rs configuration and readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,3 @@ default-members = [
     "mls-rs-provider-sqlite",
     "mls-rs-codec"
 ]
-
-[profile.release-mini]
-inherits = "release"
-codegen-units = 1
-lto = true
-opt-level = "z"
-strip = "debuginfo"
-debug = 0
-debug-assertions = false
-overflow-checks = false

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![API Documentation]][docs.rs]
 
-[build status]: https://img.shields.io/github/workflow/status/WickrInc/mls/CI/master
-[actions]: https://github.com/WickrInc/mls/actions?query=branch%3Amaster
+[build status]: https://img.shields.io/github/checks-status/awslabs/mls-rs/main
+[actions]: https://github.com/awslabs/mls-rs/actions?query=branch%3main
 [latest version]: https://img.shields.io/crates/v/mls-rs.svg
 [crates.io]: https://crates.io/crates/mls-rs
 [api documentation]: (https://docs.rs/mls-rs/badge.svg)
@@ -22,37 +22,36 @@ communication between a group of clients.
 
 ## MLS Protocol Features
 
-* Multi-party E2EE [group evolution](https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#name-cryptographic-state-and-evo)
-via a propose-then-commit mechanism.
-* Asynchronous by design with pre-computed [key packages](https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#name-key-packages),
-allowing members to be added to a group while offline.
-* Customizable credential system with built in support for X.509 certificates.
-* [Extension system](https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#name-extensions)
-allowing for application specific data to be negotiated via the protocol.
-* Strong forward secrecy and post compromise security.
-* Crypto agility via support for multiple [ciphersuites](https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#name-mls-ciphersuites).
-* Pre-shared key support.
-* Subgroup branching.
-* Group reinitialization (ex: protocol version upgrade).
+- Multi-party E2EE [group evolution](https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#name-cryptographic-state-and-evo)
+  via a propose-then-commit mechanism.
+- Asynchronous by design with pre-computed [key packages](https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#name-key-packages),
+  allowing members to be added to a group while offline.
+- Customizable credential system with built in support for X.509 certificates.
+- [Extension system](https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#name-extensions)
+  allowing for application specific data to be negotiated via the protocol.
+- Strong forward secrecy and post compromise security.
+- Crypto agility via support for multiple [ciphersuites](https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#name-mls-ciphersuites).
+- Pre-shared key support.
+- Subgroup branching.
+- Group reinitialization (ex: protocol version upgrade).
 
 ## Features
 
-* Easy to use client interface that manages multiple MLS identities and groups.
-* 100% RFC conformance with support for all default credential, proposal,
+- Easy to use client interface that manages multiple MLS identities and groups.
+- 100% RFC conformance with support for all default credential, proposal,
   and extension types.
-* Async API with async trait based extension points.
-* Configurable storage for key packages, secrets and group state
+- Async API with async trait based extension points.
+- Configurable storage for key packages, secrets and group state
   via provider traits along with default "in memory" implementations.
-* Support for custom user created proposal, and extension types.
-* Ability to create user defined credentials with custom validation
+- Support for custom user created proposal, and extension types.
+- Ability to create user defined credentials with custom validation
   routines that can bridge to existing credential schemes.
-* OpenSSL and Rust Crypto based ciphersuite implementations.
-* Crypto agility with support for user defined ciphersuites.
-* High test coverage including security focused tests and
+- OpenSSL and Rust Crypto based ciphersuite implementations.
+- Crypto agility with support for user defined ciphersuites.
+- High test coverage including security focused tests and
   pre-computed test vectors.
-* Fuzz testing suite.
-* Benchmarks for core functionality.
-
+- Fuzz testing suite.
+- Benchmarks for core functionality.
 
 <!-- cargo-sync-readme end -->
 

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -8,6 +8,11 @@ repository = "https://github.com/awslabs/mls-rs"
 keywords = ["crypto", "cryptography", "security", "mls", "e2ee"]
 categories = ["no-std", "cryptography"]
 license = "Apache-2.0 OR MIT"
+rust-version = "1.68.2"
+
+[package.metadata.docs.rs]
+features = ["external_client", "sqlite"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["std", "rayon", "rfc_compliant", "tree_index", "fast_serialize"]

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -49,6 +49,7 @@
 #![allow(clippy::result_large_err)]
 #![allow(clippy::nonstandard_macro_braces)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 extern crate alloc;
 
 #[cfg(all(test, target_arch = "wasm32"))]
@@ -125,6 +126,7 @@ pub mod extension;
 /// Tools to observe groups without being a member, useful
 /// for server implementations.
 #[cfg(feature = "external_client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "external_client")))]
 pub mod external_client;
 mod grease;
 /// E2EE group created by a [`Client`].

--- a/mls-rs/src/storage_provider.rs
+++ b/mls-rs/src/storage_provider.rs
@@ -11,5 +11,6 @@ pub use group_state::*;
 pub use key_package::*;
 
 #[cfg(feature = "sqlite")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
 /// SQLite based storage providers.
 pub mod sqlite;


### PR DESCRIPTION
### Issues:

Resolves #6

### Description of changes:

Added the necessary flags to support docs.rs + feature flags for the `mls-rs` crate

### Call-outs:

Specifically did not look at the other crates, maybe some follow up work there later.

### Testing:

The documentation with feature labeling can be generated following the instructions [here](https://users.rust-lang.org/t/how-to-document-optional-features-in-api-docs/64577/3)
