### PR TITLE
Apply pending commits automatically when processing that commit

### DIFF
--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1276,7 +1276,7 @@ where
         if let Some(pending) = &self.pending_commit {
             let message_hash = CommitHash::compute(&self.cipher_suite_provider, &message).await?;
 
-            if &message_hash == &pending.commit_message_hash {
+            if message_hash == pending.commit_message_hash {
                 let message_description = self.apply_pending_commit().await?;
 
                 return Ok(ReceivedMessage::Commit(message_description));

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1273,6 +1273,16 @@ where
         &mut self,
         message: MlsMessage,
     ) -> Result<ReceivedMessage, MlsError> {
+        if let Some(pending) = &self.pending_commit {
+            let message_hash = CommitHash::compute(&self.cipher_suite_provider, &message).await?;
+
+            if &message_hash == &pending.commit_message_hash {
+                let message_description = self.apply_pending_commit().await?;
+
+                return Ok(ReceivedMessage::Commit(message_description));
+            }
+        }
+
         MessageProcessor::process_incoming_message(
             self,
             message,
@@ -4182,5 +4192,25 @@ mod tests {
 
             allowed.then_some(proposals).ok_or(MlsError::InvalidSender)
         }
+    }
+
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn group_can_receive_commit_from_self() {
+        let mut group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE)
+            .await
+            .group;
+
+        let commit = group.commit(vec![]).await.unwrap();
+
+        let update = group
+            .process_incoming_message(commit.commit_message)
+            .await
+            .unwrap();
+
+        let ReceivedMessage::Commit(update) = update else {
+            panic!("expected commit message")
+        };
+
+        assert_eq!(update.committer, *group.private_tree.self_index);
     }
 }

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -450,6 +450,7 @@ async fn test_group_application_messages() {
     test_on_all_params(test_application_messages).await
 }
 
+#[cfg(feature = "private_message")]
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
 async fn processing_message_from_self_returns_error(
     protocol_version: ProtocolVersion,
@@ -461,20 +462,20 @@ async fn processing_message_from_self_returns_error(
         get_test_groups(protocol_version, cipher_suite, 1, encrypt_controls).await;
     let creator_group = &mut creator_group[0];
 
-    let commit = creator_group
-        .commit(Vec::new())
+    let msg = creator_group
+        .encrypt_application_message(b"hello self", vec![])
         .await
-        .unwrap()
-        .commit_message;
+        .unwrap();
 
     let error = creator_group
-        .process_incoming_message(commit)
+        .process_incoming_message(msg)
         .await
         .unwrap_err();
 
     assert_matches!(error, MlsError::CantProcessMessageFromSelf);
 }
 
+#[cfg(feature = "private_message")]
 #[maybe_async::test(not(mls_build_async), async(mls_build_async, futures_test))]
 async fn test_processing_message_from_self_returns_error() {
     test_on_all_params(processing_message_from_self_returns_error).await;


### PR DESCRIPTION
Alternative to `apply_pending_commit`. This is useful if the DS can't distinguish recipients, we don't have a DS or control messages are encrypted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
