### PR TITLE
Fix documentation

### DIFF
--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -146,7 +146,7 @@ where
     }
 
     /// Set group info extensions that will be inserted into the resulting
-    /// [welcome message](CommitOutput::welcome_message) for new members.
+    /// [welcome messages](CommitOutput::welcome_messages) for new members.
     ///
     /// Group info extensions that are transmitted as part of a welcome message
     /// are encrypted along with other private values.

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -171,6 +171,9 @@ pub mod mls_rules {
         },
         proposal_filter::{ProposalBundle, ProposalInfo, ProposalSource},
     };
+
+    #[cfg(feature = "by_ref_proposal")]
+    pub use crate::group::proposal_ref::ProposalRef;
 }
 
 pub use mls_rs_core::extension::{Extension, ExtensionList};


### PR DESCRIPTION
### Description of changes:

A link was incorrect and `ProposalRef`, used in other parts of the public API, was not exported.

### Call-outs:

N/A

### Testing:

Documentation was built.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
