### PR TITLE
Update aws-lc-sys

### DIFF
--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["mls", "mls-rs", "aws-lc"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-aws-lc-rs = "1.5.1"
-aws-lc-sys = { version = "0.12.0" }
+aws-lc-rs = "1.6.1"
+aws-lc-sys = { version = "0.13.0" }
 mls-rs-core = { path = "../mls-rs-core", version = "0.17.0" }
 mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.8.0" }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.9.0" }


### PR DESCRIPTION
aws-lc-rs released a minor update bringing in a major update of a sys crate, causing 2 sys crates to be linked together (since we depend directly on this sys crate too), leading to duplicate symbol errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
