### PR TITLE
Introduce `ExportedTree` to represent ratchet tree contents

### DIFF
--- a/mls-rs-codec/Cargo.toml
+++ b/mls-rs-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-codec"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "TLS codec and MLS specific encoding used by mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs-codec/src/cow.rs
+++ b/mls-rs-codec/src/cow.rs
@@ -1,4 +1,7 @@
-use alloc::borrow::Cow;
+use alloc::{
+    borrow::{Cow, ToOwned},
+    vec::Vec,
+};
 
 use crate::{Error, MlsDecode, MlsEncode, MlsSize};
 

--- a/mls-rs-codec/src/cow.rs
+++ b/mls-rs-codec/src/cow.rs
@@ -1,0 +1,31 @@
+use alloc::borrow::Cow;
+
+use crate::{Error, MlsDecode, MlsEncode, MlsSize};
+
+impl<'a, T> MlsSize for Cow<'a, T>
+where
+    T: MlsSize + ToOwned,
+{
+    fn mls_encoded_len(&self) -> usize {
+        self.as_ref().mls_encoded_len()
+    }
+}
+
+impl<'a, T> MlsEncode for Cow<'a, T>
+where
+    T: MlsEncode + ToOwned,
+{
+    #[inline]
+    fn mls_encode(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
+        self.as_ref().mls_encode(writer)
+    }
+}
+
+impl<'a, T> MlsDecode for Cow<'a, T>
+where
+    T: MlsDecode + ToOwned<Owned = T>,
+{
+    fn mls_decode(reader: &mut &[u8]) -> Result<Self, Error> {
+        T::mls_decode(reader).map(Cow::Owned)
+    }
+}

--- a/mls-rs-codec/src/cow.rs
+++ b/mls-rs-codec/src/cow.rs
@@ -26,9 +26,10 @@ where
 
 impl<'a, T> MlsDecode for Cow<'a, T>
 where
-    T: MlsDecode + ToOwned<Owned = T>,
+    T: ToOwned,
+    <T as ToOwned>::Owned: MlsDecode,
 {
     fn mls_decode(reader: &mut &[u8]) -> Result<Self, Error> {
-        T::mls_decode(reader).map(Cow::Owned)
+        MlsDecode::mls_decode(reader).map(Cow::Owned)
     }
 }

--- a/mls-rs-codec/src/lib.rs
+++ b/mls-rs-codec/src/lib.rs
@@ -18,6 +18,7 @@ pub mod byte_vec;
 
 pub mod iter;
 
+mod cow;
 mod map;
 mod option;
 mod stdint;

