### PR TITLE
Re-export AnyError and IntoAnyError from core

### DIFF
--- a/mls-rs-core/src/error.rs
+++ b/mls-rs-core/src/error.rs
@@ -6,6 +6,7 @@ use core::fmt::{self, Display};
 
 #[cfg(feature = "std")]
 #[derive(Debug)]
+/// Generic error used to wrap errors produced by providers.
 pub struct AnyError(Box<dyn std::error::Error + Send + Sync>);
 
 #[cfg(not(feature = "std"))]
@@ -33,6 +34,7 @@ impl Display for AnyError {
     }
 }
 
+/// Trait to convert a provider specific error into [`AnyError`]
 pub trait IntoAnyError: core::fmt::Debug + Sized {
     #[cfg(feature = "std")]
     fn into_any_error(self) -> AnyError {

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -187,6 +187,7 @@ pub use group::{
 /// Error types.
 pub mod error {
     pub use crate::client::MlsError;
+    pub use mls_rs_core::error::{AnyError, IntoAnyError};
     pub use mls_rs_core::extension::ExtensionError;
 }
 


### PR DESCRIPTION
### Issues:

Resolves #25 

### Description of changes:

Add these two dependencies to the `error` module in mls-rs