### PR TITLE
Depend on portable-atomic-* only if the target has no OS

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -57,9 +57,7 @@ thiserror = { version = "1.0.40", optional = true }
 itertools = { version = "0.12.0", default-features = false, features = ["use_alloc"]}
 cfg-if = "1"
 debug_tree = { version = "0.4.0", optional = true }
-spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin_mutex", "portable_atomic"] }
-portable-atomic = { version = "1.5.1", default-features = false, features = ["critical-section"] }
-portable-atomic-util = { version = "0.1.2", default-features = false, features = ["alloc"] }
+spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin_mutex"] }
 maybe-async = { version = "0.2.7" }
 
 # Optional dependencies
@@ -76,6 +74,11 @@ once_cell = { version = "1.18", optional = true }
 [target.'cfg(mls_build_async)'.dependencies]
 futures = { version = "0.3.25", default-features = false, features = ["alloc"]}
 async-trait = "0.1.74"
+
+[target.'cfg(target_os = "none")'.dependencies]
+portable-atomic = { version = "1.5.1", default-features = false, features = ["critical-section"] }
+portable-atomic-util = { version = "0.1.2", default-features = false, features = ["alloc"] }
+spin = { version = "0.9.8", default-features = false, features = ["portable_atomic"] }
 
 [target.'cfg(mls_build_async)'.dev-dependencies]
 futures-test = "0.3.25"

--- a/mls-rs/src/storage_provider/in_memory/group_state_storage.rs
+++ b/mls-rs/src/storage_provider/in_memory/group_state_storage.rs
@@ -4,7 +4,7 @@
 
 use alloc::collections::VecDeque;
 
-#[cfg(feature = "std")]
+#[cfg(not(target_os = "none"))]
 use alloc::sync::Arc;
 
 #[cfg(mls_build_async)]
@@ -12,7 +12,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode};
 use mls_rs_core::group::{EpochRecord, GroupState, GroupStateStorage};
-#[cfg(not(feature = "std"))]
+#[cfg(target_os = "none")]
 use portable_atomic_util::Arc;
 
 use crate::{client::MlsError, storage_provider::group_state::EpochData};

--- a/mls-rs/src/storage_provider/in_memory/key_package_storage.rs
+++ b/mls-rs/src/storage_provider/in_memory/key_package_storage.rs
@@ -2,10 +2,10 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-#[cfg(feature = "std")]
+#[cfg(not(target_os = "none"))]
 use alloc::sync::Arc;
 
-#[cfg(not(feature = "std"))]
+#[cfg(target_os = "none")]
 use portable_atomic_util::Arc;
 
 use core::convert::Infallible;

--- a/mls-rs/src/storage_provider/in_memory/psk_storage.rs
+++ b/mls-rs/src/storage_provider/in_memory/psk_storage.rs
@@ -2,10 +2,10 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-#[cfg(feature = "std")]
+#[cfg(not(target_os = "none"))]
 use alloc::sync::Arc;
 
-#[cfg(not(feature = "std"))]
+#[cfg(target_os = "none")]
 use portable_atomic_util::Arc;
 
 use core::convert::Infallible;


### PR DESCRIPTION
### Issues:

N/A

### Description of changes:

This makes the `portable-atomic*` dependencies conditional on the target not having an OS.

### Call-outs:

N/A

### Testing:

Built

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
