### PR TITLE
Fix cipher suite choice in aws-lc crypto provider

### DIFF
--- a/mls-rs-core/src/group/roster.rs
+++ b/mls-rs-core/src/group/roster.rs
@@ -61,6 +61,17 @@ impl Capabilities {
     pub fn credentials(&self) -> &[CredentialType] {
         &self.credentials
     }
+
+    /// Canonical form
+    pub fn sorted(mut self) -> Self {
+        self.protocol_versions.sort();
+        self.cipher_suites.sort();
+        self.extensions.sort();
+        self.proposals.sort();
+        self.credentials.sort();
+
+        self
+    }
 }
 
 impl Default for Capabilities {

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1989,11 +1989,12 @@ mod tests {
 
         assert_eq!(update.leaf_node.ungreased_extensions(), extension_list);
         assert_eq!(
-            update.leaf_node.ungreased_capabilities(),
+            update.leaf_node.ungreased_capabilities().sorted(),
             Capabilities {
                 extensions: vec![42.into()],
                 ..get_test_capabilities()
             }
+            .sorted()
         );
     }
 


### PR DESCRIPTION
### Description of changes:

The AWS-LC crypto provider hard-coded P521 as the returned cipher suite and always used SHA512 in the hash function.

### Testing:

Added tests for SHA from [the nist website](https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/secure-hashing#sha-2) and the test_suite function. Also checked that mls-rs passes tests with AWS-LC

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
