### PR TITLE
Expose more group info

### DIFF
--- a/mls-rs/src/group/context.rs
+++ b/mls-rs/src/group/context.rs
@@ -12,20 +12,25 @@ use super::ConfirmedTranscriptHash;
 
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    all(feature = "ffi", not(test)),
+    safer_ffi_gen::ffi_type(clone, opaque)
+)]
 pub struct GroupContext {
-    pub protocol_version: ProtocolVersion,
-    pub cipher_suite: CipherSuite,
+    pub(crate) protocol_version: ProtocolVersion,
+    pub(crate) cipher_suite: CipherSuite,
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
-    pub group_id: Vec<u8>,
-    pub epoch: u64,
+    pub(crate) group_id: Vec<u8>,
+    pub(crate) epoch: u64,
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
-    pub tree_hash: Vec<u8>,
-    pub confirmed_transcript_hash: ConfirmedTranscriptHash,
-    pub extensions: ExtensionList,
+    pub(crate) tree_hash: Vec<u8>,
+    pub(crate) confirmed_transcript_hash: ConfirmedTranscriptHash,
+    pub(crate) extensions: ExtensionList,
 }
 
+#[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
 impl GroupContext {
-    pub fn new_group(
+    pub(crate) fn new_group(
         protocol_version: ProtocolVersion,
         cipher_suite: CipherSuite,
         group_id: Vec<u8>,
@@ -41,5 +46,29 @@ impl GroupContext {
             confirmed_transcript_hash: ConfirmedTranscriptHash::from(vec![]),
             extensions,
         }
+    }
+
+    /// Get the current protocol version in use by the group.
+    pub fn version(&self) -> ProtocolVersion {
+        self.protocol_version
+    }
+
+    /// Get the current cipher suite in use by the group.
+    pub fn cipher_suite(&self) -> CipherSuite {
+        self.cipher_suite
+    }
+
+    /// Get the unique identifier of this group.
+    pub fn group_id(&self) -> &[u8] {
+        &self.group_id
+    }
+
+    /// Get the current epoch number of the group's state.
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    pub fn extensions(&self) -> &ExtensionList {
+        &self.extensions
     }
 }

--- a/mls-rs/src/group/framing.rs
+++ b/mls-rs/src/group/framing.rs
@@ -311,7 +311,7 @@ impl MlsMessage {
     }
 
     #[inline(always)]
-    pub(crate) fn into_group_info(self) -> Option<GroupInfo> {
+    pub fn into_group_info(self) -> Option<GroupInfo> {
         match self.payload {
             MlsMessagePayload::GroupInfo(info) => Some(info),
             _ => None,

--- a/mls-rs/src/group/group_info.rs
+++ b/mls-rs/src/group/group_info.rs
@@ -10,13 +10,28 @@ use super::*;
 
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub(crate) struct GroupInfo {
-    pub group_context: GroupContext,
-    pub extensions: ExtensionList,
-    pub confirmation_tag: ConfirmationTag,
-    pub signer: LeafIndex,
+#[cfg_attr(
+    all(feature = "ffi", not(test)),
+    safer_ffi_gen::ffi_type(clone, opaque)
+)]
+pub struct GroupInfo {
+    pub(crate) group_context: GroupContext,
+    pub(crate) extensions: ExtensionList,
+    pub(crate) confirmation_tag: ConfirmationTag,
+    pub(crate) signer: LeafIndex,
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
-    pub signature: Vec<u8>,
+    pub(crate) signature: Vec<u8>,
+}
+
+#[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
+impl GroupInfo {
+    pub fn group_context(&self) -> &GroupContext {
+        &self.group_context
+    }
+
+    pub fn extensions(&self) -> &ExtensionList {
+        &self.extensions
+    }
 }
 
 #[derive(MlsEncode, MlsSize)]

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -102,13 +102,11 @@ pub(crate) use group_info::GroupInfo;
 use self::framing::MlsMessage;
 pub use self::framing::Sender;
 pub use commit::*;
-
+pub use context::GroupContext;
 pub use roster::*;
 
 pub(crate) use transcript_hash::ConfirmedTranscriptHash;
 pub(crate) use util::*;
-
-pub(crate) use context::*;
 
 #[cfg(all(feature = "by_ref_proposal", feature = "external_client"))]
 pub use self::message_processor::CachedProposal;
@@ -1406,13 +1404,10 @@ where
         ))
     }
 
+    /// Get the current group context summarizing various information about the group.
     #[inline(always)]
-    pub(crate) fn context(&self) -> &GroupContext {
-        &self.state.context
-    }
-
-    pub fn context_extensions(&self) -> &ExtensionList {
-        &self.state.context.extensions
+    pub fn context(&self) -> &GroupContext {
+        &self.group_state().context
     }
 
     /// Get the
@@ -1503,7 +1498,7 @@ where
     pub(crate) fn encryption_options(&self) -> Result<EncryptionOptions, MlsError> {
         self.config
             .mls_rules()
-            .encryption_options(&self.roster(), self.context_extensions())
+            .encryption_options(&self.roster(), self.group_context().extensions())
             .map_err(|e| MlsError::MlsRulesError(e.into_any_error()))
     }
 

--- a/mls-rs/src/group/resumption.rs
+++ b/mls-rs/src/group/resumption.rs
@@ -54,7 +54,7 @@ where
             group_id: &sub_group_id,
             cipher_suite: self.cipher_suite(),
             version: self.protocol_version(),
-            extensions: self.context_extensions(),
+            extensions: &self.group_state().context.extensions,
         };
 
         resumption_create_group(
@@ -81,7 +81,7 @@ where
             group_id: &[],
             cipher_suite: self.cipher_suite(),
             version: self.protocol_version(),
-            extensions: self.context_extensions(),
+            extensions: &self.group_state().context.extensions,
         };
 
         resumption_join_group(
@@ -291,7 +291,7 @@ async fn resumption_join_group<C: ClientConfig + Clone>(
         Err(MlsError::CipherSuiteMismatch)
     } else if verify_group_id && group.group_id() != expected_new_group_params.group_id {
         Err(MlsError::GroupIdMismatch)
-    } else if group.context_extensions() != expected_new_group_params.extensions {
+    } else if &group.group_state().context.extensions != expected_new_group_params.extensions {
         Err(MlsError::ReInitExtensionsMismatch)
     } else {
         Ok((group, new_member_info))

--- a/mls-rs/test_harness_integration/src/by_ref_proposal.rs
+++ b/mls-rs/test_harness_integration/src/by_ref_proposal.rs
@@ -218,7 +218,7 @@ pub(crate) mod inner {
             let request = request.into_inner();
 
             self.send_proposal(request.state_id, move |group| {
-                let mut extensions = group.context_extensions().clone();
+                let mut extensions = group.context().extensions().clone();
 
                 let ext_sender =
                     SigningIdentity::mls_decode(&mut &*request.external_sender).map_err(abort)?;


### PR DESCRIPTION
### Description of changes:

Make a bunch of information about the group from group info and group public. All grouped in GroupContext now.

### Call-outs:

This is a breaking change but the previously merged PR already increased versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
