### PR TITLE
Ignore test code in coverage reports, integrate with codecov

### DIFF
--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -33,3 +33,18 @@ jobs:
       - name: Examples
         working-directory: mls-rs
         run: cargo run --example basic_usage
+  CodeCoverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Setup code coverage
+        run: cargo install cargo-llvm-cov
+      - name: Run code coverage
+        run: cargo llvm-cov --lcov --features "test_util" --output-path lcov.info
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/mls-rs-core/src/crypto/test_suite.rs
+++ b/mls-rs-core/src/crypto/test_suite.rs
@@ -40,6 +40,7 @@ struct TestSuite {
 }
 
 #[cfg(all(not(mls_build_async), not(target_arch = "wasm32"), feature = "std"))]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn generate_tests<C: CryptoProvider>(crypto: &C) {
     for cs in crypto.supported_cipher_suites() {
         crypto.cipher_suite_provider(cs).unwrap();
@@ -60,6 +61,7 @@ pub fn generate_tests<C: CryptoProvider>(crypto: &C) {
 }
 
 #[cfg(all(not(mls_build_async), not(target_arch = "wasm32"), feature = "std"))]
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn create_or_load_tests<C: CryptoProvider>(crypto: &C) -> Vec<TestSuite> {
     if std::path::Path::new(PATH).exists() {
         serde_json::from_slice(&std::fs::read(PATH).unwrap()).unwrap()
@@ -138,6 +140,7 @@ async fn verify_signature_tests<C: CipherSuiteProvider>(
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn generate_signature_tests<C: CipherSuiteProvider>(cs: &C) -> Vec<SignatureTestCase> {
     let mut tests = Vec::new();
 
@@ -310,6 +313,7 @@ async fn test_open_ciphertext<C: CipherSuiteProvider>(
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn generate_hpke_tests<C: CipherSuiteProvider>(cs: &C) -> HpkeTestCases {
     let ikm = cs.random_bytes_vec(cs.kdf_extract_size()).unwrap();
     let (secret, public) = cs.kem_derive(&ikm).await.unwrap();
@@ -417,6 +421,7 @@ async fn verify_hkdf_tests<C: CipherSuiteProvider>(cs: &C, test_cases: Vec<HkdfT
 }
 
 #[cfg(all(not(mls_build_async), not(target_arch = "wasm32"), feature = "std"))]
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn generate_hkdf_tests<C: CipherSuiteProvider>(cs: &C) -> Vec<HkdfTestCase> {
     let iter = DATA_SIZES.iter().copied();
 

--- a/mls-rs-core/src/lib.rs
+++ b/mls-rs-core/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 extern crate alloc;
 
 #[cfg(all(test, target_arch = "wasm32"))]

--- a/mls-rs/README.md
+++ b/mls-rs/README.md
@@ -1,4 +1,4 @@
-# mls-rs &emsp; [![Build Status]][actions] [![Latest Version]][crates.io] [![API Documentation]][docs.rs]
+# mls-rs &emsp; [![Build Status]][actions] [![Latest Version]][crates.io] [![API Documentation]][docs.rs] [![codecov](https://codecov.io/gh/awslabs/mls-rs/graph/badge.svg?token=6655ESMTZT)](https://codecov.io/gh/awslabs/mls-rs)
 
 [build status]: https://img.shields.io/github/checks-status/awslabs/mls-rs/main
 [actions]: https://github.com/awslabs/mls-rs/actions?query=branch%3Amain++

--- a/mls-rs/src/group/ciphertext_processor/reuse_guard.rs
+++ b/mls-rs/src/group/ciphertext_processor/reuse_guard.rs
@@ -92,23 +92,27 @@ mod tests {
         result: Vec<u8>,
     }
 
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn generate_reuse_guard_test_cases() -> Vec<TestCase> {
         let provider = test_cipher_suite_provider(TEST_CIPHER_SUITE);
 
         [16, 32]
             .into_iter()
-            .map(|len| {
-                let nonce = provider.random_bytes_vec(len).unwrap();
-                let guard = ReuseGuard::random(&provider).unwrap();
+            .map(
+                #[cfg_attr(coverage_nightly, coverage(off))]
+                |len| {
+                    let nonce = provider.random_bytes_vec(len).unwrap();
+                    let guard = ReuseGuard::random(&provider).unwrap();
 
-                let result = guard.apply(&nonce);
+                    let result = guard.apply(&nonce);
 
-                TestCase {
-                    nonce,
-                    guard: guard.into(),
-                    result,
-                }
-            })
+                    TestCase {
+                        nonce,
+                        guard: guard.into(),
+                        result,
+                    }
+                },
+            )
             .collect()
     }
 

--- a/mls-rs/src/group/interop_test_vectors/framing.rs
+++ b/mls-rs/src/group/interop_test_vectors/framing.rs
@@ -68,6 +68,7 @@ struct FramingTestCase {
 
 impl FramingTestCase {
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     async fn random<P: CipherSuiteProvider>(cs: &P) -> Self {
         let mut context = InteropGroupContext::random(cs);
         context.cipher_suite = cs.cipher_suite().into();
@@ -103,6 +104,7 @@ pub struct InteropGroupContext {
 }
 
 impl InteropGroupContext {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn random<P: CipherSuiteProvider>(cs: &P) -> Self {
         Self {
             cipher_suite: cs.cipher_suite().into(),
@@ -115,6 +117,7 @@ impl InteropGroupContext {
 }
 
 impl From<InteropGroupContext> for GroupContext {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn from(ctx: InteropGroupContext) -> Self {
         Self {
             cipher_suite: ctx.cipher_suite.into(),
@@ -278,6 +281,7 @@ async fn framing_commit() {
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn generate_framing_test_vector() -> Vec<FramingTestCase> {
     let mut test_vector = vec![];
 

--- a/mls-rs/src/group/interop_test_vectors/passive_client.rs
+++ b/mls-rs/src/group/interop_test_vectors/passive_client.rs
@@ -78,6 +78,7 @@ pub struct TestMlsMessage(#[serde(with = "hex::serde")] pub Vec<u8>);
 pub struct TestRatchetTree(#[serde(with = "hex::serde")] pub Vec<u8>);
 
 impl TestEpoch {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn new(
         proposals: Vec<MlsMessage>,
         commit: &MlsMessage,
@@ -209,6 +210,7 @@ async fn interop_passive_client() {
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn invite_passive_client<P: CipherSuiteProvider>(
     groups: &mut [Group<impl MlsConfig>],
     with_psk: bool,
@@ -267,6 +269,7 @@ async fn invite_passive_client<P: CipherSuiteProvider>(
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub async fn generate_passive_client_proposal_tests() {
     let mut test_cases: Vec<TestCase> = vec![];
 
@@ -431,6 +434,7 @@ pub async fn generate_passive_client_proposal_tests() {
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn commit_by_value<F, C: MlsConfig>(
     group: &mut Group<C>,
     proposal_adder: F,
@@ -450,6 +454,7 @@ where
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn create_key_package(cs: CipherSuite) -> MlsMessage {
     let client =
         generate_basic_client(cs, VERSION, 0xbeef, None, false, &TestCryptoProvider::new()).await;
@@ -458,6 +463,7 @@ async fn create_key_package(cs: CipherSuite) -> MlsMessage {
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub async fn generate_passive_client_welcome_tests() {
     let mut test_cases: Vec<TestCase> = vec![];
 
@@ -502,6 +508,7 @@ pub async fn generate_passive_client_welcome_tests() {
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub async fn generate_passive_client_random_tests() {
     let mut test_cases: Vec<TestCase> = vec![];
 
@@ -571,6 +578,7 @@ pub async fn generate_passive_client_random_tests() {
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub async fn add_random_members<C: MlsConfig>(
     committer: usize,
     groups: &mut Vec<Group<C>>,
@@ -631,6 +639,7 @@ pub async fn add_random_members<C: MlsConfig>(
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub async fn remove_members<C: MlsConfig>(
     removed_members: Vec<usize>,
     committer: usize,

--- a/mls-rs/src/group/interop_test_vectors/tree_modifications.rs
+++ b/mls-rs/src/group/interop_test_vectors/tree_modifications.rs
@@ -39,6 +39,7 @@ struct TreeModsTestCase {
 
 impl TreeModsTestCase {
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     async fn new(tree_before: TreeKemPublic, proposal: Proposal, proposal_sender: u32) -> Self {
         let tree_after = apply_proposal(proposal.clone(), proposal_sender, &tree_before).await;
 
@@ -52,6 +53,7 @@ impl TreeModsTestCase {
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn generate_tree_mods_tests() -> Vec<TreeModsTestCase> {
     let mut test_vector = vec![];
     let cs = test_cipher_suite_provider(TEST_CIPHER_SUITE);
@@ -139,17 +141,20 @@ async fn apply_proposal(
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn generate_add() -> Proposal {
     let key_package = test_key_package(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "Roger").await;
     Proposal::Add(Box::new(AddProposal { key_package }))
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn generate_remove(i: u32) -> Proposal {
     let to_remove = LeafIndex(i);
     Proposal::Remove(RemoveProposal { to_remove })
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn generate_update(i: u32, tree: &TreeWithSigners) -> Proposal {
     let signer = tree.signers[i as usize].as_ref().unwrap();
     let mut leaf_node = tree.tree.get_leaf_node(LeafIndex(i)).unwrap().clone();

--- a/mls-rs/src/group/key_schedule.rs
+++ b/mls-rs/src/group/key_schedule.rs
@@ -481,7 +481,8 @@ pub(crate) mod test_utils {
             InitSecret(Zeroizing::new(init_secret))
         }
 
-        #[cfg(feature = "rfc_compliant")]
+        #[cfg(all(feature = "rfc_compliant", test))]
+        #[cfg_attr(coverage_nightly, coverage(off))]
         pub fn random<P: CipherSuiteProvider>(cipher_suite: &P) -> Result<Self, MlsError> {
             cipher_suite
                 .random_bytes_vec(cipher_suite.kdf_extract_size())
@@ -708,6 +709,7 @@ mod tests {
     }
 
     #[cfg(all(not(mls_build_async), feature = "rfc_compliant"))]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn generate_test_vector() -> Vec<TestCase> {
         let mut test_cases = vec![];
 
@@ -799,6 +801,7 @@ mod tests {
 
     #[cfg(all(not(mls_build_async), feature = "rfc_compliant"))]
     impl KeyScheduleEpoch {
+        #[cfg_attr(coverage_nightly, coverage(off))]
         fn new<P: CipherSuiteProvider>(
             key_schedule_res: KeyScheduleDerivationResult,
             psk_secret: PskSecret,

--- a/mls-rs/src/group/membership_tag.rs
+++ b/mls-rs/src/group/membership_tag.rs
@@ -99,6 +99,7 @@ mod tests {
     }
 
     #[cfg(not(mls_build_async))]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn generate_test_cases() -> Vec<TestCase> {
         let mut test_cases = Vec::new();
 

--- a/mls-rs/src/group/padding.rs
+++ b/mls-rs/src/group/padding.rs
@@ -51,6 +51,7 @@ mod tests {
         output: usize,
     }
 
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn generate_message_padding_test_vector() -> Vec<TestCase> {
         let mut test_cases = vec![];
         for x in 1..1024 {

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -3820,6 +3820,7 @@ mod tests {
                 Ok(proposals)
             }
 
+            #[cfg_attr(coverage_nightly, coverage(off))]
             fn commit_options(
                 &self,
                 _: &Roster,
@@ -3829,6 +3830,7 @@ mod tests {
                 Ok(Default::default())
             }
 
+            #[cfg_attr(coverage_nightly, coverage(off))]
             fn encryption_options(
                 &self,
                 _: &Roster,
@@ -3869,6 +3871,7 @@ mod tests {
             Err(MlsError::InvalidSignature)
         }
 
+        #[cfg_attr(coverage_nightly, coverage(off))]
         fn commit_options(
             &self,
             _: &Roster,
@@ -3878,6 +3881,7 @@ mod tests {
             Ok(Default::default())
         }
 
+        #[cfg_attr(coverage_nightly, coverage(off))]
         fn encryption_options(
             &self,
             _: &Roster,
@@ -3913,6 +3917,7 @@ mod tests {
             Ok(proposals)
         }
 
+        #[cfg_attr(coverage_nightly, coverage(off))]
         fn commit_options(
             &self,
             _: &Roster,
@@ -3922,6 +3927,7 @@ mod tests {
             Ok(Default::default())
         }
 
+        #[cfg_attr(coverage_nightly, coverage(off))]
         fn encryption_options(
             &self,
             _: &Roster,

--- a/mls-rs/src/group/proposal_ref.rs
+++ b/mls-rs/src/group/proposal_ref.rs
@@ -79,6 +79,7 @@ mod test {
 
     use crate::extension::RequiredCapabilitiesExt;
 
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn get_test_extension_list() -> ExtensionList {
         let test_extension = RequiredCapabilitiesExt {
             extensions: vec![42.into()],
@@ -102,6 +103,7 @@ mod test {
     }
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     async fn generate_proposal_test_cases() -> Vec<TestCase> {
         let mut test_cases = Vec::new();
 

--- a/mls-rs/src/group/secret_tree.rs
+++ b/mls-rs/src/group/secret_tree.rs
@@ -894,6 +894,7 @@ mod tests {
     }
 
     #[cfg(not(mls_build_async))]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn generate_test_vector() -> Vec<TestCase> {
         CipherSuite::all()
             .map(|cipher_suite| {
@@ -1023,6 +1024,7 @@ mod interop_tests {
     }
 
     #[cfg(not(mls_build_async))]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn generate_test_vector() -> Vec<InteropTestCase> {
         let mut test_cases = vec![];
 

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -399,12 +399,14 @@ pub(crate) struct GroupWithoutKeySchedule {
 impl Deref for GroupWithoutKeySchedule {
     type Target = Group<TestClientConfig>;
 
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
 impl DerefMut for GroupWithoutKeySchedule {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
@@ -435,6 +437,7 @@ impl MessageProcessor for GroupWithoutKeySchedule {
         self.inner.group_state()
     }
 
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn group_state_mut(&mut self) -> &mut GroupState {
         self.inner.group_state_mut()
     }
@@ -459,6 +462,7 @@ impl MessageProcessor for GroupWithoutKeySchedule {
         self.inner.can_continue_processing(provisional_state)
     }
 
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn min_epoch_available(&self) -> Option<u64> {
         self.inner.min_epoch_available()
     }
@@ -475,6 +479,7 @@ impl MessageProcessor for GroupWithoutKeySchedule {
     }
 
     #[cfg(feature = "private_message")]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     async fn process_ciphertext(
         &mut self,
         cipher_text: PrivateMessage,
@@ -482,6 +487,7 @@ impl MessageProcessor for GroupWithoutKeySchedule {
         self.inner.process_ciphertext(cipher_text).await
     }
 
+    #[cfg_attr(coverage_nightly, coverage(off))]
     async fn verify_plaintext_authentication(
         &self,
         message: PublicMessage,
@@ -501,6 +507,7 @@ impl MessageProcessor for GroupWithoutKeySchedule {
         Ok(())
     }
 
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn self_index(&self) -> Option<LeafIndex> {
         <Group<TestClientConfig> as MessageProcessor>::self_index(&self.inner)
     }

--- a/mls-rs/src/group/transcript_hash.rs
+++ b/mls-rs/src/group/transcript_hash.rs
@@ -187,6 +187,7 @@ mod tests {
     }
 
     #[cfg(not(mls_build_async))]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn generate_test_vector() -> Vec<TestCase> {
         CipherSuite::all().fold(vec![], |mut test_cases, cs| {
             let cs = test_cipher_suite_provider(cs);

--- a/mls-rs/src/hash_reference.rs
+++ b/mls-rs/src/hash_reference.rs
@@ -93,6 +93,7 @@ mod tests {
     }
 
     #[cfg(not(mls_build_async))]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn generate_test_vector() -> Vec<InteropTestCase> {
         CipherSuite::all()
             .map(|cipher_suite| {

--- a/mls-rs/src/identity.rs
+++ b/mls-rs/src/identity.rs
@@ -35,7 +35,7 @@ pub(crate) mod test_utils {
 
     use crate::crypto::test_utils::test_cipher_suite_provider;
 
-    use super::basic::{BasicCredential, BasicIdentityProvider, BasicIdentityProviderError};
+    use super::basic::{BasicCredential, BasicIdentityProvider};
 
     #[derive(Debug)]
     #[cfg_attr(feature = "std", derive(thiserror::Error))]
@@ -44,12 +44,6 @@ pub(crate) mod test_utils {
         error("expected basic or custom credential type 42 found: {0:?}")
     )]
     pub struct BasicWithCustomProviderError(CredentialType);
-
-    impl From<BasicIdentityProviderError> for BasicWithCustomProviderError {
-        fn from(value: BasicIdentityProviderError) -> Self {
-            BasicWithCustomProviderError(value.credential_type())
-        }
-    }
 
     impl IntoAnyError for BasicWithCustomProviderError {
         #[cfg(feature = "std")]

--- a/mls-rs/src/identity/basic.rs
+++ b/mls-rs/src/identity/basic.rs
@@ -20,12 +20,6 @@ use mls_rs_core::{
 /// credential is passed to a [`BasicIdentityProvider`].
 pub struct BasicIdentityProviderError(CredentialType);
 
-impl From<CredentialType> for BasicIdentityProviderError {
-    fn from(value: CredentialType) -> Self {
-        BasicIdentityProviderError(value)
-    }
-}
-
 impl IntoAnyError for BasicIdentityProviderError {
     #[cfg(feature = "std")]
     fn into_dyn_error(self) -> Result<Box<dyn std::error::Error + Send + Sync>, Self> {

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -74,14 +74,6 @@ impl KeyPackage {
         self.version
     }
 
-    pub fn cipher_suite(&self) -> CipherSuite {
-        self.cipher_suite
-    }
-
-    pub fn extensions(&self) -> &ExtensionList {
-        &self.extensions
-    }
-
     pub fn signing_identity(&self) -> &SigningIdentity {
         &self.leaf_node.signing_identity
     }
@@ -290,6 +282,7 @@ mod tests {
 
     impl TestCase {
         #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+        #[cfg_attr(coverage_nightly, coverage(off))]
         async fn generate() -> Vec<TestCase> {
             let mut test_cases = Vec::new();
 

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -61,6 +61,7 @@
 #![allow(clippy::nonstandard_macro_braces)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 extern crate alloc;
 
 #[cfg(all(test, target_arch = "wasm32"))]

--- a/mls-rs/src/psk.rs
+++ b/mls-rs/src/psk.rs
@@ -125,6 +125,7 @@ pub(crate) mod test_utils {
         psk::ExternalPskId,
     };
 
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub(crate) fn make_external_psk_id<P: CipherSuiteProvider>(
         cipher_suite_provider: &P,
     ) -> ExternalPskId {

--- a/mls-rs/src/psk/resolver.rs
+++ b/mls-rs/src/psk/resolver.rs
@@ -31,19 +31,6 @@ where
     pub psk_store: &'a PS,
 }
 
-impl<GS: GroupStateStorage, K: KeyPackageStorage, PS: PreSharedKeyStorage> Clone
-    for PskResolver<'_, GS, K, PS>
-{
-    fn clone(&self) -> Self {
-        Self {
-            group_context: self.group_context,
-            current_epoch: self.current_epoch,
-            prior_epochs: self.prior_epochs,
-            psk_store: self.psk_store,
-        }
-    }
-}
-
 impl<GS: GroupStateStorage, K: KeyPackageStorage, PS: PreSharedKeyStorage>
     PskResolver<'_, GS, K, PS>
 {

--- a/mls-rs/src/psk/secret.rs
+++ b/mls-rs/src/psk/secret.rs
@@ -152,30 +152,41 @@ mod tests {
     }
 
     impl TestScenario {
+        #[cfg_attr(coverage_nightly, coverage(off))]
         fn make_psk_list<CS: CipherSuiteProvider>(cs: &CS, n: usize) -> Vec<PskInfo> {
-            iter::repeat_with(|| PskInfo {
-                id: make_external_psk_id(cs).to_vec(),
-                psk: cs.random_bytes_vec(cs.kdf_extract_size()).unwrap(),
-                nonce: make_nonce(cs.cipher_suite()).0,
-            })
+            iter::repeat_with(
+                #[cfg_attr(coverage_nightly, coverage(off))]
+                || PskInfo {
+                    id: make_external_psk_id(cs).to_vec(),
+                    psk: cs.random_bytes_vec(cs.kdf_extract_size()).unwrap(),
+                    nonce: make_nonce(cs.cipher_suite()).0,
+                },
+            )
             .take(n)
             .collect::<Vec<_>>()
         }
 
         #[cfg(not(mls_build_async))]
+        #[cfg_attr(coverage_nightly, coverage(off))]
         fn generate() -> Vec<TestScenario> {
             CipherSuite::all()
-                .flat_map(|cs| (1..=10).map(move |n| (cs, n)))
-                .map(|(cs, n)| {
-                    let provider = test_cipher_suite_provider(cs);
-                    let psks = Self::make_psk_list(&provider, n);
-                    let psk_secret = Self::compute_psk_secret(&provider, psks.clone());
-                    TestScenario {
-                        cipher_suite: cs.into(),
-                        psks: psks.to_vec(),
-                        psk_secret: psk_secret.to_vec(),
-                    }
-                })
+                .flat_map(
+                    #[cfg_attr(coverage_nightly, coverage(off))]
+                    |cs| (1..=10).map(move |n| (cs, n)),
+                )
+                .map(
+                    #[cfg_attr(coverage_nightly, coverage(off))]
+                    |(cs, n)| {
+                        let provider = test_cipher_suite_provider(cs);
+                        let psks = Self::make_psk_list(&provider, n);
+                        let psk_secret = Self::compute_psk_secret(&provider, psks.clone());
+                        TestScenario {
+                            cipher_suite: cs.into(),
+                            psks: psks.to_vec(),
+                            psk_secret: psk_secret.to_vec(),
+                        }
+                    },
+                )
                 .collect()
         }
 

--- a/mls-rs/src/signer.rs
+++ b/mls-rs/src/signer.rs
@@ -193,6 +193,7 @@ mod tests {
     }
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     async fn generate_test_cases() -> Vec<TestCase> {
         let mut test_cases = Vec::new();
 

--- a/mls-rs/src/test_utils/mod.rs
+++ b/mls-rs/src/test_utils/mod.rs
@@ -27,12 +27,14 @@ use crate::group::{mls_rules::EncryptionOptions, padding::PaddingMode};
 
 use alloc::{vec, vec::Vec};
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn get_test_basic_credential(identity: Vec<u8>) -> Credential {
     BasicCredential::new(identity).into_credential()
 }
 
 pub const TEST_EXT_PSK_ID: &[u8] = b"external psk";
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn make_test_ext_psk() -> Vec<u8> {
     b"secret psk key".to_vec()
 }
@@ -48,6 +50,7 @@ pub fn is_edwards(cs: u16) -> bool {
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub async fn generate_basic_client<C: CryptoProvider + Clone>(
     cipher_suite: CipherSuite,
     protocol_version: ProtocolVersion,
@@ -88,6 +91,7 @@ pub async fn generate_basic_client<C: CryptoProvider + Clone>(
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub async fn get_test_groups<C: CryptoProvider + Clone>(
     version: ProtocolVersion,
     cipher_suite: CipherSuite,
@@ -149,6 +153,7 @@ pub async fn get_test_groups<C: CryptoProvider + Clone>(
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub async fn all_process_message<C: MlsConfig>(
     groups: &mut [Group<C>],
     message: &MlsMessage,

--- a/mls-rs/src/tree_kem/hpke_encryption.rs
+++ b/mls-rs/src/tree_kem/hpke_encryption.rs
@@ -130,6 +130,7 @@ pub(crate) mod test_utils {
             Ok(Self(bytes))
         }
 
+        #[cfg_attr(coverage_nightly, coverage(off))]
         fn get_bytes(&self) -> Result<Vec<u8>, MlsError> {
             Ok(self.0.clone())
         }

--- a/mls-rs/src/tree_kem/interop_test_vectors.rs
+++ b/mls-rs/src/tree_kem/interop_test_vectors.rs
@@ -36,12 +36,14 @@ struct ValidationTestCase {
 struct TreeHash(#[serde(with = "hex::serde")] pub Vec<u8>);
 
 impl From<crate::tree_kem::tree_hash::TreeHash> for TreeHash {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn from(value: crate::tree_kem::tree_hash::TreeHash) -> Self {
         TreeHash(value.to_vec())
     }
 }
 
 impl ValidationTestCase {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn new<P: CipherSuiteProvider>(tree: TreeKemPublic, group_id: &[u8], cs: &P) -> Self {
         let tree_size = tree.total_leaf_count() * 2 - 1;
 
@@ -51,7 +53,10 @@ impl ValidationTestCase {
         );
 
         let resolutions = (0..tree_size)
-            .map(|i| tree.nodes.get_resolution_index(i).unwrap())
+            .map(
+                #[cfg_attr(coverage_nightly, coverage(off))]
+                |i| tree.nodes.get_resolution_index(i).unwrap(),
+            )
             .collect();
 
         Self {
@@ -71,6 +76,7 @@ impl ValidationTestCase {
 
 #[cfg(feature = "rfc_compliant")]
 #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn validation() {
     #[cfg(mls_build_async)]
     let test_cases: Vec<ValidationTestCase> = load_test_case_json!(
@@ -126,6 +132,7 @@ async fn validation() {
 
 #[cfg(feature = "rfc_compliant")]
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn generate_validation_test_vector() -> Vec<ValidationTestCase> {
     let mut test_cases = vec![];
 
@@ -156,7 +163,10 @@ async fn generate_validation_test_vector() -> Vec<ValidationTestCase> {
 
         // Internal blanks, with skipping : 8 leaves, 0 commits removing 1, 2, 3
         let mut tree = TreeWithSigners::make_full_tree(8, &cs).await;
-        [1, 2, 3].into_iter().for_each(|i| tree.remove_member(i));
+        [1, 2, 3].into_iter().for_each(
+            #[cfg_attr(coverage_nightly, coverage(off))]
+            |i| tree.remove_member(i),
+        );
         tree.update_committer_path(0, &cs).await;
         trees.push(tree);
 
@@ -182,9 +192,10 @@ async fn generate_validation_test_vector() -> Vec<ValidationTestCase> {
         trees.push(tree);
 
         // Generate tests
-        trees.into_iter().for_each(|tree| {
-            test_cases.push(ValidationTestCase::new(tree.tree, &tree.group_id, &cs))
-        });
+        trees.into_iter().for_each(
+            #[cfg_attr(coverage_nightly, coverage(off))]
+            |tree| test_cases.push(ValidationTestCase::new(tree.tree, &tree.group_id, &cs)),
+        );
     }
 
     test_cases

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -682,10 +682,12 @@ pub(crate) mod test_utils {
             Err(TestFailureError)
         }
 
+        #[cfg_attr(coverage_nightly, coverage(off))]
         async fn identity(&self, signing_id: &SigningIdentity) -> Result<Vec<u8>, Self::Error> {
             Ok(signing_id.credential.mls_encode_to_vec().unwrap())
         }
 
+        #[cfg_attr(coverage_nightly, coverage(off))]
         async fn valid_successor(
             &self,
             _predecessor: &SigningIdentity,
@@ -694,10 +696,12 @@ pub(crate) mod test_utils {
             Err(TestFailureError)
         }
 
+        #[cfg_attr(coverage_nightly, coverage(off))]
         fn supported_types(&self) -> Vec<crate::identity::CredentialType> {
             vec![BasicCredential::credential_type()]
         }
 
+        #[cfg_attr(coverage_nightly, coverage(off))]
         async fn identity_warnings(
             &self,
             _update: &RosterUpdate,

--- a/mls-rs/src/tree_kem/math.rs
+++ b/mls-rs/src/tree_kem/math.rs
@@ -214,6 +214,7 @@ mod tests {
         assert_eq!(bfs.collect::<Vec<_>>(), expected);
     }
 
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn generate_tree_math_test_cases() -> Vec<TestCase> {
         let mut test_cases = Vec::new();
 

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -790,6 +790,7 @@ pub(crate) mod test_utils {
         }
 
         #[cfg(feature = "rfc_compliant")]
+        #[cfg_attr(coverage_nightly, coverage(off))]
         pub fn remove_member(&mut self, member: u32) {
             self.tree
                 .nodes

--- a/mls-rs/src/tree_kem/path_secret.rs
+++ b/mls-rs/src/tree_kem/path_secret.rs
@@ -145,21 +145,25 @@ mod tests {
 
     impl TestCase {
         #[cfg(not(mls_build_async))]
+        #[cfg_attr(coverage_nightly, coverage(off))]
         fn generate() -> Vec<TestCase> {
             CipherSuite::all()
-                .map(|cipher_suite| {
-                    let cs_provider = test_cipher_suite_provider(cipher_suite);
-                    let mut generator = PathSecretGenerator::new(&cs_provider);
+                .map(
+                    #[cfg_attr(coverage_nightly, coverage(off))]
+                    |cipher_suite| {
+                        let cs_provider = test_cipher_suite_provider(cipher_suite);
+                        let mut generator = PathSecretGenerator::new(&cs_provider);
 
-                    let generations = (0..10)
-                        .map(|_| hex::encode(&*generator.next_secret().unwrap()))
-                        .collect();
+                        let generations = (0..10)
+                            .map(|_| hex::encode(&*generator.next_secret().unwrap()))
+                            .collect();
 
-                    TestCase {
-                        cipher_suite: cipher_suite.into(),
-                        generations,
-                    }
-                })
+                        TestCase {
+                            cipher_suite: cipher_suite.into(),
+                            generations,
+                        }
+                    },
+                )
                 .collect()
         }
 

--- a/mls-rs/src/tree_kem/tree_hash.rs
+++ b/mls-rs/src/tree_kem/tree_hash.rs
@@ -366,6 +366,7 @@ mod tests {
 
     impl TestCase {
         #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+        #[cfg_attr(coverage_nightly, coverage(off))]
         async fn generate() -> Vec<TestCase> {
             let mut test_cases = Vec::new();
 


### PR DESCRIPTION
Generate a clean coverage report by eliminating code that is only compiled under the test cfg. Add support for codecov under github actions
