### PR TITLE
Use `ProposalInfo` instead of `Proposal` for unused proposals

### DIFF
--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -422,8 +422,6 @@ where
             .state
             .apply_resolved(
                 sender,
-                #[cfg(all(feature = "by_ref_proposal", feature = "state_update"))]
-                Some(sender),
                 proposals,
                 external_leaf,
                 &self.config.identity_provider(),

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -516,8 +516,18 @@ impl<T> ProposalInfo<T> {
         &self.proposal
     }
 
+    /// The source of the proposal.
     pub fn source(&self) -> &ProposalSource {
         &self.source
+    }
+
+    /// The [`ProposalRef`] of this proposal if its source is [`ProposalSource::ByReference`]
+    #[cfg(feature = "by_ref_proposal")]
+    pub fn proposal_ref(&self) -> Option<&ProposalRef> {
+        match self.source {
+            ProposalSource::ByReference(ref reference) => Some(reference),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
### Issues:

Resolves #27 

### Description of changes:

Replace `Proposal` with `ProposalInfo<Proposal>` to offer a better description of the proposal that was not used.

### Call-outs:

Chose this over `CachedProposal` since this has the same information and is used in the public API already.

### Testing:

Updated a lot of tests to verify. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
