### PR TITLE
Remove outdated identity warning API

### DIFF
--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-core"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Core components and traits for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs-core/src/identity/provider.rs
+++ b/mls-rs-core/src/identity/provider.rs
@@ -2,37 +2,12 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{error::IntoAnyError, extension::ExtensionList, group::RosterUpdate, time::MlsTime};
+use crate::{error::IntoAnyError, extension::ExtensionList, time::MlsTime};
 #[cfg(mls_build_async)]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use super::{CredentialType, SigningIdentity};
-
-#[derive(Debug, Clone, PartialEq)]
-#[non_exhaustive]
-/// Customizable identity warning returned by an [`IdentityProvider`].
-pub struct IdentityWarning {
-    member_index: u32,
-    code: u64,
-}
-
-impl IdentityWarning {
-    /// Create a new identity warning.
-    pub fn new(member_index: u32, code: u64) -> IdentityWarning {
-        IdentityWarning { member_index, code }
-    }
-
-    /// Index in the group roster associated with this warning.
-    pub fn member_index(&self) -> u32 {
-        self.member_index
-    }
-
-    /// Code to indicate the reason for the warning.
-    pub fn code(&self) -> u64 {
-        self.code
-    }
-}
 
 /// Identity system that can be used to validate a
 /// [`SigningIdentity`](mls-rs-core::identity::SigningIdentity)
@@ -87,16 +62,4 @@ pub trait IdentityProvider: Send + Sync {
 
     /// Credential types that are supported by this provider.
     fn supported_types(&self) -> Vec<CredentialType>;
-
-    /// Throw warnings based on changes to a group roster.
-    ///
-    /// For example, if a credential consists of only a public key an
-    /// application may want to issue a warning the key has changed to
-    /// existing members rather than say the new credential is invalid.
-    async fn identity_warnings(
-        &self,
-        update: &RosterUpdate,
-    ) -> Result<Vec<IdentityWarning>, Self::Error>
-    where
-        Self: Sized;
 }

--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-awslc"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "AWS-LC based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -11,18 +11,18 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 aws-lc-rs = "1.5.1"
 aws-lc-sys = { version = "0.12.0" }
-mls-rs-core = { path = "../mls-rs-core", version = "0.15.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.6.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.7.0" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.8.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.16.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.7.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.8.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.9.0" }
 thiserror = "1.0.40"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.7"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.15.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.6.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.16.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.7.0", features = ["test_utils"] }
 futures-test = "0.3.25"
 
 [target.'cfg(mls_build_async)'.dependencies]

