### PR TITLE
Take fuzz targets out of the main workspace

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy, rustfmt
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
       - name: Rust Fmt on fuzz targets

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -9,16 +9,22 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v3
-        - uses: dtolnay/rust-toolchain@nightly
-        - name: Install cargo-fuzz
-          run: cargo install cargo-fuzz
-        - name: Run Fuzz Targets
-          working-directory: mls-rs
-          run: |
-            cargo +nightly fuzz run application_data -- -runs=$RUNS -timeout=$TIME
-            cargo +nightly fuzz run cipher_text -- -runs=$RUNS -timeout=$TIME
-            cargo +nightly fuzz run deserialize -- -runs=$RUNS -timeout=$TIME
-            cargo +nightly fuzz run export_secret -- -runs=$RUNS -timeout=$TIME
-            cargo +nightly fuzz run mls_message -- -runs=$RUNS -timeout=$TIME
-            cargo +nightly fuzz run process_bytes -- -runs=$RUNS -timeout=$TIME
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+      - name: Rust Fmt on fuzz targets
+        working-directory: mls-rs/fuzz
+        run: cargo fmt --all -- --check
+      - name: Clippy on fuzz targets
+        working-directory: mls-rs/fuzz
+        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+      - name: Run Fuzz Targets
+        working-directory: mls-rs
+        run: |
+          cargo +nightly fuzz run application_data -- -runs=$RUNS -timeout=$TIME
+          cargo +nightly fuzz run cipher_text -- -runs=$RUNS -timeout=$TIME
+          cargo +nightly fuzz run deserialize -- -runs=$RUNS -timeout=$TIME
+          cargo +nightly fuzz run export_secret -- -runs=$RUNS -timeout=$TIME
+          cargo +nightly fuzz run mls_message -- -runs=$RUNS -timeout=$TIME
+          cargo +nightly fuzz run process_bytes -- -runs=$RUNS -timeout=$TIME

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
     "mls-rs-core",
     "mls-rs-ffi",
     "mls-rs-identity-x509",
-    "mls-rs/fuzz",
     "mls-rs/test_harness_integration",
     "mls-rs-crypto-openssl",
     "mls-rs-crypto-rustcrypto",

--- a/mls-rs/fuzz/Cargo.toml
+++ b/mls-rs/fuzz/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "fuzz"
 version = "0.0.0"


### PR DESCRIPTION
The MacOS github actions runner has stopped working due to inability to build the fuzzing library. This will prevent that by only running on the linux target