### PR TITLE
Make KeyPackage public

### DIFF
--- a/mls-rs/src/external_client.rs
+++ b/mls-rs/src/external_client.rs
@@ -6,7 +6,7 @@ use crate::{
     cipher_suite::CipherSuite,
     client::MlsError,
     group::framing::MlsMessage,
-    key_package::validate_key_package_properties,
+    key_package::{validate_key_package_properties, KeyPackage},
     protocol_version::ProtocolVersion,
     time::MlsTime,
     tree_kem::leaf_node_validator::{LeafNodeValidator, ValidationContext},
@@ -106,7 +106,7 @@ where
         package: MlsMessage,
         protocol: ProtocolVersion,
         cipher_suite: CipherSuite,
-    ) -> Result<KeyPackageValidationOutput, MlsError> {
+    ) -> Result<KeyPackage, MlsError> {
         let key_package = package
             .into_key_package()
             .ok_or(MlsError::UnexpectedMessageType)?;
@@ -128,15 +128,8 @@ where
 
         validate_key_package_properties(&key_package, protocol, &cs).await?;
 
-        Ok(KeyPackageValidationOutput {
-            expiration_timestamp: key_package.expiration()?,
-        })
+        Ok(key_package)
     }
-}
-
-#[derive(Debug)]
-pub struct KeyPackageValidationOutput {
-    pub expiration_timestamp: u64,
 }
 
 #[cfg(test)]

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -902,7 +902,7 @@ mod tests {
         assert_matches!(
             commit_result,
             ExternalReceivedMessage::Commit(commit_description)
-                if commit_description.state_update.roster_update.added().iter().any(|added| added.index() == 1)
+                if commit_description.state_update.roster_update.added().iter().any(|added| added.index == 1)
         );
 
         #[cfg(not(feature = "state_update"))]

--- a/mls-rs/src/group/framing.rs
+++ b/mls-rs/src/group/framing.rs
@@ -319,7 +319,7 @@ impl MlsMessage {
     }
 
     #[inline(always)]
-    pub(crate) fn into_key_package(self) -> Option<KeyPackage> {
+    pub fn into_key_package(self) -> Option<KeyPackage> {
         match self.payload {
             MlsMessagePayload::KeyPackage(kp) => Some(kp),
             _ => None,

--- a/mls-rs/src/key_package/generator.rs
+++ b/mls-rs/src/key_package/generator.rs
@@ -69,7 +69,7 @@ impl KeyPackageGeneration {
 
     pub fn key_package_message(&self) -> MlsMessage {
         MlsMessage::new(
-            self.key_package.version(),
+            self.key_package.version,
             MlsMessagePayload::KeyPackage(self.key_package.clone()),
         )
     }

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -27,14 +27,18 @@ pub(crate) use generator::*;
 #[non_exhaustive]
 #[derive(Clone, Debug, MlsSize, MlsEncode, MlsDecode, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    all(feature = "ffi", not(test)),
+    safer_ffi_gen::ffi_type(clone, opaque)
+)]
 pub struct KeyPackage {
-    pub(crate) version: ProtocolVersion,
-    pub(crate) cipher_suite: CipherSuite,
-    pub(crate) hpke_init_key: HpkePublicKey,
+    pub version: ProtocolVersion,
+    pub cipher_suite: CipherSuite,
+    pub hpke_init_key: HpkePublicKey,
     pub(crate) leaf_node: LeafNode,
-    pub(crate) extensions: ExtensionList,
+    pub extensions: ExtensionList,
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
-    pub(crate) signature: Vec<u8>,
+    pub signature: Vec<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, MlsSize, MlsEncode, MlsDecode)]
@@ -69,15 +73,23 @@ struct KeyPackageData<'a> {
     pub extensions: &'a ExtensionList,
 }
 
+#[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
 impl KeyPackage {
+    #[cfg(feature = "ffi")]
     pub fn version(&self) -> ProtocolVersion {
         self.version
+    }
+
+    #[cfg(feature = "ffi")]
+    pub fn cipher_suite(&self) -> CipherSuite {
+        self.cipher_suite
     }
 
     pub fn signing_identity(&self) -> &SigningIdentity {
         &self.leaf_node.signing_identity
     }
 
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn to_reference<CP: CipherSuiteProvider>(
         &self,

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -173,15 +173,16 @@ pub mod mls_rules {
     };
 }
 
-pub use crate::group::mls_rules::MlsRules;
-
 pub use mls_rs_core::extension::{Extension, ExtensionList};
 
-pub use crate::client::Client;
-
-pub use group::{
-    framing::{MlsMessage, WireFormat},
-    Group,
+pub use crate::{
+    client::Client,
+    group::{
+        framing::{MlsMessage, WireFormat},
+        mls_rules::MlsRules,
+        Group,
+    },
+    key_package::{KeyPackage, KeyPackageRef},
 };
 
 /// Error types.


### PR DESCRIPTION
### Description of changes:

Make `KeyPackage` public as well as function to extract it from `MlsMessage`.

### Call-outs:

N/A

### Testing:

Built and checked that `KeyPackage` appears in the documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
