### PR TITLE
Update interop client to the latest version

### DIFF
--- a/.github/workflows/interop_tests.yml
+++ b/.github/workflows/interop_tests.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: mlswg/mls-implementations
-          ref: 3d338d341b1b02c5a2a1a631c60985ce844d2def
+          ref: 7066309c555bfc11fbc74f8288a8563c927637b2
           path: interop
       - uses: arduino/setup-protoc@v2
         with:

--- a/mls-rs/test_harness_integration/proto/mls_client.proto
+++ b/mls-rs/test_harness_integration/proto/mls_client.proto
@@ -57,6 +57,9 @@ service MLSClient {
   rpc CreateExternalSigner(CreateExternalSignerRequest) returns (CreateExternalSignerResponse) {}
   rpc AddExternalSigner(AddExternalSignerRequest) returns (ProposalResponse) {}
   rpc ExternalSignerProposal(ExternalSignerProposalRequest) returns (ProposalResponse) {}
+
+  // Cleanup
+  rpc Free(FreeRequest) returns (FreeResponse) {}
 }
 
 // rpc Name
@@ -251,9 +254,9 @@ message ProposalDescription {
   bytes removed_id = 3; // Required if proposal_type is "remove"
   bytes psk_id = 4; // Required if proposal_type is "externalPSK"
   uint64 epoch_id = 5; // Required if proposal_type is "resumptionPSK"
-  repeated Extension extensions = 6; // Required if proposal_type is "groupContextExtensions"
+  repeated Extension extensions = 6; // Required if proposal_type is "groupContextExtensions" or "reinit"
   bytes group_id = 7; // Required if proposal_type is "reinit"
-  uint32 ciphersuite = 8; // Required if proposal_type is "reinit"
+  uint32 cipher_suite = 8; // Required if proposal_type is "reinit"
 }
 
 // rpc Commit
@@ -400,3 +403,10 @@ message ExternalSignerProposalRequest{
   bytes ratchet_tree = 4;
   ProposalDescription description = 5;
 }
+
+// rpc Free
+message FreeRequest {
+  uint32 state_id = 1;
+}
+
+message FreeResponse {}

--- a/mls-rs/test_harness_integration/src/branch_reinit.rs
+++ b/mls-rs/test_harness_integration/src/branch_reinit.rs
@@ -28,7 +28,7 @@ pub(crate) mod inner {
                 let clients = &mut self.clients.lock().await;
 
                 let group = clients
-                    .get_mut(request.state_id as usize)
+                    .get_mut(&request.state_id)
                     .ok_or_else(|| Status::aborted("no group with such index."))?
                     .group
                     .as_mut()
@@ -56,7 +56,7 @@ pub(crate) mod inner {
             let clients = &mut self.clients.lock().await;
 
             let client = clients
-                .get_mut(request.reinit_id as usize)
+                .get_mut(&request.reinit_id)
                 .ok_or_else(|| Status::aborted("no group with such index."))?;
 
             let group = client
@@ -98,14 +98,14 @@ pub(crate) mod inner {
             // Find the key package generated earlier based on the transaction_id
             let (id, key_package_data) = {
                 let key_package_client = clients
-                    .get(request.transaction_id as usize)
+                    .get(&request.transaction_id)
                     .ok_or_else(|| Status::aborted("no group with such index."))?;
 
                 key_package_client.key_package_repo.key_packages()[0].clone()
             };
 
             let client = clients
-                .get_mut(request.state_id as usize)
+                .get_mut(&request.state_id)
                 .ok_or_else(|| Status::aborted("no group with such index."))?;
 
             // Insert the previously created key package
@@ -142,7 +142,7 @@ pub(crate) mod inner {
             let clients = &mut self.clients.lock().await;
 
             let client = clients
-                .get_mut(client_id as usize)
+                .get_mut(&client_id)
                 .ok_or_else(|| Status::aborted("no group with such index."))?;
 
             let group = client
@@ -210,7 +210,7 @@ pub(crate) mod inner {
             let mut clients = self.clients.lock().await;
 
             let client = clients
-                .get_mut(commit_resp.state_id as usize)
+                .get_mut(&commit_resp.state_id)
                 .ok_or_else(|| Status::aborted("no group with such index."))?;
 
             let group = client


### PR DESCRIPTION
The `free` function was added. Also store clients in a map instead of an array, which makes sense with `free`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
