### PR TITLE
Commit option for generating an external commit group info

### DIFF
--- a/mls-rs/src/group/key_schedule.rs
+++ b/mls-rs/src/group/key_schedule.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use crate::client::MlsError;
+use crate::extension::ExternalPubExt;
 use crate::group::{GroupContext, MembershipTag};
 use crate::psk::secret::PskSecret;
 #[cfg(feature = "psk")]
@@ -238,6 +239,16 @@ impl KeySchedule {
             .kem_derive(&self.external_secret)
             .await
             .map_err(|e| MlsError::CryptoProviderError(e.into_any_error()))
+    }
+
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub async fn get_external_key_pair_ext<P: CipherSuiteProvider>(
+        &self,
+        cipher_suite: &P,
+    ) -> Result<ExternalPubExt, MlsError> {
+        let (_external_secret, external_pub) = self.get_external_key_pair(cipher_suite).await?;
+
+        Ok(ExternalPubExt { external_pub })
     }
 }
 

--- a/mls-rs/src/group/mls_rules.rs
+++ b/mls-rs/src/group/mls_rules.rs
@@ -37,6 +37,7 @@ pub struct CommitOptions {
     pub path_required: bool,
     pub ratchet_tree_extension: bool,
     pub single_welcome_message: bool,
+    pub allow_external_commit: bool,
 }
 
 impl Default for CommitOptions {
@@ -45,6 +46,7 @@ impl Default for CommitOptions {
             path_required: false,
             ratchet_tree_extension: true,
             single_welcome_message: true,
+            allow_external_commit: false,
         }
     }
 }
@@ -71,6 +73,13 @@ impl CommitOptions {
     pub fn with_single_welcome_message(self, single_welcome_message: bool) -> Self {
         Self {
             single_welcome_message,
+            ..self
+        }
+    }
+
+    pub fn with_allow_external_commit(self, allow_external_commit: bool) -> Self {
+        Self {
+            allow_external_commit,
             ..self
         }
     }

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2404,7 +2404,7 @@ mod tests {
         )
         .await;
 
-        let commit_output = group.group.commit(vec![]).unwrap();
+        let commit_output = group.group.commit(vec![]).await.unwrap();
 
         let (test_client, _) =
             test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "bob").await;

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -83,6 +83,7 @@ impl TestGroup {
             mut welcome_messages,
             ratchet_tree,
             commit_message,
+            ..
         } = self
             .group
             .commit_builder()


### PR DESCRIPTION
### Description of changes:

* Add `allow_external_commit` to `CommitOptions`
* Add `external_commit_group_info` to `CommitOutput` that will be set if allow_external_commit is true during commit processing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
