### PR TITLE
Bump package versions for 0.35

### DIFF
--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-core"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 description = "Core components and traits for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -37,7 +37,7 @@ maybe-async = "0.2.7"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
 serde_json = { version = "^1.0", optional = true }
 hex = { version = "^0.4.3", default-features = false, features = ["serde", "alloc"], optional = true }
-itertools = { version = "0.11", optional = true }
+itertools = { version = "0.12", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-awslc"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 description = "AWS-LC based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -11,18 +11,18 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 aws-lc-rs = "1.5.1"
 aws-lc-sys = { version = "0.12.0" }
-mls-rs-core = { path = "../mls-rs-core", version = "0.14.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.5.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.6.1" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.7.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.15.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.6.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.7.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.8.0" }
 thiserror = "1.0.40"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.7"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.14.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.5.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.15.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.6.0", features = ["test_utils"] }
 futures-test = "0.3.25"
 
 [target.'cfg(mls_build_async)'.dependencies]

--- a/mls-rs-crypto-hpke/Cargo.toml
+++ b/mls-rs-crypto-hpke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-hpke"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "HPKE implementation based on mls-rs-crypto-traits used by mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -15,8 +15,8 @@ std = ["mls-rs-core/std", "mls-rs-crypto-traits/std", "dep:thiserror", "zeroize/
 test_utils = ["mls-rs-core/test_suite"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.14.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.6.1" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.15.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.7.0" }
 thiserror = { version = "1.0.40", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 cfg-if = "^1"
@@ -28,7 +28,7 @@ serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
 mockall = "0.11"
 hex = { version = "^0.4.3", features = ["serde"] }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.6.1" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.7.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.26", default-features = false }

--- a/mls-rs-crypto-openssl/Cargo.toml
+++ b/mls-rs-crypto-openssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-openssl"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 description = "OpenSSL based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -13,11 +13,11 @@ x509 = ["mls-rs-identity-x509"]
 default = ["x509"]
 
 [dependencies]
-openssl = { version = "^0.10.40" }
-mls-rs-core = { path = "../mls-rs-core", version = "0.14.0" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.7.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.5.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.6.1" }
+openssl = { version = "0.10.40" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.15.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.8.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.6.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.7.0" }
 thiserror = "1.0.40"
 enum-iterator = "1.1.2"
 zeroize = { version = "1", features = ["zeroize_derive"] }
@@ -28,8 +28,8 @@ hex = { version = "^0.4.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.14.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.5.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.15.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.6.0", features = ["test_utils"] }
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"

--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-rustcrypto"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 description = "RustCrypto based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -29,9 +29,9 @@ std = [
 ]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.14.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.5.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.6.1" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.15.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.6.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.7.0" }
 
 thiserror = { version = "1.0.40", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
@@ -59,7 +59,7 @@ ed25519-dalek = { version = "2", default-features = false, features = ["alloc", 
 sec1 = { version = "0.7", default-features = false, features = ["alloc"] }
 
 # X509 feature
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.7.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.8.0" }
 x509-cert = { version = "0.2", optional = true, features = ["std"] }
 spki = { version = "0.7", optional = true, features = ["std", "alloc"] }
 sha1 = { version = "0.10", optional = true, features = ["std"] }
@@ -71,8 +71,8 @@ hex = { version = "^0.4.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.14.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.5.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.15.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.6.0", features = ["test_utils"] }
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"

--- a/mls-rs-crypto-traits/Cargo.toml
+++ b/mls-rs-crypto-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-traits"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 description = "Crypto traits required to create a CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -14,7 +14,7 @@ std = ["mls-rs-core/std"]
 default = ["std"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "0.14.0", default-features = false }
+mls-rs-core = { path = "../mls-rs-core", version = "0.15.0", default-features = false }
 mockall = { version = "^0.11", optional = true }
 maybe-async = "0.2.7"
 

--- a/mls-rs-crypto-webcrypto/Cargo.toml
+++ b/mls-rs-crypto-webcrypto/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["std"], version = "0.14.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, features = ["std"], version = "0.5.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, features = ["std"], version = "0.6.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["std"], version = "0.15.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, features = ["std"], version = "0.6.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, features = ["std"], version = "0.7.0" }
 thiserror = "1.0.40"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.7"
@@ -21,7 +21,7 @@ web-sys = { version = "0.3.64", features = ["Window", "CryptoKey", "CryptoKeyPai
 const-oid = { version = "0.9", features = ["db"] }
 
 [dev-dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "*", features = ["test_suite"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.15.0", features = ["test_suite"] }
 wasm-bindgen-test = { version = "0.3.26", default-features = false }
 futures-test = "0.3.25"
 serde_json = "^1.0"

--- a/mls-rs-ffi/Cargo.toml
+++ b/mls-rs-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-ffi"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Helper crate to generate FFI definitions for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -19,9 +19,9 @@ std = ["mls-rs/std", "safer-ffi-gen/std"]
 x509 = ["mls-rs-identity-x509"]
 
 [dependencies]
-mls-rs = { path = "../mls-rs", version = "0.34.0", features = ["ffi"] }
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.5.0", optional = true }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.7.0", optional = true }
-mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.7.0", default-features = false, optional = true }
+mls-rs = { path = "../mls-rs", version = "0.35.0", features = ["ffi"] }
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.6.0", optional = true }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.8.0", optional = true }
+mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.8.0", default-features = false, optional = true }
 safer-ffi = { version = "0.1.3", default-features = false }
 safer-ffi-gen = { version = "0.9.2", default-features = false }

--- a/mls-rs-identity-x509/Cargo.toml
+++ b/mls-rs-identity-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-identity-x509"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "X509 Identity utilities for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -14,7 +14,7 @@ std = ["mls-rs-core/std", "dep:thiserror"]
 
 [dependencies]
 async-trait = "0.1.74"
-mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["x509"], version = "0.14.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["x509"], version = "0.15.0" }
 maybe-async = "0.2.7"
 thiserror = { version = "1.0.40", optional = true }
 

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-provider-sqlite"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "SQLite based state storage for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -9,12 +9,12 @@ keywords = ["mls", "mls-rs"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "0.14.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.15.0" }
 thiserror = "1.0.40"
 uuid = { version = "1.1", features = ["v4"] }
 wasm-bindgen = { version = "0.2", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }
-rusqlite = { version = "0.29", default-features = false }
+rusqlite = { version = "0.30", default-features = false }
 async-trait = "0.1"
 rand = "0.8"
 hex = { version = "0.4" }

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.34.2"
+version = "0.35.0"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -50,13 +50,13 @@ fuzz_util = ["test_util", "default", "dep:once_cell", "dep:mls-rs-crypto-openssl
 
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.14.0" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", default-features = false, version = "0.7.0", optional = true }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.15.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", default-features = false, version = "0.8.0", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 mls-rs-codec = { version = "0.4.0", path = "../mls-rs-codec", default-features = false}
 thiserror = { version = "1.0.40", optional = true }
 futures = { version = "0.3.25", default-features = false, features = ["alloc"]}
-itertools = { version = "0.11.0", default-features = false, features = ["use_alloc"]}
+itertools = { version = "0.12.0", default-features = false, features = ["use_alloc"]}
 enum-iterator = "1.1.3"
 cfg-if = "1"
 async-trait = "0.1.74"
@@ -67,8 +67,8 @@ portable-atomic-util = { version = "0.1.2", default-features = false, features =
 maybe-async = { version = "0.2.7" }
 
 # Optional dependencies
-mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.7.0", default-features = false, optional = true }
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", optional = true, version = "0.5.0" }
+mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.8.0", default-features = false, optional = true }
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", optional = true, version = "0.6.0" }
 # TODO: https://github.com/GoogleChromeLabs/wasm-bindgen-rayon
 rayon = { version = "1", optional = true }
 arbitrary = { version = "1", features = ["derive"], optional = true }
@@ -96,13 +96,13 @@ mls-rs-crypto-webcrypto = { path = "../mls-rs-crypto-webcrypto", version = "0.1.
 criterion = { version = "0.5.1", default-features = false, features = ["plotters", "cargo_bench_support", "async_futures", "html_reports"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.5.0"}
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.6.0"}
 criterion = { version = "0.5.1", features = ["async_futures", "html_reports"] }
 
 # Benchmark crypto engine swaps
 
 [target.'cfg(rustcrypto)'.dependencies]
-mls-rs-crypto-rustcrypto = { path = "../mls-rs-crypto-rustcrypto", version = "0.6.0" }
+mls-rs-crypto-rustcrypto = { path = "../mls-rs-crypto-rustcrypto", version = "0.7.0" }
 
 
 [[example]]

--- a/mls-rs/fuzz/Cargo.toml
+++ b/mls-rs/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-mls-rs = { version = "0.34.0", path = "..", features = ["arbitrary", "fuzz_util"] }
+mls-rs = { version = "0.35.0", path = "..", features = ["arbitrary", "fuzz_util"] }
 futures = "0.3.25"
 libfuzzer-sys = "0.4"
 once_cell = "1.13.0"

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mls-rs = { version = "0.34.0", path = "..", default-features = false, features = ["std", "external_client", "state_update"]}
+mls-rs = { version = "0.35.0", path = "..", default-features = false, features = ["std", "external_client", "state_update"]}
 tonic = "0.7"
 prost = "0.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
@@ -26,10 +26,10 @@ by_ref_proposal = [ "mls-rs/by_ref_proposal" ]
 default = ["tree_index", "private_message", "prior_epoch", "out_of_order", "psk", "custom_proposal", "by_ref_proposal"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features = ["browser"], version = "0.6.0" }
+mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features = ["browser"], version = "0.7.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-mls-rs-crypto-openssl = { path = "../../mls-rs-crypto-openssl", version = "0.5.0"}
+mls-rs-crypto-openssl = { path = "../../mls-rs-crypto-openssl", version = "0.6.0"}
 
 [build-dependencies]
 tonic-build = "0.7"


### PR DESCRIPTION
Bump package versions for 0.35 release. Note that webcrypto was not bumped since this is the first release for that package.