--- a/mls-rs/examples/basic_server_usage.rs
+++ b/mls-rs/examples/basic_server_usage.rs
@@ -39,10 +39,9 @@ struct BasicServer {
 
 impl BasicServer {
     // Client uploads group data after creating the group
-    fn create_group(group_info: &[u8], tree: &[u8]) -> Result<Self, MlsError> {
+    fn create_group(group_info: &[u8], tree: ExportedTree) -> Result<Self, MlsError> {
         let server = make_server();
         let group_info = MlsMessage::from_bytes(group_info)?;
-        let tree = ExportedTree::from_bytes(tree)?;
 
         let group = server.observe_group(group_info, Some(tree))?;
 
@@ -157,9 +156,9 @@ fn main() -> Result<(), MlsError> {
 
     // Server starts observing Alice's group
     let group_info = alice_group.group_info_message(true)?.to_bytes()?;
-    let tree = alice_group.export_tree()?;
+    let tree = alice_group.export_tree();
 
-    let mut server = BasicServer::create_group(&group_info, &tree)?;
+    let mut server = BasicServer::create_group(&group_info, tree)?;
 
     // Bob uploads a proposal
     let proposal = bob_group

--- a/mls-rs/examples/basic_server_usage.rs
+++ b/mls-rs/examples/basic_server_usage.rs
@@ -42,7 +42,7 @@ impl BasicServer {
     fn create_group(group_info: &[u8], tree: &[u8]) -> Result<Self, MlsError> {
         let server = make_server();
         let group_info = MlsMessage::from_bytes(group_info)?;
-        let tree = ExportedTree::from_bytes(tree).unwrap();
+        let tree = ExportedTree::from_bytes(tree)?;
 
         let group = server.observe_group(group_info, Some(tree))?;
 
@@ -157,7 +157,7 @@ fn main() -> Result<(), MlsError> {
 
     // Server starts observing Alice's group
     let group_info = alice_group.group_info_message(true)?.to_bytes()?;
-    let tree = alice_group.export_tree().to_bytes().unwrap();
+    let tree = alice_group.export_tree()?;
 
     let mut server = BasicServer::create_group(&group_info, &tree)?;
 

--- a/mls-rs/examples/basic_server_usage.rs
+++ b/mls-rs/examples/basic_server_usage.rs
@@ -9,7 +9,7 @@ use mls_rs::{
         builder::MlsConfig as ExternalMlsConfig, ExternalClient, ExternalReceivedMessage,
         ExternalSnapshot,
     },
-    group::{CachedProposal, ReceivedMessage},
+    group::{CachedProposal, ExportedTree, ReceivedMessage},
     identity::{
         basic::{BasicCredential, BasicIdentityProvider},
         SigningIdentity,
@@ -42,6 +42,8 @@ impl BasicServer {
     fn create_group(group_info: &[u8], tree: &[u8]) -> Result<Self, MlsError> {
         let server = make_server();
         let group_info = MlsMessage::from_bytes(group_info)?;
+        let tree = ExportedTree::from_bytes(tree).unwrap();
+
         let group = server.observe_group(group_info, Some(tree))?;
 
         Ok(Self {
@@ -155,7 +157,7 @@ fn main() -> Result<(), MlsError> {
 
     // Server starts observing Alice's group
     let group_info = alice_group.group_info_message(true)?.to_bytes()?;
-    let tree = alice_group.export_tree()?;
+    let tree = alice_group.export_tree().to_bytes().unwrap();
 
     let mut server = BasicServer::create_group(&group_info, &tree)?;
 

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -14,7 +14,7 @@ use crate::group::{
     process_group_info,
     proposal::{AddProposal, Proposal},
 };
-use crate::group::{Group, NewMemberInfo};
+use crate::group::{ExportedTree, Group, NewMemberInfo};
 use crate::identity::SigningIdentity;
 use crate::key_package::{KeyPackageGeneration, KeyPackageGenerator};
 use crate::protocol_version::ProtocolVersion;
@@ -531,7 +531,7 @@ where
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn join_group(
         &self,
-        tree_data: Option<&[u8]>,
+        tree_data: Option<ExportedTree>,
         welcome_message: MlsMessage,
     ) -> Result<(Group<C>, NewMemberInfo), MlsError> {
         Group::join(
@@ -624,7 +624,7 @@ where
     pub async fn external_add_proposal(
         &self,
         group_info: MlsMessage,
-        tree_data: Option<&[u8]>,
+        tree_data: Option<crate::group::ExportedTree>,
         authenticated_data: Vec<u8>,
     ) -> Result<MlsMessage, MlsError> {
         let protocol_version = group_info.version;
@@ -831,7 +831,7 @@ mod tests {
                     .group_info_message_allowing_ext_commit(true)
                     .await
                     .unwrap(),
-                Some(&alice_group.group.export_tree().unwrap()),
+                Some(alice_group.group.export_tree()),
                 vec![],
             )
             .await
@@ -903,7 +903,7 @@ mod tests {
         let mut builder = new_client
             .external_commit_builder()
             .unwrap()
-            .with_tree_data(alice_group.group.export_tree().unwrap());
+            .with_tree_data(alice_group.group.export_tree());
 
         if do_remove {
             builder = builder.with_removal(1);
@@ -1009,7 +1009,7 @@ mod tests {
         let (_, external_commit) = carol
             .external_commit_builder()
             .unwrap()
-            .with_tree_data(bob_group.group.export_tree().unwrap())
+            .with_tree_data(bob_group.group.export_tree())
             .build(group_info_msg)
             .await
             .unwrap();

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -531,7 +531,7 @@ where
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn join_group(
         &self,
-        tree_data: Option<ExportedTree>,
+        tree_data: Option<ExportedTree<'_>>,
         welcome_message: MlsMessage,
     ) -> Result<(Group<C>, NewMemberInfo), MlsError> {
         Group::join(
@@ -624,7 +624,7 @@ where
     pub async fn external_add_proposal(
         &self,
         group_info: MlsMessage,
-        tree_data: Option<crate::group::ExportedTree>,
+        tree_data: Option<crate::group::ExportedTree<'_>>,
         authenticated_data: Vec<u8>,
     ) -> Result<MlsMessage, MlsError> {
         let protocol_version = group_info.version;
@@ -903,7 +903,7 @@ mod tests {
         let mut builder = new_client
             .external_commit_builder()
             .unwrap()
-            .with_tree_data(alice_group.group.export_tree());
+            .with_tree_data(alice_group.group.export_tree().into_owned());
 
         if do_remove {
             builder = builder.with_removal(1);
@@ -1009,7 +1009,7 @@ mod tests {
         let (_, external_commit) = carol
             .external_commit_builder()
             .unwrap()
-            .with_tree_data(bob_group.group.export_tree())
+            .with_tree_data(bob_group.group.export_tree().into_owned())
             .build(group_info_msg)
             .await
             .unwrap();

--- a/mls-rs/src/extension/built_in.rs
+++ b/mls-rs/src/extension/built_in.rs
@@ -15,7 +15,7 @@ use mls_rs_core::{
     time::MlsTime,
 };
 
-use crate::tree_kem::node::NodeVec;
+use crate::group::ExportedTree;
 
 use mls_rs_core::crypto::HpkePublicKey;
 
@@ -64,7 +64,16 @@ impl MlsCodecExtension for ApplicationIdExt {
 )]
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 pub struct RatchetTreeExt {
-    pub(crate) tree_data: NodeVec,
+    pub tree_data: ExportedTree,
+}
+
+#[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
+impl RatchetTreeExt {
+    /// Required custom extension types.
+    #[cfg(feature = "ffi")]
+    pub fn tree_data(&self) -> &ExportedTree {
+        &self.tree_data
+    }
 }
 
 impl MlsCodecExtension for RatchetTreeExt {
@@ -218,6 +227,7 @@ impl MlsCodecExtension for ExternalSendersExt {
 mod tests {
     use super::*;
 
+    use crate::tree_kem::node::NodeVec;
     #[cfg(feature = "by_ref_proposal")]
     use crate::{
         client::test_utils::TEST_CIPHER_SUITE, identity::test_utils::get_test_signing_identity,
@@ -250,7 +260,7 @@ mod tests {
     #[test]
     fn test_ratchet_tree() {
         let ext = RatchetTreeExt {
-            tree_data: NodeVec::from(vec![None, None]),
+            tree_data: ExportedTree::new(NodeVec::from(vec![None, None])),
         };
 
         let as_extension = ext.clone().into_extension().unwrap();

--- a/mls-rs/src/extension/built_in.rs
+++ b/mls-rs/src/extension/built_in.rs
@@ -64,14 +64,14 @@ impl MlsCodecExtension for ApplicationIdExt {
 )]
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 pub struct RatchetTreeExt {
-    pub tree_data: ExportedTree,
+    pub tree_data: ExportedTree<'static>,
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
 impl RatchetTreeExt {
     /// Required custom extension types.
     #[cfg(feature = "ffi")]
-    pub fn tree_data(&self) -> &ExportedTree {
+    pub fn tree_data(&self) -> &ExportedTree<'static> {
         &self.tree_data
     }
 }

--- a/mls-rs/src/external_client.rs
+++ b/mls-rs/src/external_client.rs
@@ -77,7 +77,7 @@ where
     pub async fn observe_group(
         &self,
         group_info: MlsMessage,
-        tree_data: Option<ExportedTree>,
+        tree_data: Option<ExportedTree<'_>>,
     ) -> Result<ExternalGroup<C>, MlsError> {
         ExternalGroup::join(
             self.config.clone(),

--- a/mls-rs/src/external_client.rs
+++ b/mls-rs/src/external_client.rs
@@ -5,7 +5,7 @@
 use crate::{
     cipher_suite::CipherSuite,
     client::MlsError,
-    group::framing::MlsMessage,
+    group::{framing::MlsMessage, ExportedTree},
     key_package::{validate_key_package_properties, KeyPackage},
     protocol_version::ProtocolVersion,
     time::MlsTime,
@@ -77,7 +77,7 @@ where
     pub async fn observe_group(
         &self,
         group_info: MlsMessage,
-        tree_data: Option<&[u8]>,
+        tree_data: Option<ExportedTree>,
     ) -> Result<ExternalGroup<C>, MlsError> {
         ExternalGroup::join(
             self.config.clone(),

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -24,7 +24,7 @@ use crate::{
         snapshot::RawGroupState,
         state::GroupState,
         transcript_hash::InterimTranscriptHash,
-        validate_group_info, GroupContext, Roster,
+        validate_group_info, ExportedTree, GroupContext, Roster,
     },
     identity::SigningIdentity,
     protocol_version::ProtocolVersion,
@@ -103,7 +103,7 @@ impl<C: ExternalClientConfig + Clone> ExternalGroup<C> {
         config: C,
         signing_data: Option<(SignatureSecretKey, SigningIdentity)>,
         group_info: MlsMessage,
-        tree_data: Option<&[u8]>,
+        tree_data: Option<ExportedTree>,
     ) -> Result<Self, MlsError> {
         let protocol_version = group_info.version;
 

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -103,7 +103,7 @@ impl<C: ExternalClientConfig + Clone> ExternalGroup<C> {
         config: C,
         signing_data: Option<(SignatureSecretKey, SigningIdentity)>,
         group_info: MlsMessage,
-        tree_data: Option<ExportedTree>,
+        tree_data: Option<ExportedTree<'_>>,
     ) -> Result<Self, MlsError> {
         let protocol_version = group_info.version;
 

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -476,7 +476,7 @@ impl<C: ExternalClientConfig + Clone> ExternalGroup<C> {
     pub fn export_tree(&self) -> Result<Vec<u8>, MlsError> {
         self.group_state()
             .public_tree
-            .export_node_data()
+            .nodes
             .mls_encode_to_vec()
             .map_err(Into::into)
     }

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -89,7 +89,7 @@ pub struct CommitOutput {
     /// Ratchet tree that can be sent out of band if
     /// `ratchet_tree_extension` is not used according to
     /// [`MlsRules::encryption_options`].
-    pub ratchet_tree: Option<ExportedTree>,
+    pub ratchet_tree: Option<ExportedTree<'static>>,
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
@@ -110,7 +110,7 @@ impl CommitOutput {
     /// `ratchet_tree_extension` is not used according to
     /// [`MlsRules::encryption_options`].
     #[cfg(feature = "ffi")]
-    pub fn ratchet_tree(&self) -> Option<&ExportedTree> {
+    pub fn ratchet_tree(&self) -> Option<&ExportedTree<'static>> {
         self.ratchet_tree.as_ref()
     }
 }
@@ -560,7 +560,7 @@ where
 
         if commit_options.ratchet_tree_extension {
             let ratchet_tree_ext = RatchetTreeExt {
-                tree_data: ExportedTree::new(provisional_state.public_tree.export_node_data()),
+                tree_data: ExportedTree::new(provisional_state.public_tree.nodes.clone()),
             };
 
             extensions.set_from(ratchet_tree_ext)?;
@@ -675,7 +675,7 @@ where
         self.pending_commit = Some(pending_commit);
 
         let ratchet_tree = (!commit_options.ratchet_tree_extension)
-            .then(|| ExportedTree::new(provisional_state.public_tree.export_node_data()));
+            .then_some(ExportedTree::new(provisional_state.public_tree.nodes));
 
         if let Some(signer) = new_signer {
             self.signer = signer;

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -43,7 +43,8 @@ use super::{
     message_signature::AuthenticatedContent,
     mls_rules::CommitDirection,
     proposal::{Proposal, ProposalOrRef},
-    ConfirmedTranscriptHash, EncryptedGroupSecrets, Group, GroupContext, GroupInfo, Welcome,
+    ConfirmedTranscriptHash, EncryptedGroupSecrets, ExportedTree, Group, GroupContext, GroupInfo,
+    Welcome,
 };
 
 #[cfg(not(feature = "by_ref_proposal"))]
@@ -88,7 +89,7 @@ pub struct CommitOutput {
     /// Ratchet tree that can be sent out of band if
     /// `ratchet_tree_extension` is not used according to
     /// [`MlsRules::encryption_options`].
-    pub ratchet_tree: Option<Vec<u8>>,
+    pub ratchet_tree: Option<ExportedTree>,
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
@@ -109,8 +110,8 @@ impl CommitOutput {
     /// `ratchet_tree_extension` is not used according to
     /// [`MlsRules::encryption_options`].
     #[cfg(feature = "ffi")]
-    pub fn ratchet_tree(&self) -> Option<&[u8]> {
-        self.ratchet_tree.as_deref()
+    pub fn ratchet_tree(&self) -> Option<&ExportedTree> {
+        self.ratchet_tree.as_ref()
     }
 }
 
@@ -559,7 +560,7 @@ where
 
         if commit_options.ratchet_tree_extension {
             let ratchet_tree_ext = RatchetTreeExt {
-                tree_data: provisional_state.public_tree.export_node_data(),
+                tree_data: ExportedTree::new(provisional_state.public_tree.export_node_data()),
             };
 
             extensions.set_from(ratchet_tree_ext)?;
@@ -674,13 +675,7 @@ where
         self.pending_commit = Some(pending_commit);
 
         let ratchet_tree = (!commit_options.ratchet_tree_extension)
-            .then(|| {
-                provisional_state
-                    .public_tree
-                    .export_node_data()
-                    .mls_encode_to_vec()
-            })
-            .transpose()?;
+            .then(|| ExportedTree::new(provisional_state.public_tree.export_node_data()));
 
         if let Some(signer) = new_signer {
             self.signer = signer;
@@ -1222,7 +1217,7 @@ mod tests {
 
         group.apply_pending_commit().await.unwrap();
 
-        let new_tree = group.export_tree().unwrap();
+        let new_tree = group.export_tree();
 
         assert_eq!(new_tree, commit.ratchet_tree.unwrap())
     }

--- a/mls-rs/src/group/exported_tree.rs
+++ b/mls-rs/src/group/exported_tree.rs
@@ -1,4 +1,8 @@
-use alloc::vec::Vec;
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright by contributors to this project.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+use alloc::{borrow::Cow, vec::Vec};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
 use crate::{client::MlsError, tree_kem::node::NodeVec};
@@ -8,12 +12,16 @@ use crate::{client::MlsError, tree_kem::node::NodeVec};
     safer_ffi_gen::ffi_type(clone, opaque)
 )]
 #[derive(Debug, MlsSize, MlsEncode, MlsDecode, PartialEq, Clone)]
-pub struct ExportedTree(pub(crate) NodeVec);
+pub struct ExportedTree<'a>(pub(crate) Cow<'a, NodeVec>);
 
 #[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
-impl ExportedTree {
+impl<'a> ExportedTree<'a> {
     pub(crate) fn new(node_data: NodeVec) -> Self {
-        Self(node_data)
+        Self(Cow::Owned(node_data))
+    }
+
+    pub(crate) fn new_borrowed(node_data: &'a NodeVec) -> Self {
+        Self(Cow::Borrowed(node_data))
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, MlsError> {
@@ -23,10 +31,18 @@ impl ExportedTree {
     pub fn to_bytes(&self) -> Result<Vec<u8>, MlsError> {
         self.mls_encode_to_vec().map_err(Into::into)
     }
+
+    pub fn byte_size(&self) -> usize {
+        self.mls_encoded_len()
+    }
+
+    pub fn into_owned(self) -> ExportedTree<'static> {
+        ExportedTree(Cow::Owned(self.0.into_owned()))
+    }
 }
 
-impl From<ExportedTree> for NodeVec {
+impl From<ExportedTree<'_>> for NodeVec {
     fn from(value: ExportedTree) -> Self {
-        value.0
+        value.0.into_owned()
     }
 }

--- a/mls-rs/src/group/exported_tree.rs
+++ b/mls-rs/src/group/exported_tree.rs
@@ -1,0 +1,32 @@
+use alloc::vec::Vec;
+use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
+
+use crate::{client::MlsError, tree_kem::node::NodeVec};
+
+#[cfg_attr(
+    all(feature = "ffi", not(test)),
+    safer_ffi_gen::ffi_type(clone, opaque)
+)]
+#[derive(Debug, MlsSize, MlsEncode, MlsDecode, PartialEq, Clone)]
+pub struct ExportedTree(pub(crate) NodeVec);
+
+#[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
+impl ExportedTree {
+    pub(crate) fn new(node_data: NodeVec) -> Self {
+        Self(node_data)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, MlsError> {
+        Self::mls_decode(&mut &*bytes).map_err(Into::into)
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>, MlsError> {
+        self.mls_encode_to_vec().map_err(Into::into)
+    }
+}
+
+impl From<ExportedTree> for NodeVec {
+    fn from(value: ExportedTree) -> Self {
+        value.0
+    }
+}

--- a/mls-rs/src/group/exported_tree.rs
+++ b/mls-rs/src/group/exported_tree.rs
@@ -24,10 +24,6 @@ impl<'a> ExportedTree<'a> {
         Self(Cow::Borrowed(node_data))
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, MlsError> {
-        Self::mls_decode(&mut &*bytes).map_err(Into::into)
-    }
-
     pub fn to_bytes(&self) -> Result<Vec<u8>, MlsError> {
         self.mls_encode_to_vec().map_err(Into::into)
     }
@@ -38,6 +34,13 @@ impl<'a> ExportedTree<'a> {
 
     pub fn into_owned(self) -> ExportedTree<'static> {
         ExportedTree(Cow::Owned(self.0.into_owned()))
+    }
+}
+
+#[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
+impl ExportedTree<'static> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, MlsError> {
+        Self::mls_decode(&mut &*bytes).map_err(Into::into)
     }
 }
 

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -48,7 +48,7 @@ pub struct ExternalCommitBuilder<C: ClientConfig> {
     signer: SignatureSecretKey,
     signing_identity: SigningIdentity,
     config: C,
-    tree_data: Option<ExportedTree>,
+    tree_data: Option<ExportedTree<'static>>,
     to_remove: Option<u32>,
     #[cfg(feature = "psk")]
     external_psks: Vec<ExternalPskId>,
@@ -84,7 +84,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
     #[must_use]
     /// Use external tree data if the GroupInfo message does not contain a
     /// [`RatchetTreeExt`](crate::extension::built_in::RatchetTreeExt)
-    pub fn with_tree_data(self, tree_data: ExportedTree) -> Self {
+    pub fn with_tree_data(self, tree_data: ExportedTree<'static>) -> Self {
         Self {
             tree_data: Some(tree_data),
             ..self

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -40,13 +40,15 @@ use crate::group::{
     PreSharedKeyProposal, {JustPreSharedKeyID, PreSharedKeyID},
 };
 
+use super::ExportedTree;
+
 /// A builder that aids with the construction of an external commit.
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::ffi_type(opaque))]
 pub struct ExternalCommitBuilder<C: ClientConfig> {
     signer: SignatureSecretKey,
     signing_identity: SigningIdentity,
     config: C,
-    tree_data: Option<Vec<u8>>,
+    tree_data: Option<ExportedTree>,
     to_remove: Option<u32>,
     #[cfg(feature = "psk")]
     external_psks: Vec<ExternalPskId>,
@@ -82,7 +84,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
     #[must_use]
     /// Use external tree data if the GroupInfo message does not contain a
     /// [`RatchetTreeExt`](crate::extension::built_in::RatchetTreeExt)
-    pub fn with_tree_data(self, tree_data: Vec<u8>) -> Self {
+    pub fn with_tree_data(self, tree_data: ExportedTree) -> Self {
         Self {
             tree_data: Some(tree_data),
             ..self
@@ -165,7 +167,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
         let join_context = validate_group_info(
             protocol_version,
             group_info,
-            self.tree_data.as_deref(),
+            self.tree_data,
             &self.config.identity_provider(),
             &cipher_suite,
         )

--- a/mls-rs/src/group/interop_test_vectors/passive_client.rs
+++ b/mls-rs/src/group/interop_test_vectors/passive_client.rs
@@ -625,7 +625,7 @@ pub async fn add_random_members<C: MlsConfig>(
         tc.epochs.push(epoch)
     };
 
-    let tree_data = groups[committer].export_tree();
+    let tree_data = groups[committer].export_tree().into_owned();
 
     for client in &clients {
         let commit = commit_output.welcome_messages[0].clone();

--- a/mls-rs/src/group/interop_test_vectors/tree_modifications.rs
+++ b/mls-rs/src/group/interop_test_vectors/tree_modifications.rs
@@ -119,7 +119,7 @@ async fn tree_modifications_interop() {
 
         let tree_after = apply_proposal(proposal, test_case.proposal_sender, &tree_before).await;
 
-        let tree_after = tree_after.export_node_data().mls_encode_to_vec().unwrap();
+        let tree_after = tree_after.nodes.mls_encode_to_vec().unwrap();
 
         assert_eq!(tree_after, test_case.tree_after);
     }

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1434,8 +1434,8 @@ where
     ///
     /// This function is used to provide the current group tree to new members
     /// when the `ratchet_tree_extension` is not used according to [`MlsRules::commit_options`].
-    pub fn export_tree(&self) -> ExportedTree {
-        ExportedTree::new(self.current_epoch_tree().export_node_data())
+    pub fn export_tree(&self) -> ExportedTree<'_> {
+        ExportedTree::new_borrowed(&self.current_epoch_tree().nodes)
     }
 
     /// Current version of the MLS protocol in use by this group.
@@ -2641,7 +2641,7 @@ mod tests {
         let (bob_group, commit) = bob
             .external_commit_builder()
             .unwrap()
-            .with_tree_data(alice_group.group.export_tree())
+            .with_tree_data(alice_group.group.export_tree().into_owned())
             .build(
                 alice_group
                     .group
@@ -2687,7 +2687,7 @@ mod tests {
         let (_, commit) = bob
             .external_commit_builder()
             .unwrap()
-            .with_tree_data(alice_group.group.export_tree())
+            .with_tree_data(alice_group.group.export_tree().into_owned())
             .build(
                 alice_group
                     .group

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -383,7 +383,7 @@ where
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub(crate) async fn join(
         welcome: MlsMessage,
-        tree_data: Option<ExportedTree>,
+        tree_data: Option<ExportedTree<'_>>,
         config: C,
         signer: SignatureSecretKey,
     ) -> Result<(Self, NewMemberInfo), MlsError> {
@@ -401,7 +401,7 @@ where
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     async fn from_welcome_message(
         welcome: MlsMessage,
-        tree_data: Option<ExportedTree>,
+        tree_data: Option<ExportedTree<'_>>,
         config: C,
         signer: SignatureSecretKey,
         #[cfg(feature = "psk")] additional_psk: Option<PskSecretInput>,

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -162,6 +162,10 @@ pub use secret_tree::MessageKeyData as MessageKey;
 #[cfg(all(test, feature = "rfc_compliant"))]
 mod interop_test_vectors;
 
+mod exported_tree;
+
+pub use exported_tree::ExportedTree;
+
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 struct GroupSecrets {
     joiner_secret: JoinerSecret,
@@ -379,7 +383,7 @@ where
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub(crate) async fn join(
         welcome: MlsMessage,
-        tree_data: Option<&[u8]>,
+        tree_data: Option<ExportedTree>,
         config: C,
         signer: SignatureSecretKey,
     ) -> Result<(Self, NewMemberInfo), MlsError> {
@@ -397,7 +401,7 @@ where
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     async fn from_welcome_message(
         welcome: MlsMessage,
-        tree_data: Option<&[u8]>,
+        tree_data: Option<ExportedTree>,
         config: C,
         signer: SignatureSecretKey,
         #[cfg(feature = "psk")] additional_psk: Option<PskSecretInput>,
@@ -1377,7 +1381,7 @@ where
     ) -> Result<MlsMessage, MlsError> {
         if with_tree_in_extension {
             initial_extensions.set_from(RatchetTreeExt {
-                tree_data: self.state.public_tree.nodes.clone(),
+                tree_data: ExportedTree::new(self.state.public_tree.nodes.clone()),
             })?;
         }
 
@@ -1430,11 +1434,8 @@ where
     ///
     /// This function is used to provide the current group tree to new members
     /// when the `ratchet_tree_extension` is not used according to [`MlsRules::commit_options`].
-    pub fn export_tree(&self) -> Result<Vec<u8>, MlsError> {
-        self.current_epoch_tree()
-            .export_node_data()
-            .mls_encode_to_vec()
-            .map_err(Into::into)
+    pub fn export_tree(&self) -> ExportedTree {
+        ExportedTree::new(self.current_epoch_tree().export_node_data())
     }
 
     /// Current version of the MLS protocol in use by this group.
@@ -2640,7 +2641,7 @@ mod tests {
         let (bob_group, commit) = bob
             .external_commit_builder()
             .unwrap()
-            .with_tree_data(alice_group.group.export_tree().unwrap())
+            .with_tree_data(alice_group.group.export_tree())
             .build(
                 alice_group
                     .group
@@ -2686,7 +2687,7 @@ mod tests {
         let (_, commit) = bob
             .external_commit_builder()
             .unwrap()
-            .with_tree_data(alice_group.group.export_tree().unwrap())
+            .with_tree_data(alice_group.group.export_tree())
             .build(
                 alice_group
                     .group
@@ -2851,7 +2852,7 @@ mod tests {
         // Carol can't join
         let res = carol
             .group
-            .join_subgroup(welcome, Some(&alice_sub_group.export_tree().unwrap()))
+            .join_subgroup(welcome, Some(alice_sub_group.export_tree()))
             .await
             .map(|_| ());
 

--- a/mls-rs/src/group/resumption.rs
+++ b/mls-rs/src/group/resumption.rs
@@ -75,7 +75,7 @@ where
     pub async fn join_subgroup(
         &self,
         welcome: MlsMessage,
-        tree_data: Option<ExportedTree>,
+        tree_data: Option<ExportedTree<'_>>,
     ) -> Result<(Group<C>, NewMemberInfo), MlsError> {
         let expected_new_group_prams = ResumptionGroupParameters {
             group_id: &[],
@@ -205,7 +205,7 @@ impl<C: ClientConfig + Clone> ReinitClient<C> {
     pub async fn join(
         self,
         welcome: MlsMessage,
-        tree_data: Option<ExportedTree>,
+        tree_data: Option<ExportedTree<'_>>,
     ) -> Result<(Group<C>, NewMemberInfo), MlsError> {
         let reinit = self.reinit;
 
@@ -275,7 +275,7 @@ async fn resumption_join_group<C: ClientConfig + Clone>(
     config: C,
     signer: SignatureSecretKey,
     welcome: MlsMessage,
-    tree_data: Option<ExportedTree>,
+    tree_data: Option<ExportedTree<'_>>,
     expected_new_group_params: ResumptionGroupParameters<'_>,
     verify_group_id: bool,
     psk_input: PskSecretInput,

--- a/mls-rs/src/group/resumption.rs
+++ b/mls-rs/src/group/resumption.rs
@@ -14,8 +14,8 @@ use mls_rs_core::{
 use crate::{client::MlsError, Client, Group, MlsMessage};
 
 use super::{
-    proposal::ReInitProposal, ClientConfig, JustPreSharedKeyID, MessageProcessor, NewMemberInfo,
-    PreSharedKeyID, PskGroupId, PskSecretInput, ResumptionPSKUsage, ResumptionPsk,
+    proposal::ReInitProposal, ClientConfig, ExportedTree, JustPreSharedKeyID, MessageProcessor,
+    NewMemberInfo, PreSharedKeyID, PskGroupId, PskSecretInput, ResumptionPSKUsage, ResumptionPsk,
 };
 
 struct ResumptionGroupParameters<'a> {
@@ -75,7 +75,7 @@ where
     pub async fn join_subgroup(
         &self,
         welcome: MlsMessage,
-        tree_data: Option<&[u8]>,
+        tree_data: Option<ExportedTree>,
     ) -> Result<(Group<C>, NewMemberInfo), MlsError> {
         let expected_new_group_prams = ResumptionGroupParameters {
             group_id: &[],
@@ -205,7 +205,7 @@ impl<C: ClientConfig + Clone> ReinitClient<C> {
     pub async fn join(
         self,
         welcome: MlsMessage,
-        tree_data: Option<&[u8]>,
+        tree_data: Option<ExportedTree>,
     ) -> Result<(Group<C>, NewMemberInfo), MlsError> {
         let reinit = self.reinit;
 
@@ -275,7 +275,7 @@ async fn resumption_join_group<C: ClientConfig + Clone>(
     config: C,
     signer: SignatureSecretKey,
     welcome: MlsMessage,
-    tree_data: Option<&[u8]>,
+    tree_data: Option<ExportedTree>,
     expected_new_group_params: ResumptionGroupParameters<'_>,
     verify_group_id: bool,
     psk_input: PskSecretInput,

--- a/mls-rs/src/group/snapshot.rs
+++ b/mls-rs/src/group/snapshot.rs
@@ -77,7 +77,7 @@ impl RawGroupState {
         #[cfg(not(feature = "tree_index"))]
         let public_tree = {
             let mut tree = TreeKemPublic::new();
-            tree.nodes = state.public_tree.export_node_data();
+            tree.nodes = state.public_tree.nodes.clone();
             tree
         };
 

--- a/mls-rs/src/group/state_repo.rs
+++ b/mls-rs/src/group/state_repo.rs
@@ -325,7 +325,10 @@ mod tests {
         assert_eq!(test_repo.pending_commit.updates.len(), 1);
         assert!(test_repo.pending_commit.inserts.is_empty());
 
-        assert_eq!(test_repo.pending_commit.updates.get(0).unwrap(), &to_update);
+        assert_eq!(
+            test_repo.pending_commit.updates.first().unwrap(),
+            &to_update
+        );
 
         // Make sure you can access an epoch pending update
         let psk_id = ResumptionPsk {

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -100,7 +100,7 @@ impl TestGroup {
         // Group from new member's perspective
         let (new_group, _) = Group::join(
             welcome_messages.pop().unwrap(),
-            ratchet_tree.as_deref(),
+            ratchet_tree,
             new_client.config.clone(),
             new_client.signer.clone().unwrap(),
         )

--- a/mls-rs/src/group/util.rs
+++ b/mls-rs/src/group/util.rs
@@ -42,7 +42,7 @@ pub(crate) struct JoinContext {
 pub(crate) async fn process_group_info<C, I>(
     msg_protocol_version: ProtocolVersion,
     group_info: GroupInfo,
-    tree_data: Option<ExportedTree>,
+    tree_data: Option<ExportedTree<'_>>,
     id_provider: &I,
     cs: &C,
 ) -> Result<JoinContext, MlsError>
@@ -104,7 +104,7 @@ where
 pub(crate) async fn validate_group_info<I: IdentityProvider, C: CipherSuiteProvider>(
     msg_protocol_version: ProtocolVersion,
     group_info: GroupInfo,
-    tree_data: Option<ExportedTree>,
+    tree_data: Option<ExportedTree<'_>>,
     identity_provider: &I,
     cipher_suite_provider: &C,
 ) -> Result<JoinContext, MlsError> {

--- a/mls-rs/src/test_utils/mod.rs
+++ b/mls-rs/src/test_utils/mod.rs
@@ -136,7 +136,7 @@ pub async fn get_test_groups<C: CryptoProvider + Clone>(
 
     creator_group.apply_pending_commit().await.unwrap();
 
-    let tree_data = creator_group.export_tree();
+    let tree_data = creator_group.export_tree().into_owned();
 
     let mut groups = vec![creator_group];
 

--- a/mls-rs/src/test_utils/mod.rs
+++ b/mls-rs/src/test_utils/mod.rs
@@ -136,13 +136,13 @@ pub async fn get_test_groups<C: CryptoProvider + Clone>(
 
     creator_group.apply_pending_commit().await.unwrap();
 
-    let tree_data = creator_group.export_tree().unwrap();
+    let tree_data = creator_group.export_tree();
 
     let mut groups = vec![creator_group];
 
     for client in &receiver_clients {
         let (test_client, _info) = client
-            .join_group(Some(&tree_data), welcome[0].clone())
+            .join_group(Some(tree_data.clone()), welcome[0].clone())
             .await
             .unwrap();
 

--- a/mls-rs/src/tree_kem/interop_test_vectors.rs
+++ b/mls-rs/src/tree_kem/interop_test_vectors.rs
@@ -61,7 +61,7 @@ impl ValidationTestCase {
 
         Self {
             cipher_suite: cs.cipher_suite().into(),
-            tree: tree.export_node_data().mls_encode_to_vec().unwrap(),
+            tree: tree.nodes.mls_encode_to_vec().unwrap(),
             tree_hashes: tree
                 .tree_hashes
                 .current

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -159,10 +159,6 @@ impl TreeKemPublic {
         Ok(None)
     }
 
-    pub(crate) fn export_node_data(&self) -> NodeVec {
-        self.nodes.clone()
-    }
-
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn derive<I: IdentityProvider>(
         leaf_node: LeafNode,
@@ -1008,12 +1004,13 @@ mod tests {
             .await
             .unwrap();
 
-        let exported = test_tree.public.export_node_data();
-
-        let imported =
-            TreeKemPublic::import_node_data(exported, &BasicIdentityProvider, &Default::default())
-                .await
-                .unwrap();
+        let imported = TreeKemPublic::import_node_data(
+            test_tree.public.nodes.clone(),
+            &BasicIdentityProvider,
+            &Default::default(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(test_tree.public.nodes, imported.nodes);
 

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -1266,12 +1266,8 @@ mod tests {
         let original_leaf_count = tree.occupied_leaf_count();
 
         // Remove two leaves from the tree
-        let expected_result: Vec<(LeafIndex, LeafNode)> = indexes
-            .clone()
-            .into_iter()
-            .zip(key_packages)
-            .map(|(index, ln)| (index, ln))
-            .collect();
+        let expected_result: Vec<(LeafIndex, LeafNode)> =
+            indexes.clone().into_iter().zip(key_packages).collect();
 
         let res = tree
             .remove_leaves(

--- a/mls-rs/src/tree_kem/private.rs
+++ b/mls-rs/src/tree_kem/private.rs
@@ -213,7 +213,7 @@ mod tests {
         let (public_tree, mut charlie_private, alice_private, path_secret) =
             update_secrets_setup(cipher_suite).await;
 
-        let existing_private = charlie_private.secret_keys.get(0).cloned().unwrap();
+        let existing_private = charlie_private.secret_keys.first().cloned().unwrap();
 
         // Add the secrets for Charlie to his private key
         charlie_private
@@ -295,6 +295,6 @@ mod tests {
         assert!(private_key.secret_keys.iter().skip(1).all(|n| n.is_none()));
 
         // The secret key for our leaf should have been updated accordingly
-        assert_eq!(private_key.secret_keys.get(0).unwrap(), &Some(new_secret));
+        assert_eq!(private_key.secret_keys.first().unwrap(), &Some(new_secret));
     }
 }

--- a/mls-rs/src/tree_kem/tree_hash.rs
+++ b/mls-rs/src/tree_kem/tree_hash.rs
@@ -373,7 +373,7 @@ mod tests {
 
                 test_cases.push(TestCase {
                     cipher_suite: cipher_suite.into(),
-                    tree_data: tree.export_node_data().mls_encode_to_vec().unwrap(),
+                    tree_data: tree.nodes.mls_encode_to_vec().unwrap(),
                     tree_hash: tree
                         .tree_hash(&test_cipher_suite_provider(cipher_suite))
                         .await

--- a/mls-rs/test_harness_integration/src/by_ref_proposal.rs
+++ b/mls-rs/test_harness_integration/src/by_ref_proposal.rs
@@ -261,7 +261,7 @@ pub(crate) mod inner {
 
             let mut server = ext_client
                 .ext_client
-                .observe_group(group_info, get_tree(&request.ratchet_tree))
+                .observe_group(group_info, get_tree(&request.ratchet_tree)?)
                 .map_err(abort)?;
 
             let proposal = request

--- a/mls-rs/test_harness_integration/src/main.rs
+++ b/mls-rs/test_harness_integration/src/main.rs
@@ -846,7 +846,7 @@ async fn create_client(cipher_suite: u16, identity: &[u8]) -> Result<ClientDetai
     })
 }
 
-fn get_tree(tree: &[u8]) -> Result<Option<ExportedTree>, tonic::Status> {
+fn get_tree(tree: &[u8]) -> Result<Option<ExportedTree<'static>>, tonic::Status> {
     if tree.is_empty() {
         Ok(None)
     } else {

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -516,7 +516,7 @@ async fn external_commits_work(
         let (new_group, commit) = client
             .external_commit_builder()
             .unwrap()
-            .with_tree_data(existing_group.export_tree())
+            .with_tree_data(existing_group.export_tree().into_owned())
             .build(group_info)
             .await
             .unwrap();


### PR DESCRIPTION
### Description of changes:

Currently the ratchet tree is exported as a `Vec<u8>` and imported as `Option<&[u8]>`. It is more flexible to make this a wrapper around `NodeVec` so that serialization operations can happen separately.