--- a/mls-rs-crypto-hpke/Cargo.toml
+++ b/mls-rs-crypto-hpke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-hpke"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "HPKE implementation based on mls-rs-crypto-traits used by mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -15,8 +15,8 @@ std = ["mls-rs-core/std", "mls-rs-crypto-traits/std", "dep:thiserror", "zeroize/
 test_utils = ["mls-rs-core/test_suite"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.15.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.7.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.16.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.8.0" }
 thiserror = { version = "1.0.40", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 cfg-if = "^1"
@@ -28,7 +28,7 @@ serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
 mockall = "0.11"
 hex = { version = "^0.4.3", features = ["serde"] }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.7.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.8.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.26", default-features = false }

--- a/mls-rs-crypto-openssl/Cargo.toml
+++ b/mls-rs-crypto-openssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-openssl"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "OpenSSL based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -14,10 +14,10 @@ default = ["x509"]
 
 [dependencies]
 openssl = { version = "0.10.40" }
-mls-rs-core = { path = "../mls-rs-core", version = "0.15.0" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.8.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.6.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.7.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.16.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.9.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.7.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.8.0" }
 thiserror = "1.0.40"
 enum-iterator = "1.1.2"
 zeroize = { version = "1", features = ["zeroize_derive"] }
@@ -28,8 +28,8 @@ hex = { version = "^0.4.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.15.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.6.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.16.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.7.0", features = ["test_utils"] }
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"

--- a/mls-rs-crypto-openssl/src/x509.rs
+++ b/mls-rs-crypto-openssl/src/x509.rs
@@ -10,9 +10,9 @@ use mls_rs_core::{
     identity::{CertificateChain, SigningIdentity},
 };
 use mls_rs_identity_x509::{
-    CertificateRequestParameters, DerCertificate, DerCertificateRequest, NoOpWarningProvider,
-    SubjectAltName, SubjectComponent, SubjectIdentityExtractor, X509CredentialValidator,
-    X509IdentityProvider, X509RequestWriter,
+    CertificateRequestParameters, DerCertificate, DerCertificateRequest, SubjectAltName,
+    SubjectComponent, SubjectIdentityExtractor, X509CredentialValidator, X509IdentityProvider,
+    X509RequestWriter,
 };
 use openssl::{
     bn::BigNumContext,
@@ -527,10 +527,7 @@ pub fn signing_identity_from_certificate(certificate: &[u8]) -> Result<SigningId
 /// Returns a X509 identity provider from a root CA certificate in DER or PEM format
 pub fn identity_provider_from_certificate(
     certificate: &[u8],
-) -> Result<
-    X509IdentityProvider<SubjectIdentityExtractor<X509Reader>, X509Validator, NoOpWarningProvider>,
-    X509Error,
-> {
+) -> Result<X509IdentityProvider<SubjectIdentityExtractor<X509Reader>, X509Validator>, X509Error> {
     let certificate = if looks_like_der(certificate) {
         X509::from_der(certificate)
     } else {
@@ -541,7 +538,6 @@ pub fn identity_provider_from_certificate(
     Ok(X509IdentityProvider::new(
         SubjectIdentityExtractor::new(0, X509Reader::new()),
         X509Validator::new(vec![certificate.into()])?,
-        NoOpWarningProvider::new(),
     ))
 }
 

--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-rustcrypto"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "RustCrypto based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -29,9 +29,9 @@ std = [
 ]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.15.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.6.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.7.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.16.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.7.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.8.0" }
 
 thiserror = { version = "1.0.40", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
@@ -59,7 +59,7 @@ ed25519-dalek = { version = "2", default-features = false, features = ["alloc", 
 sec1 = { version = "0.7", default-features = false, features = ["alloc"] }
 
 # X509 feature
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.8.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.9.0" }
 x509-cert = { version = "0.2", optional = true, features = ["std"] }
 spki = { version = "0.7", optional = true, features = ["std", "alloc"] }
 sha1 = { version = "0.10", optional = true, features = ["std"] }
@@ -71,8 +71,8 @@ hex = { version = "^0.4.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.15.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.6.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.16.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.7.0", features = ["test_utils"] }
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"

--- a/mls-rs-crypto-traits/Cargo.toml
+++ b/mls-rs-crypto-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-traits"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Crypto traits required to create a CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -14,7 +14,7 @@ std = ["mls-rs-core/std"]
 default = ["std"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "0.15.0", default-features = false }
+mls-rs-core = { path = "../mls-rs-core", version = "0.16.0", default-features = false }
 mockall = { version = "^0.11", optional = true }
 maybe-async = "0.2.7"
 

--- a/mls-rs-crypto-webcrypto/Cargo.toml
+++ b/mls-rs-crypto-webcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-webcrypto"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "SubtleCrypto based CryptoProvider for supporting mls-rs in a browser"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -9,9 +9,9 @@ keywords = ["mls", "mls-rs"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["std"], version = "0.15.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, features = ["std"], version = "0.6.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, features = ["std"], version = "0.7.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["std"], version = "0.16.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, features = ["std"], version = "0.7.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, features = ["std"], version = "0.8.0" }
 thiserror = "1.0.40"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.7"
@@ -26,7 +26,7 @@ web-sys = { version = "0.3.64", features = ["Window", "CryptoKey", "CryptoKeyPai
 const-oid = { version = "0.9", features = ["db"] }
 
 [dev-dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "0.15.0", features = ["test_suite"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.16.0", features = ["test_suite"] }
 wasm-bindgen-test = { version = "0.3.26", default-features = false }
 futures-test = "0.3.25"
 serde_json = "^1.0"

--- a/mls-rs-ffi/Cargo.toml
+++ b/mls-rs-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-ffi"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Helper crate to generate FFI definitions for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -19,9 +19,9 @@ std = ["mls-rs/std", "safer-ffi-gen/std"]
 x509 = ["mls-rs-identity-x509"]
 
 [dependencies]
-mls-rs = { path = "../mls-rs", version = "0.35.0", features = ["ffi"] }
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.6.0", optional = true }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.8.0", optional = true }
-mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.8.0", default-features = false, optional = true }
+mls-rs = { path = "../mls-rs", version = "0.36.0", features = ["ffi"] }
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.7.0", optional = true }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.9.0", optional = true }
+mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.9.0", default-features = false, optional = true }
 safer-ffi = { version = "0.1.3", default-features = false }
 safer-ffi-gen = { version = "0.9.2", default-features = false }

--- a/mls-rs-ffi/src/lib.rs
+++ b/mls-rs-ffi/src/lib.rs
@@ -9,16 +9,10 @@ mod openssl_sqlite {
         x509::{X509Reader, X509Validator},
         OpensslCryptoProvider,
     };
-    use mls_rs_identity_x509::{
-        NoOpWarningProvider, SubjectIdentityExtractor, X509IdentityProvider,
-    };
+    use mls_rs_identity_x509::{SubjectIdentityExtractor, X509IdentityProvider};
 
     pub type OpensslSqlMlsConfig = WithIdentityProvider<
-        X509IdentityProvider<
-            SubjectIdentityExtractor<X509Reader>,
-            X509Validator,
-            NoOpWarningProvider,
-        >,
+        X509IdentityProvider<SubjectIdentityExtractor<X509Reader>, X509Validator>,
         WithCryptoProvider<OpensslCryptoProvider, BaseConfig>,
     >;
 

--- a/mls-rs-identity-x509/Cargo.toml
+++ b/mls-rs-identity-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-identity-x509"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "X509 Identity utilities for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -14,7 +14,7 @@ std = ["mls-rs-core/std", "dep:thiserror"]
 
 [dependencies]
 async-trait = "0.1.74"
-mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["x509"], version = "0.15.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["x509"], version = "0.16.0" }
 maybe-async = "0.2.7"
 thiserror = { version = "1.0.40", optional = true }
 

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-provider-sqlite"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "SQLite based state storage for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -9,7 +9,7 @@ keywords = ["mls", "mls-rs"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "0.15.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.16.0" }
 thiserror = "1.0.40"
 uuid = { version = "1.1", features = ["v4"] }
 wasm-bindgen = { version = "0.2", optional = true }

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -50,8 +50,8 @@ fuzz_util = ["test_util", "default", "dep:once_cell", "dep:mls-rs-crypto-openssl
 
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.15.0" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", default-features = false, version = "0.8.0", optional = true }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.16.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", default-features = false, version = "0.9.0", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 mls-rs-codec = { version = "0.4.0", path = "../mls-rs-codec", default-features = false}
 thiserror = { version = "1.0.40", optional = true }
@@ -67,8 +67,8 @@ portable-atomic-util = { version = "0.1.2", default-features = false, features =
 maybe-async = { version = "0.2.7" }
 
 # Optional dependencies
-mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.8.0", default-features = false, optional = true }
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", optional = true, version = "0.6.0" }
+mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.9.0", default-features = false, optional = true }
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", optional = true, version = "0.7.0" }
 # TODO: https://github.com/GoogleChromeLabs/wasm-bindgen-rayon
 rayon = { version = "1", optional = true }
 arbitrary = { version = "1", features = ["derive"], optional = true }
@@ -92,17 +92,17 @@ rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.26", default-features = false }
-mls-rs-crypto-webcrypto = { path = "../mls-rs-crypto-webcrypto", version = "0.1.0" }
+mls-rs-crypto-webcrypto = { path = "../mls-rs-crypto-webcrypto", version = "0.2.0" }
 criterion = { version = "0.5.1", default-features = false, features = ["plotters", "cargo_bench_support", "async_futures", "html_reports"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.6.0"}
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.7.0"}
 criterion = { version = "0.5.1", features = ["async_futures", "html_reports"] }
 
 # Benchmark crypto engine swaps
 
 [target.'cfg(rustcrypto)'.dependencies]
-mls-rs-crypto-rustcrypto = { path = "../mls-rs-crypto-rustcrypto", version = "0.7.0" }
+mls-rs-crypto-rustcrypto = { path = "../mls-rs-crypto-rustcrypto", version = "0.8.0" }
 
 
 [[example]]

--- a/mls-rs/fuzz/Cargo.toml
+++ b/mls-rs/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-mls-rs = { version = "0.35.0", path = "..", features = ["arbitrary", "fuzz_util"] }
+mls-rs = { version = "0.36.0", path = "..", features = ["arbitrary", "fuzz_util"] }
 futures = "0.3.25"
 libfuzzer-sys = "0.4"
 once_cell = "1.13.0"

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -770,8 +770,7 @@ mod tests {
 
     use mls_rs_core::{
         error::IntoAnyError,
-        group::RosterUpdate,
-        identity::{CredentialType, IdentityProvider, IdentityWarning},
+        identity::{CredentialType, IdentityProvider},
         time::MlsTime,
     };
 
@@ -1414,13 +1413,6 @@ mod tests {
 
         fn supported_types(&self) -> Vec<CredentialType> {
             self.0.supported_types()
-        }
-
-        async fn identity_warnings(
-            &self,
-            _update: &RosterUpdate,
-        ) -> Result<Vec<IdentityWarning>, Self::Error> {
-            Ok(vec![])
         }
     }
 

--- a/mls-rs/src/identity.rs
+++ b/mls-rs/src/identity.rs
@@ -12,7 +12,7 @@ pub mod x509 {
 }
 
 pub use mls_rs_core::identity::{
-    Credential, CredentialType, CustomCredential, IdentityWarning, MlsCredential, SigningIdentity,
+    Credential, CredentialType, CustomCredential, MlsCredential, SigningIdentity,
 };
 
 pub use mls_rs_core::group::RosterUpdate;
@@ -26,10 +26,7 @@ pub(crate) mod test_utils {
         crypto::{CipherSuite, CipherSuiteProvider, SignatureSecretKey},
         error::IntoAnyError,
         extension::ExtensionList,
-        group::RosterUpdate,
-        identity::{
-            Credential, CredentialType, IdentityProvider, IdentityWarning, SigningIdentity,
-        },
+        identity::{Credential, CredentialType, IdentityProvider, SigningIdentity},
         time::MlsTime,
     };
 
@@ -154,13 +151,6 @@ pub(crate) mod test_utils {
 
         fn supported_types(&self) -> Vec<CredentialType> {
             self.supported_cred_types.clone()
-        }
-
-        async fn identity_warnings(
-            &self,
-            _update: &RosterUpdate,
-        ) -> Result<Vec<IdentityWarning>, Self::Error> {
-            Ok(vec![])
         }
     }
 

--- a/mls-rs/src/identity/basic.rs
+++ b/mls-rs/src/identity/basic.rs
@@ -6,12 +6,7 @@ use crate::{identity::CredentialType, identity::SigningIdentity, time::MlsTime};
 use alloc::vec;
 use alloc::vec::Vec;
 pub use mls_rs_core::identity::BasicCredential;
-use mls_rs_core::{
-    error::IntoAnyError,
-    extension::ExtensionList,
-    group::RosterUpdate,
-    identity::{IdentityProvider, IdentityWarning},
-};
+use mls_rs_core::{error::IntoAnyError, extension::ExtensionList, identity::IdentityProvider};
 
 #[derive(Debug)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
@@ -95,12 +90,5 @@ impl IdentityProvider for BasicIdentityProvider {
 
     fn supported_types(&self) -> Vec<CredentialType> {
         vec![BasicCredential::credential_type()]
-    }
-
-    async fn identity_warnings(
-        &self,
-        _update: &RosterUpdate,
-    ) -> Result<Vec<IdentityWarning>, Self::Error> {
-        Ok(vec![])
     }
 }

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -631,8 +631,7 @@ pub(crate) mod test_utils {
     use mls_rs_core::{
         error::IntoAnyError,
         extension::ExtensionList,
-        group::RosterUpdate,
-        identity::{BasicCredential, IdentityProvider, IdentityWarning},
+        identity::{BasicCredential, IdentityProvider},
     };
 
     use crate::{identity::SigningIdentity, time::MlsTime};
@@ -699,14 +698,6 @@ pub(crate) mod test_utils {
         #[cfg_attr(coverage_nightly, coverage(off))]
         fn supported_types(&self) -> Vec<crate::identity::CredentialType> {
             vec![BasicCredential::credential_type()]
-        }
-
-        #[cfg_attr(coverage_nightly, coverage(off))]
-        async fn identity_warnings(
-            &self,
-            _update: &RosterUpdate,
-        ) -> Result<Vec<IdentityWarning>, Self::Error> {
-            Ok(vec![])
         }
     }
 }

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mls-rs = { version = "0.35.0", path = "..", default-features = false, features = ["std", "external_client", "state_update"]}
+mls-rs = { version = "0.36.0", path = "..", default-features = false, features = ["std", "external_client", "state_update"]}
 tonic = "0.7"
 prost = "0.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
@@ -26,10 +26,10 @@ by_ref_proposal = [ "mls-rs/by_ref_proposal" ]
 default = ["tree_index", "private_message", "prior_epoch", "out_of_order", "psk", "custom_proposal", "by_ref_proposal"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features = ["browser"], version = "0.7.0" }
+mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features = ["browser"], version = "0.8.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-mls-rs-crypto-openssl = { path = "../../mls-rs-crypto-openssl", version = "0.6.0"}
+mls-rs-crypto-openssl = { path = "../../mls-rs-crypto-openssl", version = "0.7.0"}
 
 [build-dependencies]
 tonic-build = "0.7"


### PR DESCRIPTION
### Description of changes:

* Remove identity_warnings function from IdentityProvider. It is now possible to calculate this outside the library since we have now added group context extensions to the other IdentityProvider functions.


### Call-outs:

* Bump versions for 0.36 since this is a breaking change.

### Testing:

Standard unit tests apply

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
