### PR TITLE
Add tests and fixes for external commit proposal rules

### DIFF
--- a/mls-rs-core/src/extension.rs
+++ b/mls-rs-core/src/extension.rs
@@ -30,6 +30,16 @@ impl ExtensionType {
     pub const EXTERNAL_PUB: ExtensionType = ExtensionType(4);
     pub const EXTERNAL_SENDERS: ExtensionType = ExtensionType(5);
 
+    /// Default extension types defined
+    /// in [RFC 9420](https://www.rfc-editor.org/rfc/rfc9420.html#name-leaf-node-contents)
+    pub const DEFAULT: &'static [ExtensionType] = &[
+        ExtensionType::APPLICATION_ID,
+        ExtensionType::RATCHET_TREE,
+        ExtensionType::REQUIRED_CAPABILITIES,
+        ExtensionType::EXTERNAL_PUB,
+        ExtensionType::EXTERNAL_SENDERS,
+    ];
+
     /// Extension type from a raw value
     pub const fn new(raw_value: u16) -> Self {
         ExtensionType(raw_value)

--- a/mls-rs-core/src/group/proposal_type.rs
+++ b/mls-rs-core/src/group/proposal_type.rs
@@ -55,4 +55,16 @@ impl ProposalType {
     pub const RE_INIT: ProposalType = ProposalType(5);
     pub const EXTERNAL_INIT: ProposalType = ProposalType(6);
     pub const GROUP_CONTEXT_EXTENSIONS: ProposalType = ProposalType(7);
+
+    /// Default proposal types defined
+    /// in [RFC 9420](https://www.rfc-editor.org/rfc/rfc9420.html#name-leaf-node-contents)
+    pub const DEFAULT: &'static [ProposalType] = &[
+        ProposalType::ADD,
+        ProposalType::UPDATE,
+        ProposalType::REMOVE,
+        ProposalType::PSK,
+        ProposalType::RE_INIT,
+        ProposalType::EXTERNAL_INIT,
+        ProposalType::GROUP_CONTEXT_EXTENSIONS,
+    ];
 }

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -713,6 +713,7 @@ pub(crate) mod test_utils {
 
     pub const TEST_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::MLS_10;
     pub const TEST_CIPHER_SUITE: CipherSuite = CipherSuite::P256_AES128;
+    pub const TEST_CUSTOM_PROPOSAL_TYPE: ProposalType = ProposalType::new(65001);
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn test_client_with_key_pkg(

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -124,7 +124,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
         self
     }
 
-    #[cfg(feature = "custom_proposal")]
+    #[cfg(all(feature = "custom_proposal", feature = "by_ref_proposal"))]
     #[must_use]
     /// Insert a [`CustomProposal`] received from a current group member into the current
     /// commit that is being built.
@@ -135,7 +135,6 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
     /// same way as by [`ExternalGroup`](`crate::external_client::ExternalGroup`).
     /// The proposal MUST be an MlsPlaintext, else the [`Self::build`] function will fail.
     pub fn with_received_custom_proposal(mut self, proposal: MlsMessage) -> Self {
-        //use super::message_verifier::verify_plaintext_authentication;
 
         self.received_custom_proposals.push(proposal);
         self

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -135,7 +135,6 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
     /// same way as by [`ExternalGroup`](`crate::external_client::ExternalGroup`).
     /// The proposal MUST be an MlsPlaintext, else the [`Self::build`] function will fail.
     pub fn with_received_custom_proposal(mut self, proposal: MlsMessage) -> Self {
-
         self.received_custom_proposals.push(proposal);
         self
     }

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -20,18 +20,24 @@ use crate::{
 #[cfg(any(feature = "secret_tree_access", feature = "private_message"))]
 use crate::group::secret_tree::SecretTree;
 
+#[cfg(feature = "custom_proposal")]
+use crate::group::{
+    framing::MlsMessagePayload,
+    message_processor::{EventOrContent, MessageProcessor},
+    message_signature::AuthenticatedContent,
+    message_verifier::verify_plaintext_authentication,
+    CustomProposal,
+};
+
 use alloc::vec;
 use alloc::vec::Vec;
 
 #[cfg(feature = "psk")]
-use mls_rs_core::{
-    error::IntoAnyError,
-    psk::{ExternalPskId, PreSharedKey},
-};
+use mls_rs_core::psk::{ExternalPskId, PreSharedKey};
 
 #[cfg(feature = "psk")]
 use crate::group::{
-    PreSharedKeyProposal, {JustPreSharedKeyID, PreSharedKeyID, PskNonce},
+    PreSharedKeyProposal, {JustPreSharedKeyID, PreSharedKeyID},
 };
 
 /// A builder that aids with the construction of an external commit.
@@ -45,6 +51,10 @@ pub struct ExternalCommitBuilder<C: ClientConfig> {
     #[cfg(feature = "psk")]
     external_psks: Vec<ExternalPskId>,
     authenticated_data: Vec<u8>,
+    #[cfg(feature = "custom_proposal")]
+    custom_proposals: Vec<Proposal>,
+    #[cfg(feature = "custom_proposal")]
+    received_custom_proposals: Vec<MlsMessage>,
 }
 
 impl<C: ClientConfig> ExternalCommitBuilder<C> {
@@ -62,6 +72,10 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             config,
             #[cfg(feature = "psk")]
             external_psks: Vec::new(),
+            #[cfg(feature = "custom_proposal")]
+            custom_proposals: Vec::new(),
+            #[cfg(feature = "custom_proposal")]
+            received_custom_proposals: Vec::new(),
         }
     }
 
@@ -102,6 +116,31 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
         self
     }
 
+    #[cfg(feature = "custom_proposal")]
+    #[must_use]
+    /// Insert a [`CustomProposal`] into the current commit that is being built.
+    pub fn with_custom_proposal(mut self, proposal: CustomProposal) -> Self {
+        self.custom_proposals.push(Proposal::Custom(proposal));
+        self
+    }
+
+    #[cfg(feature = "custom_proposal")]
+    #[must_use]
+    /// Insert a [`CustomProposal`] received from a current group member into the current
+    /// commit that is being built.
+    ///
+    /// # Warning
+    ///
+    /// The authenticity of the proposal is NOT fully verified. It is only verified the
+    /// same way as by [`ExternalGroup`](`crate::external_client::ExternalGroup`).
+    /// The proposal MUST be an MlsPlaintext, else the [`Self::build`] function will fail.
+    pub fn with_received_custom_proposal(mut self, proposal: MlsMessage) -> Self {
+        //use super::message_verifier::verify_plaintext_authentication;
+
+        self.received_custom_proposals.push(proposal);
+        self
+    }
+
     /// Build the external commit using a GroupInfo message provided by an existing group member.
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn build(self, group_info: MlsMessage) -> Result<(Group<C>, MlsMessage), MlsError> {
@@ -115,7 +154,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             .into_group_info()
             .ok_or(MlsError::UnexpectedMessageType)?;
 
-        let cipher_suite_provider = cipher_suite_provider(
+        let cipher_suite = cipher_suite_provider(
             self.config.crypto_provider(),
             group_info.group_context.cipher_suite,
         )?;
@@ -130,12 +169,12 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             group_info,
             self.tree_data.as_deref(),
             &self.config.identity_provider(),
-            &cipher_suite_provider,
+            &cipher_suite,
         )
         .await?;
 
         let (leaf_node, _) = LeafNode::generate(
-            &cipher_suite_provider,
+            &cipher_suite,
             self.config.leaf_properties(),
             self.signing_identity,
             &self.signer,
@@ -144,8 +183,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
         .await?;
 
         let (init_secret, kem_output) =
-            InitSecret::encode_for_external(&cipher_suite_provider, &external_pub_ext.external_pub)
-                .await?;
+            InitSecret::encode_for_external(&cipher_suite, &external_pub_ext.external_pub).await?;
 
         let epoch_secrets = EpochSecrets {
             #[cfg(feature = "psk")]
@@ -157,7 +195,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
 
         let (mut group, _) = Group::join_with(
             self.config,
-            cipher_suite_provider.clone(),
+            cipher_suite.clone(),
             join_context,
             KeySchedule::new(init_secret),
             epoch_secrets,
@@ -171,33 +209,45 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
         let psk_ids = self
             .external_psks
             .into_iter()
-            .map(|psk_id| {
-                Ok(PreSharedKeyID {
-                    key_id: JustPreSharedKeyID::External(psk_id),
-                    psk_nonce: PskNonce::random(&cipher_suite_provider)
-                        .map_err(|e| MlsError::CryptoProviderError(e.into_any_error()))?,
-                })
-            })
+            .map(|psk_id| PreSharedKeyID::new(JustPreSharedKeyID::External(psk_id), &cipher_suite))
             .collect::<Result<Vec<_>, MlsError>>()?;
 
-        let external_init = Proposal::ExternalInit(ExternalInit { kem_output });
+        let mut proposals = vec![Proposal::ExternalInit(ExternalInit { kem_output })];
 
         #[cfg(feature = "psk")]
-        let proposals = psk_ids
-            .into_iter()
-            .map(|psk| Proposal::Psk(PreSharedKeyProposal { psk }))
-            .chain([external_init]);
+        proposals.extend(
+            psk_ids
+                .into_iter()
+                .map(|psk| Proposal::Psk(PreSharedKeyProposal { psk })),
+        );
 
-        #[cfg(not(feature = "psk"))]
-        let proposals = [external_init].into_iter();
+        #[cfg(feature = "custom_proposal")]
+        {
+            let mut custom_proposals = self.custom_proposals;
+            proposals.append(&mut custom_proposals);
+        }
 
-        let proposals = proposals
-            .chain(self.to_remove.map(|r| {
-                Proposal::Remove(RemoveProposal {
-                    to_remove: LeafIndex(r),
-                })
-            }))
-            .collect::<Vec<_>>();
+        #[cfg(all(feature = "custom_proposal", feature = "by_ref_proposal"))]
+        for message in self.received_custom_proposals {
+            let MlsMessagePayload::Plain(plaintext) = message.payload else {
+                return Err(MlsError::UnexpectedMessageType);
+            };
+
+            let auth_content = AuthenticatedContent::from(plaintext.clone());
+
+            verify_plaintext_authentication(&cipher_suite, plaintext, None, None, &group.state)
+                .await?;
+
+            group
+                .process_event_or_content(EventOrContent::Content(auth_content), true, None)
+                .await?;
+        }
+
+        if let Some(r) = self.to_remove {
+            proposals.push(Proposal::Remove(RemoveProposal {
+                to_remove: LeafIndex(r),
+            }));
+        }
 
         let commit_output = group
             .commit_internal(

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -623,6 +623,9 @@ mod tests {
         tree_kem::leaf_node_validator::test_utils::FailureIdentityProvider,
     };
 
+    #[cfg(feature = "psk")]
+    use crate::psk::PskNonce;
+
     use assert_matches::assert_matches;
     use core::convert::Infallible;
     use itertools::Itertools;
@@ -1222,7 +1225,7 @@ mod tests {
 
         let proposal = Proposal::Psk(make_external_psk(
             b"ted",
-            PskNonce::random(&test_cipher_suite_provider(TEST_CIPHER_SUITE)).unwrap(),
+            crate::psk::PskNonce::random(&test_cipher_suite_provider(TEST_CIPHER_SUITE)).unwrap(),
         ));
 
         let res = cache
@@ -1753,11 +1756,11 @@ mod tests {
         let cache = make_proposal_cache();
 
         let psk = Proposal::Psk(PreSharedKeyProposal {
-            psk: PreSharedKeyID {
-                key_id: JustPreSharedKeyID::External(ExternalPskId::new(vec![])),
-                psk_nonce: PskNonce::random(&test_cipher_suite_provider(TEST_CIPHER_SUITE))
-                    .unwrap(),
-            },
+            psk: PreSharedKeyID::new(
+                JustPreSharedKeyID::External(ExternalPskId::new(vec![])),
+                &test_cipher_suite_provider(TEST_CIPHER_SUITE),
+            )
+            .unwrap(),
         });
 
         let add = Proposal::Add(Box::new(AddProposal {


### PR DESCRIPTION
This makes sure that external joiners can commit custom proposals with custom rules.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
