### PR TITLE
Expose content type of encrypted messages to external group

### DIFF
--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -24,7 +24,7 @@ use crate::{
         snapshot::RawGroupState,
         state::GroupState,
         transcript_hash::InterimTranscriptHash,
-        validate_group_info, ExportedTree, GroupContext, Roster,
+        validate_group_info, ContentType, ExportedTree, GroupContext, Roster,
     },
     identity::SigningIdentity,
     protocol_version::ProtocolVersion,
@@ -81,7 +81,7 @@ pub enum ExternalReceivedMessage {
     /// Received proposal and its unique identifier.
     Proposal(ProposalMessageDescription),
     /// Encrypted message that can not be processed.
-    Ciphertext,
+    Ciphertext(ContentType),
 }
 
 /// A handle to an observed group that can track plaintext control messages
@@ -584,9 +584,11 @@ where
     #[cfg(feature = "private_message")]
     async fn process_ciphertext(
         &mut self,
-        _cipher_text: PrivateMessage,
+        cipher_text: PrivateMessage,
     ) -> Result<EventOrContent<Self::OutputType>, MlsError> {
-        Ok(EventOrContent::Event(ExternalReceivedMessage::Ciphertext))
+        Ok(EventOrContent::Event(ExternalReceivedMessage::Ciphertext(
+            cipher_text.content_type,
+        )))
     }
 
     async fn update_key_schedule(

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -100,7 +100,7 @@ use self::state_repo::GroupStateRepository;
 pub(crate) use group_info::GroupInfo;
 
 use self::framing::MlsMessage;
-pub use self::framing::Sender;
+pub use self::framing::{ContentType, Sender};
 pub use commit::*;
 pub use context::GroupContext;
 pub use roster::*;


### PR DESCRIPTION
### Description of changes:

This exposes the content type of an encrypted message processed by an external group.

### Call-outs:

N/A

### Testing:

CI passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
