### PR TITLE
Re-export Secret from mls_rs_core

### DIFF
--- a/mls-rs-core/src/secret.rs
+++ b/mls-rs-core/src/secret.rs
@@ -11,6 +11,7 @@ use zeroize::Zeroizing;
     safer_ffi_gen::ffi_type(clone, opaque)
 )]
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Wrapper struct that represents a zeroize-on-drop `Vec<u8>`
 pub struct Secret(Zeroizing<Vec<u8>>);
 
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]

--- a/mls-rs/src/crypto.rs
+++ b/mls-rs/src/crypto.rs
@@ -9,6 +9,8 @@ pub use mls_rs_core::crypto::{
     SignatureSecretKey,
 };
 
+pub use mls_rs_core::secret::Secret;
+
 #[cfg(test)]
 pub(crate) mod test_utils {
     use cfg_if::cfg_if;


### PR DESCRIPTION
This type was only public in mls-rs-core so you would need to take a dependency on that internal crate to get access to it.
