### PR TITLE
Remove unused dependencies

### DIFF
--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["test_data"]
 default = ["std", "rfc_compliant", "fast_serialize"]
 arbitrary = ["std", "dep:arbitrary"]
 fast_serialize = ["mls-rs-codec/preallocate"]
-std = ["mls-rs-codec/std", "zeroize/std", "base64/std", "num_enum/std", "indexmap/std", "safer-ffi-gen?/std", "dep:thiserror", "indexmap"]
+std = ["mls-rs-codec/std", "zeroize/std", "safer-ffi-gen?/std", "dep:thiserror"]
 rfc_compliant = ["x509"]
 ffi = ["dep:safer-ffi", "dep:safer-ffi-gen"]
 x509 = []
@@ -24,11 +24,7 @@ test_suite = ["dep:serde", "dep:serde_json", "dep:hex", "dep:itertools"]
 mls-rs-codec = { version = "0.5.0", path = "../mls-rs-codec", default-features = false}
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 arbitrary = { version = "1", features = ["derive"], optional = true }
-base64 = { version = "0.21.0", default-features = false, features = ["alloc"]}
 thiserror = { version = "1.0.40", optional = true }
-enum-iterator = "1.1.3"
-num_enum = { version = "0.7", default-features = false}
-indexmap = { version = "2.0", optional = true }
 safer-ffi = { version = "0.1.3", default-features = false, optional = true }
 safer-ffi-gen = { version = "0.9.2", default-features = false, optional = true }
 maybe-async = "0.2.7"

--- a/mls-rs-core/src/lib.rs
+++ b/mls-rs-core/src/lib.rs
@@ -20,7 +20,6 @@ pub mod psk;
 pub mod secret;
 pub mod time;
 
-pub use enum_iterator;
 pub use mls_rs_codec;
 
 #[cfg(feature = "arbitrary")]

--- a/mls-rs-crypto-openssl/Cargo.toml
+++ b/mls-rs-crypto-openssl/Cargo.toml
@@ -19,7 +19,6 @@ mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, vers
 mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.8.0" }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.9.0" }
 thiserror = "1.0.40"
-enum-iterator = "1.1.2"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.7"
 

--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["mls", "mls-rs"]
 license = "Apache-2.0 OR MIT"
 
 [features]
-x509 = ["std", "mls-rs-identity-x509", "x509-cert", "spki", "sha1", "const-oid", "mls-rs-core/x509"]
+x509 = ["std", "mls-rs-identity-x509", "x509-cert", "spki", "const-oid", "mls-rs-core/x509"]
 default = ["std", "x509"]
 browser = ["getrandom/js"]
 
@@ -35,7 +35,6 @@ mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = fa
 
 thiserror = { version = "1.0.40", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
-enum-iterator = "1.1.2"
 
 # Random
 getrandom = { version = "0.2", default-features = false, features = ["custom"] }
@@ -62,7 +61,6 @@ sec1 = { version = "0.7", default-features = false, features = ["alloc"] }
 mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.10.0" }
 x509-cert = { version = "0.2", optional = true, features = ["std"] }
 spki = { version = "0.7", optional = true, features = ["std", "alloc"] }
-sha1 = { version = "0.10", optional = true, features = ["std"] }
 const-oid = { version = "0.9", optional = true, features = ["std"] }
 maybe-async = "0.2.7"
 

--- a/mls-rs-identity-x509/Cargo.toml
+++ b/mls-rs-identity-x509/Cargo.toml
@@ -13,10 +13,13 @@ default = ["std"]
 std = ["mls-rs-core/std", "dep:thiserror"]
 
 [dependencies]
-async-trait = "0.1.74"
 mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["x509"], version = "0.17.0" }
 maybe-async = "0.2.7"
 thiserror = { version = "1.0.40", optional = true }
+
+# Async mode dependencies
+[target.'cfg(mls_build_async)'.dependencies]
+async-trait = "0.1.74"
 
 [dev-dependencies]
 mockall = "0.11"

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 mls-rs-core = { path = "../mls-rs-core", version = "0.17.0" }
 thiserror = "1.0.40"
-uuid = { version = "1.1", features = ["v4"] }
 wasm-bindgen = { version = "0.2", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 rusqlite = { version = "0.30", default-features = false }

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -55,12 +55,11 @@ zeroize = { version = "1", default-features = false, features = ["alloc", "zeroi
 mls-rs-codec = { version = "0.5.0", path = "../mls-rs-codec", default-features = false}
 thiserror = { version = "1.0.40", optional = true }
 itertools = { version = "0.12.0", default-features = false, features = ["use_alloc"]}
-enum-iterator = "1.1.3"
 cfg-if = "1"
 debug_tree = { version = "0.4.0", optional = true }
-spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin_mutex", "portable_atomic"]}
-portable-atomic = { version = "1.5.1", default-features = false, features = ["critical-section"]}
-portable-atomic-util = { version = "0.1.2", default-features = false, features = ["alloc"]}
+spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin_mutex", "portable_atomic"] }
+portable-atomic = { version = "1.5.1", default-features = false, features = ["critical-section"] }
+portable-atomic-util = { version = "0.1.2", default-features = false, features = ["alloc"] }
 maybe-async = { version = "0.2.7" }
 
 # Optional dependencies

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -12,7 +12,6 @@ prost = "0.12.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 clap = { version = "4", features = ["derive"] }
 thiserror = "1"
-futures = "0.3.25"
 hex = "0.4"
 
 [features]


### PR DESCRIPTION
Hi,

I hope you'll like this small PR to remove some unused dependencies. I focused on mls-rs and its dependencies.

### Description of changes

This removes the unused enum-iterator, base64, num_enum, indexmap, and sha1 dependencies. The enum-iterator was mentioned in the code (but not used), the others were not mentioned at all outside of the Cargo.toml files.

This commit also makes spin, portable-atomic, and portable-atomic-util optional since they’re already used that way in the code.

Using

    cargo tree -p mls-rs -e normal --prefix none | sort -u | wc -l

to count unique transitive dependencies of mls-rs, this reduces the number from 60 to just 44.

### Testing

I made sure the code compiles and passes tests before and after:

```
% cargo check --all-targets
% cargo check --all-targets --all-features
% cargo test
% cargo test --all-features
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
