### PR TITLE
Make secret tree work with arbitrary indices

### DIFF
--- a/mls-rs/src/group/ciphertext_processor.rs
+++ b/mls-rs/src/group/ciphertext_processor.rs
@@ -16,7 +16,10 @@ use super::{
     secret_tree::{KeyType, MessageKeyData},
     GroupContext,
 };
-use crate::{client::MlsError, tree_kem::node::LeafIndex};
+use crate::{
+    client::MlsError,
+    tree_kem::node::{LeafIndex, NodeIndex},
+};
 use mls_rs_codec::MlsEncode;
 use mls_rs_core::{crypto::CipherSuiteProvider, error::IntoAnyError};
 use zeroize::Zeroizing;
@@ -67,7 +70,7 @@ where
         &mut self,
         key_type: KeyType,
     ) -> Result<MessageKeyData, MlsError> {
-        let self_index = self.group_state.self_index();
+        let self_index = NodeIndex::from(self.group_state.self_index());
 
         self.group_state
             .epoch_secrets_mut()
@@ -83,6 +86,8 @@ where
         key_type: KeyType,
         generation: u32,
     ) -> Result<MessageKeyData, MlsError> {
+        let sender = NodeIndex::from(sender);
+
         self.group_state
             .epoch_secrets_mut()
             .secret_tree

--- a/mls-rs/src/group/epoch.rs
+++ b/mls-rs/src/group/epoch.rs
@@ -4,6 +4,8 @@
 
 #[cfg(feature = "psk")]
 use crate::psk::PreSharedKey;
+#[cfg(any(feature = "secret_tree_access", feature = "private_message"))]
+use crate::tree_kem::node::NodeIndex;
 #[cfg(feature = "prior_epoch")]
 use crate::{crypto::SignaturePublicKey, group::GroupContext, tree_kem::node::LeafIndex};
 use alloc::vec::Vec;
@@ -66,7 +68,7 @@ pub(crate) struct EpochSecrets {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     pub(crate) sender_data_secret: SenderDataSecret,
     #[cfg(any(feature = "secret_tree_access", feature = "private_message"))]
-    pub(crate) secret_tree: SecretTree,
+    pub(crate) secret_tree: SecretTree<NodeIndex>,
 }
 
 #[derive(Clone, Debug, PartialEq, MlsEncode, MlsDecode, MlsSize)]

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -190,7 +190,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             resumption_secret: PreSharedKey::new(vec![]),
             sender_data_secret: SenderDataSecret::from(vec![]),
             #[cfg(any(feature = "secret_tree_access", feature = "private_message"))]
-            secret_tree: SecretTree::empty(0),
+            secret_tree: SecretTree::empty(),
         };
 
         let (mut group, _) = Group::join_with(

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -190,7 +190,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             resumption_secret: PreSharedKey::new(vec![]),
             sender_data_secret: SenderDataSecret::from(vec![]),
             #[cfg(any(feature = "secret_tree_access", feature = "private_message"))]
-            secret_tree: SecretTree::empty(),
+            secret_tree: SecretTree::empty(0),
         };
 
         let (mut group, _) = Group::join_with(

--- a/mls-rs/src/group/interop_test_vectors/tree_kem.rs
+++ b/mls-rs/src/group/interop_test_vectors/tree_kem.rs
@@ -102,11 +102,13 @@ async fn tree_kem() {
             let mut tree_private = TreeKemPrivate::new(LeafIndex(leaf.index));
 
             // Set and validate HPKE keys on direct path
-            let path = tree.nodes.direct_path(tree_private.self_index).unwrap();
+            let path = tree.nodes.direct_copath(tree_private.self_index);
 
             tree_private.secret_keys = Vec::new();
 
             for dp in path {
+                let dp = dp.path;
+
                 let secret = leaf
                     .path_secrets
                     .iter()

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -719,14 +719,14 @@ where
         let path = provisional_state
             .public_tree
             .nodes
-            .direct_path(self_index)?;
+            .direct_copath(self_index);
 
         provisional_private_tree
             .secret_keys
             .resize(path.len() + 1, None);
 
         for (i, n) in path.iter().enumerate() {
-            if provisional_state.public_tree.nodes.is_blank(*n)? {
+            if provisional_state.public_tree.nodes.is_blank(n.path)? {
                 provisional_private_tree.secret_keys[i + 1] = None;
             }
         }
@@ -1512,7 +1512,7 @@ where
     pub fn next_encryption_key(&mut self) -> Result<MessageKey, MlsError> {
         self.epoch_secrets.secret_tree.next_message_key(
             &self.cipher_suite_provider,
-            self.private_tree.self_index,
+            crate::tree_kem::node::NodeIndex::from(self.private_tree.self_index),
             KeyType::Application,
         )
     }
@@ -1525,7 +1525,7 @@ where
     ) -> Result<MessageKey, MlsError> {
         self.epoch_secrets.secret_tree.message_key_generation(
             &self.cipher_suite_provider,
-            LeafIndex(sender),
+            crate::tree_kem::node::NodeIndex::from(sender),
             KeyType::Application,
             generation,
         )

--- a/mls-rs/src/group/secret_tree.rs
+++ b/mls-rs/src/group/secret_tree.rs
@@ -101,6 +101,8 @@ impl<T: TreeIndex> TreeSecretsVec<T> {
     fn set_node(&mut self, index: T, value: SecretTreeNode) {
         if let Some(i) = self.find_node(&index) {
             self.inner[i] = (index, value)
+        } else {
+            self.inner.push((index, value))
         }
     }
 

--- a/mls-rs/src/group/secret_tree.rs
+++ b/mls-rs/src/group/secret_tree.rs
@@ -110,10 +110,10 @@ pub struct SecretTree<T: MlsCodec> {
 }
 
 impl<T: TreeIndex + MlsCodec> SecretTree<T> {
-    pub(crate) fn empty(zero_leaf_count: T) -> SecretTree<T> {
+    pub(crate) fn empty() -> SecretTree<T> {
         SecretTree {
             known_secrets: Default::default(),
-            leaf_count: zero_leaf_count,
+            leaf_count: T::zero(),
         }
     }
 }

--- a/mls-rs/src/group/secret_tree.rs
+++ b/mls-rs/src/group/secret_tree.rs
@@ -101,7 +101,7 @@ pub struct SecretTree<T: TreeIndex> {
     leaf_count: T,
 }
 
-impl<T: TreeIndex + TreeIndex> SecretTree<T> {
+impl<T: TreeIndex> SecretTree<T> {
     pub(crate) fn empty() -> SecretTree<T> {
         SecretTree {
             known_secrets: Default::default(),

--- a/mls-rs/src/group/secret_tree.rs
+++ b/mls-rs/src/group/secret_tree.rs
@@ -4,24 +4,34 @@
 
 use crate::client::MlsError;
 use crate::tree_kem::math as tree_math;
-use crate::tree_kem::node::{LeafIndex, NodeIndex};
 use crate::CipherSuiteProvider;
-use alloc::vec;
 use alloc::vec::Vec;
-use core::ops::{Deref, DerefMut};
+use core::hash::Hash;
+use core::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
+use tree_math::TreeIndex;
 use zeroize::Zeroizing;
 
-#[cfg(all(feature = "std", feature = "out_of_order"))]
+#[cfg(feature = "std")]
 use std::collections::HashMap;
 
-#[cfg(all(not(feature = "std"), feature = "out_of_order"))]
+#[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap;
 
 use super::key_schedule::kdf_expand_with_label;
 
 pub(crate) const MAX_RATCHET_BACK_HISTORY: u32 = 1024;
+
+pub trait MlsCodec:
+    Clone + Debug + PartialEq + Eq + Default + MlsEncode + MlsDecode + MlsSize + Hash + Ord
+{
+}
+
+impl MlsCodec for u32 {}
 
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[repr(u8)]
@@ -31,14 +41,6 @@ enum SecretTreeNode {
 }
 
 impl SecretTreeNode {
-    fn into_ratchet(self) -> Option<SecretRatchets> {
-        if let SecretTreeNode::Ratchet(ratchets) = self {
-            Some(ratchets)
-        } else {
-            None
-        }
-    }
-
     fn into_secret(self) -> Option<TreeSecret> {
         if let SecretTreeNode::Secret(secret) = self {
             Some(secret)
@@ -83,54 +85,35 @@ impl From<Zeroizing<Vec<u8>>> for TreeSecret {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, MlsEncode, MlsDecode, MlsSize)]
-struct TreeSecretsVec(Vec<Option<SecretTreeNode>>);
-
-impl Deref for TreeSecretsVec {
-    type Target = Vec<Option<SecretTreeNode>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+#[derive(Clone, Debug, PartialEq, MlsEncode, MlsDecode, MlsSize, Default)]
+struct TreeSecretsVec<T: MlsCodec> {
+    #[cfg(feature = "std")]
+    inner: HashMap<T, SecretTreeNode>,
+    #[cfg(not(feature = "std"))]
+    inner: BTreeMap<T, SecretTreeNode>,
 }
 
-impl DerefMut for TreeSecretsVec {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl TreeSecretsVec {
-    fn replace_node(
-        &mut self,
-        index: NodeIndex,
-        value: Option<SecretTreeNode>,
-    ) -> Result<(), MlsError> {
-        self.get_mut(index as usize)
-            .ok_or(MlsError::InvalidNodeIndex(index))
-            .map(|n| *n = value)
+impl<T: MlsCodec> TreeSecretsVec<T> {
+    fn set_node(&mut self, index: T, value: SecretTreeNode) {
+        self.inner.insert(index, value);
     }
 
-    fn get_secret(&self, index: NodeIndex) -> Option<SecretTreeNode> {
-        self.get(index as usize).and_then(|n| n.clone())
-    }
-
-    fn total_leaf_count(&self) -> u32 {
-        ((self.len() / 2 + 1) as u32).next_power_of_two()
+    fn take_node(&mut self, index: &T) -> Option<SecretTreeNode> {
+        self.inner.remove(index)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, MlsEncode, MlsDecode, MlsSize)]
-pub struct SecretTree {
-    known_secrets: TreeSecretsVec,
-    leaf_count: u32,
+pub struct SecretTree<T: MlsCodec> {
+    known_secrets: TreeSecretsVec<T>,
+    leaf_count: T,
 }
 
-impl SecretTree {
-    pub(crate) fn empty() -> SecretTree {
+impl<T: TreeIndex + MlsCodec> SecretTree<T> {
+    pub(crate) fn empty(zero_leaf_count: T) -> SecretTree<T> {
         SecretTree {
-            known_secrets: TreeSecretsVec(vec![]),
-            leaf_count: 0,
+            known_secrets: Default::default(),
+            leaf_count: zero_leaf_count,
         }
     }
 }
@@ -176,12 +159,12 @@ impl SecretRatchets {
     }
 }
 
-impl SecretTree {
-    pub fn new(leaf_count: u32, encryption_secret: Zeroizing<Vec<u8>>) -> SecretTree {
-        let mut known_secrets = TreeSecretsVec(vec![None; (leaf_count * 2 - 1) as usize]);
+impl<T: TreeIndex + MlsCodec> SecretTree<T> {
+    pub fn new(leaf_count: T, encryption_secret: Zeroizing<Vec<u8>>) -> SecretTree<T> {
+        let mut known_secrets = TreeSecretsVec::default();
 
-        known_secrets[tree_math::root(leaf_count) as usize] =
-            Some(SecretTreeNode::Secret(TreeSecret::from(encryption_secret)));
+        let root_secret = SecretTreeNode::Secret(TreeSecret::from(encryption_secret));
+        known_secrets.set_node(leaf_count.root(), root_secret);
 
         Self {
             known_secrets,
@@ -193,11 +176,13 @@ impl SecretTree {
     async fn consume_node<P: CipherSuiteProvider>(
         &mut self,
         cipher_suite_provider: &P,
-        index: NodeIndex,
+        index: &T,
     ) -> Result<(), MlsError> {
-        if let Some(secret) = self.read_node(index)?.and_then(|n| n.into_secret()) {
-            let left_index = tree_math::left(index)?;
-            let right_index = tree_math::right(index)?;
+        let node = self.known_secrets.take_node(index);
+
+        if let Some(secret) = node.and_then(|n| n.into_secret()) {
+            let left_index = index.left().ok_or(MlsError::LeafNodeNoChildren)?;
+            let right_index = index.right().ok_or(MlsError::LeafNodeNoChildren)?;
 
             let left_secret =
                 kdf_expand_with_label(cipher_suite_provider, &secret, b"tree", b"left", None)
@@ -207,61 +192,45 @@ impl SecretTree {
                 kdf_expand_with_label(cipher_suite_provider, &secret, b"tree", b"right", None)
                     .await?;
 
-            self.write_node(left_index, Some(SecretTreeNode::Secret(left_secret.into())))?;
+            self.known_secrets
+                .set_node(left_index, SecretTreeNode::Secret(left_secret.into()));
 
-            self.write_node(
-                right_index,
-                Some(SecretTreeNode::Secret(right_secret.into())),
-            )?;
-
-            self.write_node(index, None)
-        } else {
-            Ok(()) // If the node is empty we can just skip it
+            self.known_secrets
+                .set_node(right_index, SecretTreeNode::Secret(right_secret.into()));
         }
+
+        Ok(())
     }
 
-    fn read_node(&self, index: NodeIndex) -> Result<Option<SecretTreeNode>, MlsError> {
-        Ok(self.known_secrets.get_secret(index))
-    }
-
-    fn write_node(
-        &mut self,
-        index: NodeIndex,
-        value: Option<SecretTreeNode>,
-    ) -> Result<(), MlsError> {
-        self.known_secrets.replace_node(index, value)
-    }
-
-    // Start at the root node and work your way down consuming any intermediates needed
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
-    async fn leaf_secret_ratchets<P: CipherSuiteProvider>(
+    async fn take_leaf_ratchet<P: CipherSuiteProvider>(
         &mut self,
         cipher_suite: &P,
-        leaf_index: LeafIndex,
+        leaf_index: &T,
     ) -> Result<SecretRatchets, MlsError> {
-        if let Some(ratchet) = self
-            .read_node(leaf_index.into())?
-            .and_then(|n| n.into_ratchet())
-        {
-            return Ok(ratchet);
-        }
+        let node_index = leaf_index;
 
-        let path = leaf_index.direct_path(self.known_secrets.total_leaf_count())?;
+        let node = match self.known_secrets.take_node(node_index) {
+            Some(node) => node,
+            None => {
+                // Start at the root node and work your way down consuming any intermediates needed
+                for i in node_index.direct_copath(&self.leaf_count).into_iter().rev() {
+                    self.consume_node(cipher_suite, &i.path).await?;
+                }
 
-        for i in path.into_iter().rev() {
-            self.consume_node(cipher_suite, i).await?;
-        }
+                self.known_secrets
+                    .take_node(node_index)
+                    .ok_or(MlsError::InvalidLeafConsumption)?
+            }
+        };
 
-        let secret = self
-            .read_node(leaf_index.into())?
-            .and_then(|n| n.into_secret())
-            .ok_or(MlsError::InvalidLeafConsumption)?;
-
-        self.write_node(leaf_index.into(), None)?;
-
-        Ok(SecretRatchets {
-            application: SecretKeyRatchet::new(cipher_suite, &secret, KeyType::Application).await?,
-            handshake: SecretKeyRatchet::new(cipher_suite, &secret, KeyType::Handshake).await?,
+        Ok(match node {
+            SecretTreeNode::Ratchet(ratchet) => ratchet,
+            SecretTreeNode::Secret(secret) => SecretRatchets {
+                application: SecretKeyRatchet::new(cipher_suite, &secret, KeyType::Application)
+                    .await?,
+                handshake: SecretKeyRatchet::new(cipher_suite, &secret, KeyType::Handshake).await?,
+            },
         })
     }
 
@@ -269,12 +238,14 @@ impl SecretTree {
     pub async fn next_message_key<P: CipherSuiteProvider>(
         &mut self,
         cipher_suite: &P,
-        leaf_index: LeafIndex,
+        leaf_index: T,
         key_type: KeyType,
     ) -> Result<MessageKeyData, MlsError> {
-        let mut ratchet = self.leaf_secret_ratchets(cipher_suite, leaf_index).await?;
+        let mut ratchet = self.take_leaf_ratchet(cipher_suite, &leaf_index).await?;
         let res = ratchet.next_message_key(cipher_suite, key_type).await?;
-        self.write_node(leaf_index.into(), Some(SecretTreeNode::Ratchet(ratchet)))?;
+
+        self.known_secrets
+            .set_node(leaf_index, SecretTreeNode::Ratchet(ratchet));
 
         Ok(res)
     }
@@ -283,17 +254,18 @@ impl SecretTree {
     pub async fn message_key_generation<P: CipherSuiteProvider>(
         &mut self,
         cipher_suite: &P,
-        leaf_index: LeafIndex,
+        leaf_index: T,
         key_type: KeyType,
         generation: u32,
     ) -> Result<MessageKeyData, MlsError> {
-        let mut ratchet = self.leaf_secret_ratchets(cipher_suite, leaf_index).await?;
+        let mut ratchet = self.take_leaf_ratchet(cipher_suite, &leaf_index).await?;
 
         let res = ratchet
             .message_key_generation(cipher_suite, generation, key_type)
             .await?;
 
-        self.write_node(leaf_index.into(), Some(SecretTreeNode::Ratchet(ratchet)))?;
+        self.known_secrets
+            .set_node(leaf_index, SecretTreeNode::Ratchet(ratchet));
 
         Ok(res)
     }
@@ -538,22 +510,27 @@ pub(crate) mod test_utils {
     use mls_rs_core::crypto::CipherSuiteProvider;
     use zeroize::Zeroizing;
 
-    use crate::{crypto::test_utils::try_test_cipher_suite_provider, tree_kem};
+    use crate::{crypto::test_utils::try_test_cipher_suite_provider, tree_kem::math::TreeIndex};
 
-    use super::{KeyType, SecretKeyRatchet, SecretTree};
+    use super::{KeyType, MlsCodec, SecretKeyRatchet, SecretTree};
 
-    pub(crate) fn get_test_tree(secret: Vec<u8>, leaf_count: u32) -> SecretTree {
+    impl MlsCodec for u64 {}
+
+    pub(crate) fn get_test_tree<T: MlsCodec + TreeIndex>(
+        secret: Vec<u8>,
+        leaf_count: T,
+    ) -> SecretTree<T> {
         SecretTree::new(leaf_count, Zeroizing::new(secret))
     }
 
-    impl SecretTree {
+    impl SecretTree<u32> {
         pub(crate) fn get_root_secret(&self) -> Vec<u8> {
-            self.read_node(tree_kem::math::root(self.leaf_count))
-                .unwrap()
+            self.known_secrets
+                .clone()
+                .take_node(&self.leaf_count.root())
                 .unwrap()
                 .into_secret()
                 .unwrap()
-                .0
                 .to_vec()
         }
     }
@@ -609,12 +586,15 @@ pub(crate) mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use crate::{
         cipher_suite::CipherSuite,
         client::test_utils::TEST_CIPHER_SUITE,
         crypto::test_utils::{
             test_cipher_suite_provider, try_test_cipher_suite_provider, TestCryptoProvider,
         },
+        tree_kem::node::NodeIndex,
     };
 
     #[cfg(not(mls_build_async))]
@@ -629,18 +609,27 @@ mod tests {
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn test_secret_tree() {
+        test_secret_tree_custom(16u32, (0..16).map(|i| 2 * i).collect(), true).await;
+        test_secret_tree_custom(1u64 << 62, (1..62).map(|i| 1u64 << i).collect(), false).await;
+    }
+
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    async fn test_secret_tree_custom<T: MlsCodec + TreeIndex>(
+        leaf_count: T,
+        leaves_to_check: Vec<T>,
+        all_deleted: bool,
+    ) {
         for cipher_suite in TestCryptoProvider::all_supported_cipher_suites() {
             let cs_provider = test_cipher_suite_provider(cipher_suite);
 
             let test_secret = vec![0u8; cs_provider.kdf_extract_size()];
-
-            let mut test_tree = get_test_tree(test_secret.clone(), 16);
+            let mut test_tree = get_test_tree(test_secret, leaf_count.clone());
 
             let mut secrets = Vec::<SecretRatchets>::new();
 
-            for i in 0..16 {
+            for i in &leaves_to_check {
                 let secret = test_tree
-                    .leaf_secret_ratchets(&test_cipher_suite_provider(cipher_suite), LeafIndex(i))
+                    .take_leaf_ratchet(&test_cipher_suite_provider(cipher_suite), i)
                     .await
                     .unwrap();
 
@@ -648,12 +637,7 @@ mod tests {
             }
 
             // Verify the tree is now completely empty
-            let full = test_tree
-                .known_secrets
-                .iter()
-                .filter(|n| n.is_some())
-                .count();
-            assert_eq!(full, 0);
+            assert!(!all_deleted || test_tree.known_secrets.inner.is_empty());
 
             // Verify that all the secrets are unique
             let count = secrets.len();
@@ -844,7 +828,7 @@ mod tests {
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     async fn get_ratchet_data(
-        secret_tree: &mut SecretTree,
+        secret_tree: &mut SecretTree<NodeIndex>,
         cipher_suite: CipherSuite,
     ) -> Vec<Ratchet> {
         let provider = test_cipher_suite_provider(cipher_suite);
@@ -852,7 +836,7 @@ mod tests {
 
         for index in 0..16 {
             let mut ratchets = secret_tree
-                .leaf_secret_ratchets(&provider, LeafIndex(index))
+                .take_leaf_ratchet(&provider, &(index * 2))
                 .await
                 .unwrap();
 
@@ -943,7 +927,7 @@ mod interop_tests {
 
     use crate::{
         crypto::test_utils::try_test_cipher_suite_provider,
-        group::{ciphertext_processor::InteropSenderData, secret_tree::KeyType, LeafIndex},
+        group::{ciphertext_processor::InteropSenderData, secret_tree::KeyType},
     };
 
     use super::SecretTree;
@@ -970,7 +954,7 @@ mod interop_tests {
                     let key = tree
                         .message_key_generation(
                             &cs,
-                            LeafIndex(index as u32),
+                            (index as u32) * 2,
                             KeyType::Application,
                             leaf.generation,
                         )
@@ -983,7 +967,7 @@ mod interop_tests {
                     let key = tree
                         .message_key_generation(
                             &cs,
-                            LeafIndex(index as u32),
+                            (index as u32) * 2,
                             KeyType::Handshake,
                             leaf.generation,
                         )
@@ -1045,7 +1029,7 @@ mod interop_tests {
                     .map(|leaf| {
                         gens.into_iter()
                             .map(|gen| {
-                                let index = LeafIndex(leaf);
+                                let index = leaf * 2u32;
 
                                 let handshake_key = tree
                                     .message_key_generation(&cs, index, KeyType::Handshake, gen)

--- a/mls-rs/src/tree_kem/kem.rs
+++ b/mls-rs/src/tree_kem/kem.rs
@@ -355,9 +355,10 @@ impl<'a> TreeKem<'a> {
 
         let ctxts = ctxts.try_collect().await?;
 
-        let (path_index, _) = copath_index
+        let path_index = copath_index
             .parent_sibling(&self.tree_kem_public.total_leaf_count())
-            .ok_or(MlsError::ExpectedNode)?;
+            .ok_or(MlsError::ExpectedNode)?
+            .parent;
 
         Ok(UpdatePathNode {
             public_key: self

--- a/mls-rs/src/tree_kem/math.rs
+++ b/mls-rs/src/tree_kem/math.rs
@@ -9,7 +9,7 @@ use mls_rs_codec::{MlsDecode, MlsEncode};
 use super::node::LeafIndex;
 
 pub trait TreeIndex:
-    Send + Sync + Eq + Clone + Debug + Default + MlsEncode + MlsDecode + Hash
+    Send + Sync + Eq + Clone + Debug + Default + MlsEncode + MlsDecode + Hash + Ord
 {
     fn root(&self) -> Self;
 

--- a/mls-rs/src/tree_kem/math.rs
+++ b/mls-rs/src/tree_kem/math.rs
@@ -9,7 +9,7 @@ use mls_rs_codec::{MlsDecode, MlsEncode};
 use super::node::LeafIndex;
 
 pub trait TreeIndex:
-    Sized + Send + Sync + Eq + Clone + Debug + Default + MlsEncode + MlsDecode + Hash + Ord
+    Send + Sync + Eq + Clone + Debug + Default + MlsEncode + MlsDecode + Hash
 {
     fn root(&self) -> Self;
 

--- a/mls-rs/src/tree_kem/node.rs
+++ b/mls-rs/src/tree_kem/node.rs
@@ -221,14 +221,6 @@ impl NodeVec {
         self.iter().step_by(2).map(|n| n.as_leaf().ok())
     }
 
-    /*pub fn direct_path(&self, index: LeafIndex) -> Vec<NodeIndex> {
-        NodeIndex::from(index)
-            .direct_copath(&self.total_leaf_count())
-            .into_iter()
-            .map(|n| n.path)
-            .collect()
-    }*/
-
     pub fn direct_copath(&self, index: LeafIndex) -> Vec<CopathNode<NodeIndex>> {
         NodeIndex::from(index).direct_copath(&self.total_leaf_count())
     }

--- a/mls-rs/src/tree_kem/tree_utils.rs
+++ b/mls-rs/src/tree_kem/tree_utils.rs
@@ -8,10 +8,8 @@ use core::borrow::BorrowMut;
 
 use debug_tree::TreeBuilder;
 
-use super::node::NodeIndex;
-use super::tree_math::{left_unchecked, right_unchecked};
-use super::{math::root, node::NodeVec};
-use crate::client::MlsError;
+use super::node::{NodeIndex, NodeVec};
+use crate::{client::MlsError, tree_kem::math::TreeIndex};
 
 pub(crate) fn build_tree(
     tree: &mut TreeBuilder,
@@ -30,7 +28,7 @@ pub(crate) fn build_tree(
     // Parent Leaf
     let mut parent_tag = format!("{blank_tag}Parent ({idx})");
 
-    if root(nodes.total_leaf_count()) == idx {
+    if nodes.total_leaf_count().root() == idx {
         parent_tag = format!("{blank_tag}Root ({idx})");
     }
 
@@ -56,8 +54,8 @@ pub(crate) fn build_tree(
     let mut branch = tree.add_branch(&parent_tag);
 
     //This cannot panic, as we already checked that idx is not a leaf
-    build_tree(tree, nodes, left_unchecked(idx))?;
-    build_tree(tree, nodes, right_unchecked(idx))?;
+    build_tree(tree, nodes, idx.left_unchecked())?;
+    build_tree(tree, nodes, idx.right_unchecked())?;
 
     branch.release();
 
@@ -67,7 +65,7 @@ pub(crate) fn build_tree(
 pub(crate) fn build_ascii_tree(nodes: &NodeVec) -> String {
     let leaves_count: u32 = nodes.total_leaf_count();
     let mut tree = TreeBuilder::new();
-    build_tree(tree.borrow_mut(), nodes, root(leaves_count)).unwrap();
+    build_tree(tree.borrow_mut(), nodes, leaves_count.root()).unwrap();
     tree.string()
 }
 

--- a/mls-rs/src/tree_kem/tree_validator.rs
+++ b/mls-rs/src/tree_kem/tree_validator.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
+use tree_math::TreeIndex;
 
 use super::node::{Node, NodeIndex};
 use crate::client::MlsError;
@@ -126,13 +127,16 @@ fn validate_unmerged(tree: &TreeKemPublic) -> Result<(), MlsError> {
     // For each leaf L, we search for the longest prefix P[1], P[2], ..., P[k] of the direct path of L
     // such that for each i=1..k, either L is in the unmerged leaves of P[i], or P[i] is blank. We will
     // then check that L is unmerged at each P[1], ..., P[k] and no other node.
-    let root = tree_math::root(tree.total_leaf_count());
+    let leaf_count = tree.total_leaf_count();
+    let root = leaf_count.root();
 
     for (index, _) in tree.nodes.non_empty_leaves() {
         let mut n = NodeIndex::from(index);
 
         while n != root {
-            let parent = tree_math::parent(n);
+            let Some((parent, _)) = n.parent_sibling(&leaf_count) else {
+                break;
+            };
 
             if tree.nodes.is_blank(parent)? {
                 n = parent;

--- a/mls-rs/src/tree_kem/tree_validator.rs
+++ b/mls-rs/src/tree_kem/tree_validator.rs
@@ -128,27 +128,22 @@ fn validate_unmerged(tree: &TreeKemPublic) -> Result<(), MlsError> {
     // such that for each i=1..k, either L is in the unmerged leaves of P[i], or P[i] is blank. We will
     // then check that L is unmerged at each P[1], ..., P[k] and no other node.
     let leaf_count = tree.total_leaf_count();
-    let root = leaf_count.root();
 
     for (index, _) in tree.nodes.non_empty_leaves() {
         let mut n = NodeIndex::from(index);
 
-        while n != root {
-            let Some((parent, _)) = n.parent_sibling(&leaf_count) else {
-                break;
-            };
-
-            if tree.nodes.is_blank(parent)? {
-                n = parent;
+        while let Some(ps) = n.parent_sibling(&leaf_count) {
+            if tree.nodes.is_blank(ps.parent)? {
+                n = ps.parent;
                 continue;
             }
 
-            let parent_node = tree.nodes.borrow_as_parent(parent)?;
+            let parent_node = tree.nodes.borrow_as_parent(ps.parent)?;
 
             if parent_node.unmerged_leaves.contains(&index) {
-                unmerged_sets[parent as usize].retain(|i| i != &index);
+                unmerged_sets[ps.parent as usize].retain(|i| i != &index);
 
-                n = parent;
+                n = ps.parent;
             } else {
                 break;
             }


### PR DESCRIPTION
### Description of changes:

This is first step towards morphing SecretTree into a PPRF which is a secret tree where indices are bigints (PPRF is a crypto primitive that may be useful for some MLS extensions).

Changes: Make `SecretTree` generic over a `TreeIndex` trait that does tree math. Also use a map instead of a vec since `SecretTree` is usually sparse. `TreeKemPublic` still only works for `u32` but should be possible to generalize.

### Testing:

All interop tests pass. There is a `SecretTree` test with `u64` indices.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
