### PR TITLE
Update dependencies

### DIFF
--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -21,7 +21,6 @@ x509 = []
 test_suite = ["dep:serde", "dep:serde_json", "dep:hex", "dep:itertools"]
 
 [dependencies]
-async-trait = "0.1.74"
 mls-rs-codec = { version = "0.4.0", path = "../mls-rs-codec", default-features = false}
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 arbitrary = { version = "1", features = ["derive"], optional = true }
@@ -38,6 +37,9 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 serde_json = { version = "^1.0", optional = true }
 hex = { version = "^0.4.3", default-features = false, features = ["serde", "alloc"], optional = true }
 itertools = { version = "0.12", optional = true }
+
+[target.'cfg(mls_build_async)'.dependencies]
+async-trait = "0.1.74"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -15,7 +15,6 @@ uuid = { version = "1.1", features = ["v4"] }
 wasm-bindgen = { version = "0.2", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 rusqlite = { version = "0.30", default-features = false }
-async-trait = "0.1"
 rand = "0.8"
 hex = { version = "0.4" }
 maybe-async = "0.2.7"

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -48,18 +48,15 @@ test_util = []
 benchmark_util = ["test_util", "default", "dep:mls-rs-crypto-openssl"]
 fuzz_util = ["test_util", "default", "dep:once_cell", "dep:mls-rs-crypto-openssl"]
 
-
 [dependencies]
 mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.16.0" }
 mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", default-features = false, version = "0.9.0", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 mls-rs-codec = { version = "0.4.0", path = "../mls-rs-codec", default-features = false}
 thiserror = { version = "1.0.40", optional = true }
-futures = { version = "0.3.25", default-features = false, features = ["alloc"]}
 itertools = { version = "0.12.0", default-features = false, features = ["use_alloc"]}
 enum-iterator = "1.1.3"
 cfg-if = "1"
-async-trait = "0.1.74"
 debug_tree = { version = "0.4.0", optional = true }
 spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin_mutex", "portable_atomic"]}
 portable-atomic = { version = "1.5.1", default-features = false, features = ["critical-section"]}
@@ -76,10 +73,17 @@ safer-ffi = { version = "0.1.3", default-features = false, optional = true }
 safer-ffi-gen = { version = "0.9.2", default-features = false, optional = true }
 once_cell = { version = "1.18", optional = true }
 
+# Async mode dependencies
+[target.'cfg(mls_build_async)'.dependencies]
+futures = { version = "0.3.25", default-features = false, features = ["alloc"]}
+async-trait = "0.1.74"
+
+[target.'cfg(mls_build_async)'.dev-dependencies]
+futures-test = "0.3.25"
+
 [dev-dependencies]
 assert_matches = "1.5.0"
 criterion = { version = "0.5.1", features = ["async_futures", "html_reports"], default-features = false }
-futures-test = "0.3.25"
 serde_json = "^1.0"
 rand = "0.8"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
@@ -98,12 +102,6 @@ criterion = { version = "0.5.1", default-features = false, features = ["plotters
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.7.0"}
 criterion = { version = "0.5.1", features = ["async_futures", "html_reports"] }
-
-# Benchmark crypto engine swaps
-
-[target.'cfg(rustcrypto)'.dependencies]
-mls-rs-crypto-rustcrypto = { path = "../mls-rs-crypto-rustcrypto", version = "0.8.0" }
-
 
 [[example]]
 name = "basic_usage"

--- a/mls-rs/src/test_utils/benchmarks.rs
+++ b/mls-rs/src/test_utils/benchmarks.rs
@@ -9,12 +9,7 @@ use crate::{
     test_utils::{generate_basic_client, get_test_groups},
 };
 
-#[cfg(awslc)]
-pub use mls_rs_crypto_awslc::AwsLcCryptoProvider as MlsCryptoProvider;
-#[cfg(not(any(awslc, rustcrypto)))]
 pub use mls_rs_crypto_openssl::OpensslCryptoProvider as MlsCryptoProvider;
-#[cfg(rustcrypto)]
-pub use mls_rs_crypto_rustcrypto::RustCryptoProvider as MlsCryptoProvider;
 
 pub type TestClientConfig =
     WithIdentityProvider<BasicIdentityProvider, WithCryptoProvider<MlsCryptoProvider, BaseConfig>>;

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 
 [dependencies]
 mls-rs = { version = "0.36.0", path = "..", default-features = false, features = ["std", "external_client", "state_update"]}
-tonic = "0.7"
-prost = "0.10"
+tonic = "0.10.2"
+prost = "0.12.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 thiserror = "1"
 futures = "0.3.25"
 hex = "0.4"
@@ -32,4 +32,4 @@ mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features =
 mls-rs-crypto-openssl = { path = "../../mls-rs-crypto-openssl", version = "0.7.0"}
 
 [build-dependencies]
-tonic-build = "0.7"
+tonic-build = "0.10.2"

--- a/mls-rs/test_harness_integration/src/main.rs
+++ b/mls-rs/test_harness_integration/src/main.rs
@@ -872,7 +872,7 @@ fn find_member(roster: &[Member], cred: &Credential) -> Result<u32, Status> {
 
 #[derive(Parser)]
 struct Opts {
-    #[clap(short, long, value_parser, default_value = "0.0.0.0")]
+    #[clap(long, value_parser, default_value = "0.0.0.0")]
     host: IpAddr,
 
     #[clap(short, long, value_parser, default_value = "50009")]


### PR DESCRIPTION
Make async dependencies conditional. Remove optional dependency on rust-crypto which blows up Cargo.lock and is not used anyway. Update harness dependencies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
