### PR TITLE
Bump versions for 0.37.2 release

### DIFF
--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-core"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 description = "Core components and traits for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-awslc"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "AWS-LC based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -11,7 +11,7 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 aws-lc-rs = "1.6.1"
 aws-lc-sys = { version = "0.13.0" }
-mls-rs-core = { path = "../mls-rs-core", version = "0.17.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.17.1" }
 mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.8.0" }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.9.0" }
 mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.10.0" }
@@ -21,7 +21,7 @@ maybe-async = "0.2.7"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.17.0", features = ["test_suite"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.17.1", features = ["test_suite"] }
 mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.8.0", features = ["test_utils"] }
 futures-test = "0.3.25"
 

--- a/mls-rs-crypto-hpke/Cargo.toml
+++ b/mls-rs-crypto-hpke/Cargo.toml
@@ -26,7 +26,7 @@ maybe-async = "0.2.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
-mockall = "0.11"
+mockall = "0.12"
 hex = { version = "^0.4.3", features = ["serde"] }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.9.0" }
 

--- a/mls-rs-ffi/Cargo.toml
+++ b/mls-rs-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-ffi"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Helper crate to generate FFI definitions for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -19,7 +19,7 @@ std = ["mls-rs/std", "safer-ffi-gen/std"]
 x509 = ["mls-rs-identity-x509"]
 
 [dependencies]
-mls-rs = { path = "../mls-rs", version = "0.37.0", features = ["ffi"] }
+mls-rs = { path = "../mls-rs", version = "0.38.0", features = ["ffi"] }
 mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.8.0", optional = true }
 mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.10.0", optional = true }
 mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.10.0", default-features = false, optional = true }

--- a/mls-rs-identity-x509/Cargo.toml
+++ b/mls-rs-identity-x509/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = { version = "1.0.40", optional = true }
 async-trait = "0.1.74"
 
 [dev-dependencies]
-mockall = "0.11"
+mockall = "0.12"
 assert_matches = "1"
 rand = "0.8"
 

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.37.1"
+version = "0.38.0"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -49,7 +49,7 @@ benchmark_util = ["test_util", "default", "dep:mls-rs-crypto-openssl"]
 fuzz_util = ["test_util", "default", "dep:once_cell", "dep:mls-rs-crypto-openssl"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.17.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.17.1" }
 mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", default-features = false, version = "0.10.0", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 mls-rs-codec = { version = "0.5.0", path = "../mls-rs-codec", default-features = false}

--- a/mls-rs/fuzz/Cargo.toml
+++ b/mls-rs/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-mls-rs = { version = "0.37.0", path = "..", features = ["arbitrary", "fuzz_util"] }
+mls-rs = { version = "0.38.0", path = "..", features = ["arbitrary", "fuzz_util"] }
 futures = "0.3.25"
 libfuzzer-sys = "0.4"
 once_cell = "1.13.0"

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mls-rs = { version = "0.37.0", path = "..", default-features = false, features = ["std", "external_client", "state_update"]}
+mls-rs = { version = "0.38.0", path = "..", default-features = false, features = ["std", "external_client", "state_update"]}
 tonic = "0.10.2"
 prost = "0.12.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Update mls-rs to 0.38.0
Update mls-rs-crypto-awslc to 0.10.0 
Update mls-rs-core to 0.17.1 and force mls-rs to have at least this version to avoid issues building tests that depend on a new function in 0.17.1
