### PR TITLE
Conditionally compile getters for public fields

### DIFF
--- a/mls-rs-core/src/group/roster.rs
+++ b/mls-rs-core/src/group/roster.rs
@@ -33,26 +33,31 @@ pub struct Capabilities {
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
 impl Capabilities {
     /// Supported protocol versions
+    #[cfg(feature = "ffi")]
     pub fn protocol_versions(&self) -> &[ProtocolVersion] {
         &self.protocol_versions
     }
 
     /// Supported ciphersuites
+    #[cfg(feature = "ffi")]
     pub fn cipher_suites(&self) -> &[CipherSuite] {
         &self.cipher_suites
     }
 
     /// Supported extensions
+    #[cfg(feature = "ffi")]
     pub fn extensions(&self) -> &[ExtensionType] {
         &self.extensions
     }
 
     /// Supported proposals
+    #[cfg(feature = "ffi")]
     pub fn proposals(&self) -> &[ProposalType] {
         &self.proposals
     }
 
     /// Supported credentials
+    #[cfg(feature = "ffi")]
     pub fn credentials(&self) -> &[CredentialType] {
         &self.credentials
     }

--- a/mls-rs-core/src/group/roster.rs
+++ b/mls-rs-core/src/group/roster.rs
@@ -132,12 +132,17 @@ impl Member {
 
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+#[cfg_attr(
+    all(feature = "ffi", not(test)),
+    safer_ffi_gen::ffi_type(clone, opaque)
+)]
 /// Update of a member due to a commit.
 pub struct MemberUpdate {
-    pub(crate) prior: Member,
-    pub(crate) new: Member,
+    pub prior: Member,
+    pub new: Member,
 }
 
+#[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
 impl MemberUpdate {
     /// Create a new member update.
     pub fn new(prior: Member, new: Member) -> MemberUpdate {
@@ -150,11 +155,13 @@ impl MemberUpdate {
     }
 
     /// Member state before the update.
+    #[cfg(feature = "ffi")]
     pub fn before_update(&self) -> &Member {
         &self.prior
     }
 
     /// Member state after the update.
+    #[cfg(feature = "ffi")]
     pub fn after_update(&self) -> &Member {
         &self.new
     }

--- a/mls-rs/src/extension/built_in.rs
+++ b/mls-rs/src/extension/built_in.rs
@@ -110,16 +110,19 @@ impl RequiredCapabilitiesExt {
     }
 
     /// Required custom extension types.
+    #[cfg(feature = "ffi")]
     pub fn extensions(&self) -> &[ExtensionType] {
         &self.extensions
     }
 
     /// Required custom proposal types.
+    #[cfg(feature = "ffi")]
     pub fn proposals(&self) -> &[ProposalType] {
         &self.proposals
     }
 
     /// Required custom credential types.
+    #[cfg(feature = "ffi")]
     pub fn credentials(&self) -> &[CredentialType] {
         &self.credentials
     }

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -94,11 +94,13 @@ pub struct CommitOutput {
 #[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
 impl CommitOutput {
     /// Commit message to send to other group members.
+    #[cfg(feature = "ffi")]
     pub fn commit_message(&self) -> &MlsMessage {
         &self.commit_message
     }
 
     /// Welcome message to send to new group members.
+    #[cfg(feature = "ffi")]
     pub fn welcome_messages(&self) -> &[MlsMessage] {
         &self.welcome_messages
     }
@@ -106,6 +108,7 @@ impl CommitOutput {
     /// Ratchet tree that can be sent out of band if
     /// `ratchet_tree_extension` is not used according to
     /// [`MlsRules::encryption_options`].
+    #[cfg(feature = "ffi")]
     pub fn ratchet_tree(&self) -> Option<&[u8]> {
         self.ratchet_tree.as_deref()
     }
@@ -1239,7 +1242,7 @@ mod tests {
 
         let commit = group.commit(vec![]).await.unwrap();
 
-        assert!(commit.ratchet_tree().is_none());
+        assert!(commit.ratchet_tree.is_none());
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2588,7 +2588,7 @@ mod tests {
                 .roster_update
                 .updated()
                 .iter()
-                .map(|update| update.after_update().clone())
+                .map(|update| update.new.clone())
                 .collect_vec()
                 .as_slice(),
             &alice.group.roster().members()[0..2]
@@ -3891,7 +3891,7 @@ mod tests {
                 .roster_update
                 .updated()
                 .iter()
-                .filter_map(|u| u.before_update().signing_identity().credential.as_basic())
+                .filter_map(|u| u.prior.signing_identity().credential.as_basic())
                 .any(|c| c.identifier() == id.as_bytes())
         };
 
@@ -3903,17 +3903,12 @@ mod tests {
             .iter()
             .filter_map(|u| {
                 let before = u
-                    .before_update()
+                    .prior
                     .signing_identity()
                     .credential
                     .as_basic()?
                     .identifier();
-                let after = u
-                    .after_update()
-                    .signing_identity()
-                    .credential
-                    .as_basic()?
-                    .identifier();
+                let after = u.new.signing_identity().credential.as_basic()?.identifier();
                 Some((before, after))
             })
             .all(|(before, after)| before == after);

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -262,9 +262,9 @@ async fn test_update_proposals(
 
         assert!(commit_output.welcome_messages.is_empty());
 
-        let commit = commit_output.commit_message();
+        let commit = commit_output.commit_message;
 
-        all_process_message(&mut groups, commit, committer_index, true).await;
+        all_process_message(&mut groups, &commit, committer_index, true).await;
 
         groups
             .iter()
@@ -313,9 +313,9 @@ async fn test_remove_proposals(
 
         assert!(commit_output.welcome_messages.is_empty());
 
-        let commit = commit_output.commit_message();
+        let commit = commit_output.commit_message;
         let committer_index = groups[committer].current_member_index() as usize;
-        all_process_message(&mut groups, commit, committer_index, true).await;
+        all_process_message(&mut groups, &commit, committer_index, true).await;
 
         // Check that remove was effective
         for (i, group) in groups.iter().enumerate() {


### PR DESCRIPTION
### Issues:

Resolves #28 

### Description of changes:

Getters that only exist for FFI purposes are now conditionally compiled. Additional fields were made public.

### Call-outs:

This is a breaking change. Making fields public is a double-edged sword. It works better with move semantics (can lead to more efficient code) but it also prevents any internal refactoring of the fields of a struct (e.g. grouping fields in a helper type).

### Testing:

Built.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
