### PR TITLE
Async build

### DIFF
--- a/mls-rs-crypto-hpke/src/test_utils.rs
+++ b/mls-rs-crypto-hpke/src/test_utils.rs
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#![cfg(not(mls_build_async))]
+
 use alloc::vec::Vec;
 
 use crate::{

--- a/mls-rs-crypto-webcrypto/src/lib.rs
+++ b/mls-rs-crypto-webcrypto/src/lib.rs
@@ -2,7 +2,7 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-#![cfg(mls_build_async)]
+#![cfg(all(mls_build_async, target_arch = "wasm32"))]
 
 mod aead;
 mod ec;

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -17,6 +17,7 @@ rusqlite = { version = "0.30", default-features = false }
 rand = "0.8"
 hex = { version = "0.4" }
 maybe-async = "0.2.7"
+async-trait = "0.1.74"
 
 [dev-dependencies]
 tempfile = "3"

--- a/mls-rs-provider-sqlite/src/group_state.rs
+++ b/mls-rs-provider-sqlite/src/group_state.rs
@@ -201,10 +201,12 @@ impl SqLiteGroupStateStorage {
     }
 }
 
+#[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(mls_build_async, maybe_async::must_be_async)]
 impl GroupStateStorage for SqLiteGroupStateStorage {
     type Error = SqLiteDataStorageError;
 
-    fn write<ST, ET>(
+    async fn write<ST, ET>(
         &mut self,
         state: ST,
         epoch_inserts: Vec<ET>,
@@ -239,7 +241,7 @@ impl GroupStateStorage for SqLiteGroupStateStorage {
         self.update_group_state(group_id.as_slice(), snapshot_data, inserts, updates)
     }
 
-    fn state<T>(&self, group_id: &[u8]) -> Result<Option<T>, Self::Error>
+    async fn state<T>(&self, group_id: &[u8]) -> Result<Option<T>, Self::Error>
     where
         T: GroupState + MlsEncode + MlsDecode,
     {
@@ -249,11 +251,11 @@ impl GroupStateStorage for SqLiteGroupStateStorage {
             .map_err(|e| SqLiteDataStorageError::DataConversionError(e.into()))
     }
 
-    fn max_epoch_id(&self, group_id: &[u8]) -> Result<Option<u64>, Self::Error> {
+    async fn max_epoch_id(&self, group_id: &[u8]) -> Result<Option<u64>, Self::Error> {
         self.max_epoch_id(group_id)
     }
 
-    fn epoch<T>(&self, group_id: &[u8], epoch_id: u64) -> Result<Option<T>, Self::Error>
+    async fn epoch<T>(&self, group_id: &[u8], epoch_id: u64) -> Result<Option<T>, Self::Error>
     where
         T: EpochRecord + MlsEncode + MlsDecode,
     {

--- a/mls-rs-provider-sqlite/src/key_package.rs
+++ b/mls-rs-provider-sqlite/src/key_package.rs
@@ -92,18 +92,20 @@ impl SqLiteKeyPackageStorage {
     }
 }
 
+#[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(mls_build_async, maybe_async::must_be_async)]
 impl KeyPackageStorage for SqLiteKeyPackageStorage {
     type Error = SqLiteDataStorageError;
 
-    fn insert(&mut self, id: Vec<u8>, pkg: KeyPackageData) -> Result<(), Self::Error> {
+    async fn insert(&mut self, id: Vec<u8>, pkg: KeyPackageData) -> Result<(), Self::Error> {
         self.insert(id.as_slice(), pkg)
     }
 
-    fn get(&self, id: &[u8]) -> Result<Option<KeyPackageData>, Self::Error> {
+    async fn get(&self, id: &[u8]) -> Result<Option<KeyPackageData>, Self::Error> {
         self.get(id)
     }
 
-    fn delete(&mut self, id: &[u8]) -> Result<(), Self::Error> {
+    async fn delete(&mut self, id: &[u8]) -> Result<(), Self::Error> {
         (*self).delete(id)
     }
 }

--- a/mls-rs-provider-sqlite/src/psk.rs
+++ b/mls-rs-provider-sqlite/src/psk.rs
@@ -62,10 +62,12 @@ impl SqLitePreSharedKeyStorage {
     }
 }
 
+#[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(mls_build_async, maybe_async::must_be_async)]
 impl PreSharedKeyStorage for SqLitePreSharedKeyStorage {
     type Error = SqLiteDataStorageError;
 
-    fn get(&self, id: &ExternalPskId) -> Result<Option<PreSharedKey>, Self::Error> {
+    async fn get(&self, id: &ExternalPskId) -> Result<Option<PreSharedKey>, Self::Error> {
         self.get(id)
             .map_err(|e| SqLiteDataStorageError::DataConversionError(e.into()))
     }

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -1308,7 +1308,7 @@ mod tests {
             .await
             .unwrap();
 
-        let update = server.process_incoming_message(info.clone()).unwrap();
+        let update = server.process_incoming_message(info.clone()).await.unwrap();
         let info = info.into_group_info().unwrap();
 
         assert_matches!(update, ExternalReceivedMessage::GroupInfo(update_info) if update_info == info);
@@ -1321,7 +1321,7 @@ mod tests {
 
         let kp = test_key_package_message(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "john").await;
 
-        let update = server.process_incoming_message(kp.clone()).unwrap();
+        let update = server.process_incoming_message(kp.clone()).await.unwrap();
         let kp = kp.into_key_package().unwrap();
 
         assert_matches!(update, ExternalReceivedMessage::KeyPackage(update_kp) if update_kp == kp);
@@ -1340,12 +1340,13 @@ mod tests {
             )
             .unwrap()
             .build()
+            .await
             .unwrap()
             .welcome_messages
             .try_into()
             .unwrap();
 
-        let update = server.process_incoming_message(welcome).unwrap();
+        let update = server.process_incoming_message(welcome).await.unwrap();
 
         assert_matches!(update, ExternalReceivedMessage::Welcome);
     }

--- a/mls-rs/src/group/group_info.rs
+++ b/mls-rs/src/group/group_info.rs
@@ -6,7 +6,9 @@ use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::extension::ExtensionList;
 
-use super::*;
+use crate::{signer::Signable, tree_kem::node::LeafIndex};
+
+use super::{ConfirmationTag, GroupContext};
 
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]

--- a/mls-rs/src/group/key_schedule.rs
+++ b/mls-rs/src/group/key_schedule.rs
@@ -472,10 +472,10 @@ pub(crate) mod test_utils {
 
     use super::{InitSecret, JoinerSecret, KeySchedule};
 
-    #[cfg(feature = "rfc_compliant")]
+    #[cfg(all(feature = "rfc_compliant", not(mls_build_async)))]
     use mls_rs_core::error::IntoAnyError;
 
-    #[cfg(feature = "rfc_compliant")]
+    #[cfg(all(feature = "rfc_compliant", not(mls_build_async)))]
     use super::MlsError;
 
     impl From<JoinerSecret> for Vec<u8> {
@@ -502,7 +502,7 @@ pub(crate) mod test_utils {
             InitSecret(Zeroizing::new(init_secret))
         }
 
-        #[cfg(all(feature = "rfc_compliant", test))]
+        #[cfg(all(feature = "rfc_compliant", test, not(mls_build_async)))]
         #[cfg_attr(coverage_nightly, coverage(off))]
         pub fn random<P: CipherSuiteProvider>(cipher_suite: &P) -> Result<Self, MlsError> {
             cipher_suite

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1518,27 +1518,35 @@ where
     }
 
     #[cfg(feature = "secret_tree_access")]
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     #[inline(never)]
-    pub fn next_encryption_key(&mut self) -> Result<MessageKey, MlsError> {
-        self.epoch_secrets.secret_tree.next_message_key(
-            &self.cipher_suite_provider,
-            crate::tree_kem::node::NodeIndex::from(self.private_tree.self_index),
-            KeyType::Application,
-        )
+    pub async fn next_encryption_key(&mut self) -> Result<MessageKey, MlsError> {
+        self.epoch_secrets
+            .secret_tree
+            .next_message_key(
+                &self.cipher_suite_provider,
+                crate::tree_kem::node::NodeIndex::from(self.private_tree.self_index),
+                KeyType::Application,
+            )
+            .await
     }
 
     #[cfg(feature = "secret_tree_access")]
-    pub fn derive_decryption_key(
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub async fn derive_decryption_key(
         &mut self,
         sender: u32,
         generation: u32,
     ) -> Result<MessageKey, MlsError> {
-        self.epoch_secrets.secret_tree.message_key_generation(
-            &self.cipher_suite_provider,
-            crate::tree_kem::node::NodeIndex::from(sender),
-            KeyType::Application,
-            generation,
-        )
+        self.epoch_secrets
+            .secret_tree
+            .message_key_generation(
+                &self.cipher_suite_provider,
+                crate::tree_kem::node::NodeIndex::from(sender),
+                KeyType::Application,
+                generation,
+            )
+            .await
     }
 }
 

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -5,12 +5,8 @@
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::ops::Deref;
-use core::option::Option::Some;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
-use mls_rs_core::extension::ExtensionList;
-use mls_rs_core::identity::IdentityProvider;
 use mls_rs_core::secret::Secret;
 use mls_rs_core::time::MlsTime;
 

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -2,24 +2,37 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+use alloc::vec::Vec;
+
 use super::{
+    message_processor::ProvisionalState,
     mls_rules::{CommitDirection, CommitSource, MlsRules},
-    *,
+    GroupState, ProposalOrRef,
 };
 use crate::{
-    group::proposal_filter::{ProposalApplier, ProposalBundle, ProposalSource},
+    client::MlsError,
+    group::{
+        proposal_filter::{ProposalApplier, ProposalBundle, ProposalSource},
+        Proposal, Sender,
+    },
     time::MlsTime,
 };
 
 #[cfg(feature = "by_ref_proposal")]
-use crate::group::proposal_filter::FilterStrategy;
+use crate::group::{proposal_filter::FilterStrategy, ProposalRef, ProtocolVersion};
 
 use crate::tree_kem::leaf_node::LeafNode;
 
 #[cfg(all(feature = "std", feature = "by_ref_proposal"))]
 use std::collections::HashMap;
 
-use mls_rs_core::{error::IntoAnyError, psk::PreSharedKeyStorage};
+#[cfg(feature = "by_ref_proposal")]
+use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
+
+use mls_rs_core::{
+    crypto::CipherSuiteProvider, error::IntoAnyError, identity::IdentityProvider,
+    psk::PreSharedKeyStorage,
+};
 
 #[cfg(feature = "by_ref_proposal")]
 #[derive(Debug, Clone, MlsSize, MlsEncode, MlsDecode, PartialEq)]
@@ -588,16 +601,25 @@ pub(crate) mod test_utils {
 // TODO add tests for lite version of filtering
 #[cfg(all(feature = "by_ref_proposal", test))]
 mod tests {
-    use super::test_utils::{pass_through_rules, CommitReceiver};
-    use super::*;
-    use super::{
-        proposal_ref::test_utils::auth_content_from_proposal, test_utils::make_proposal_cache,
+    use alloc::{boxed::Box, vec, vec::Vec};
+
+    use super::test_utils::{make_proposal_cache, pass_through_rules, CommitReceiver};
+    use super::{CachedProposal, ProposalCache};
+    use crate::client::MlsError;
+    use crate::group::message_processor::ProvisionalState;
+    use crate::group::mls_rules::{CommitDirection, CommitSource, EncryptionOptions};
+    use crate::group::proposal_filter::{ProposalBundle, ProposalInfo, ProposalSource};
+    use crate::group::proposal_ref::test_utils::auth_content_from_proposal;
+    use crate::group::proposal_ref::ProposalRef;
+    use crate::group::{
+        AddProposal, AuthenticatedContent, Content, ExternalInit, Proposal, ProposalOrRef,
+        ReInitProposal, RemoveProposal, Roster, Sender, UpdateProposal,
     };
     use crate::key_package::test_utils::test_key_package_with_signer;
-    use crate::tree_kem::leaf_node::test_utils::{
-        get_basic_test_node_capabilities, get_test_capabilities,
-    };
-    use crate::tree_kem::leaf_node::LeafNodeSigningContext;
+    use crate::signer::Signable;
+    use crate::tree_kem::leaf_node::LeafNode;
+    use crate::tree_kem::node::LeafIndex;
+    use crate::tree_kem::TreeKemPublic;
     use crate::{
         client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
         crypto::{self, test_utils::test_cipher_suite_provider},
@@ -610,17 +632,20 @@ mod tests {
         identity::basic::BasicIdentityProvider,
         identity::test_utils::{get_test_signing_identity, BasicWithCustomProvider},
         key_package::{test_utils::test_key_package, KeyPackageGenerator},
+        mls_rules::{CommitOptions, DefaultMlsRules},
         psk::AlwaysFoundPskStorage,
         tree_kem::{
             leaf_node::{
                 test_utils::{
-                    default_properties, get_basic_test_node, get_basic_test_node_sig_key,
+                    default_properties, get_basic_test_node, get_basic_test_node_capabilities,
+                    get_basic_test_node_sig_key, get_test_capabilities,
                 },
-                ConfigProperties, LeafNodeSource,
+                ConfigProperties, LeafNodeSigningContext, LeafNodeSource,
             },
             Lifetime,
         },
     };
+    use crate::{KeyPackage, MlsRules};
 
     use crate::extension::RequiredCapabilitiesExt;
 
@@ -631,17 +656,30 @@ mod tests {
     };
 
     #[cfg(feature = "psk")]
-    use crate::psk::PskNonce;
+    use crate::{
+        group::proposal::PreSharedKeyProposal,
+        psk::{
+            ExternalPskId, JustPreSharedKeyID, PreSharedKeyID, PskGroupId, PskNonce,
+            ResumptionPSKUsage, ResumptionPsk,
+        },
+    };
+
+    #[cfg(feature = "custom_proposal")]
+    use crate::group::proposal::CustomProposal;
 
     use assert_matches::assert_matches;
     use core::convert::Infallible;
     use itertools::Itertools;
-    use mls_rs_core::psk::PreSharedKey;
+    use mls_rs_core::crypto::{CipherSuite, CipherSuiteProvider};
+    use mls_rs_core::extension::ExtensionList;
+    use mls_rs_core::group::{Capabilities, ProposalType};
+    use mls_rs_core::identity::IdentityProvider;
+    use mls_rs_core::protocol_version::ProtocolVersion;
+    use mls_rs_core::psk::{PreSharedKey, PreSharedKeyStorage};
     use mls_rs_core::{
         extension::MlsExtension,
         identity::{Credential, CredentialType, CustomCredential},
     };
-    use mls_rules::{CommitOptions, DefaultMlsRules};
 
     fn test_sender() -> u32 {
         1

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -643,9 +643,6 @@ mod tests {
     };
     use mls_rules::{CommitOptions, DefaultMlsRules};
 
-    #[cfg(mls_build_async)]
-    use futures::FutureExt;
-
     fn test_sender() -> u32 {
         1
     }

--- a/mls-rs/src/group/proposal_ref.rs
+++ b/mls-rs/src/group/proposal_ref.rs
@@ -2,6 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+use core::ops::Deref;
+
 use super::*;
 use crate::hash_reference::HashReference;
 

--- a/mls-rs/src/group/snapshot.rs
+++ b/mls-rs/src/group/snapshot.rs
@@ -324,7 +324,7 @@ mod tests {
     #[cfg(feature = "serde")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn serde() {
-        let snapshot = super::test_utils::get_test_snapshot(TEST_CIPHER_SUITE, 5);
+        let snapshot = super::test_utils::get_test_snapshot(TEST_CIPHER_SUITE, 5).await;
         let json = serde_json::to_string_pretty(&snapshot).unwrap();
         let recovered = serde_json::from_str(&json).unwrap();
         assert_eq!(snapshot, recovered);

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -2,7 +2,7 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use core::ops::DerefMut;
+use core::ops::{Deref, DerefMut};
 
 use alloc::format;
 use rand::RngCore;

--- a/mls-rs/src/group/transcript_hash.rs
+++ b/mls-rs/src/group/transcript_hash.rs
@@ -2,9 +2,19 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use super::*;
+use alloc::vec::Vec;
 use core::ops::Deref;
-use mls_rs_core::error::IntoAnyError;
+
+use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
+use mls_rs_core::{crypto::CipherSuiteProvider, error::IntoAnyError};
+
+use crate::{
+    client::MlsError,
+    group::{framing::FramedContent, MessageSignature},
+    WireFormat,
+};
+
+use super::{AuthenticatedContent, ConfirmationTag};
 
 #[derive(Debug, Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -160,8 +160,6 @@ pub(crate) mod test_utils {
         MlsMessage,
     };
 
-    #[cfg(mls_build_async)]
-    use futures::FutureExt;
     use mls_rs_core::crypto::SignatureSecretKey;
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]

--- a/mls-rs/src/key_package/validator.rs
+++ b/mls-rs/src/key_package/validator.rs
@@ -2,9 +2,9 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use super::*;
-use crate::client::MlsError;
-use crate::CipherSuiteProvider;
+use mls_rs_core::{crypto::CipherSuiteProvider, protocol_version::ProtocolVersion};
+
+use crate::{client::MlsError, signer::Signable, KeyPackage};
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
 pub(crate) async fn validate_key_package_properties<CSP: CipherSuiteProvider>(

--- a/mls-rs/src/psk.rs
+++ b/mls-rs/src/psk.rs
@@ -134,10 +134,10 @@ pub(crate) mod test_utils {
     use crate::crypto::test_utils::test_cipher_suite_provider;
 
     use super::PskNonce;
-    use mls_rs_core::{
-        crypto::{CipherSuite, CipherSuiteProvider},
-        psk::ExternalPskId,
-    };
+    use mls_rs_core::crypto::CipherSuite;
+
+    #[cfg(not(mls_build_async))]
+    use mls_rs_core::{crypto::CipherSuiteProvider, psk::ExternalPskId};
 
     #[cfg_attr(coverage_nightly, coverage(off))]
     #[cfg(not(mls_build_async))]

--- a/mls-rs/src/psk/secret.rs
+++ b/mls-rs/src/psk/secret.rs
@@ -101,13 +101,14 @@ impl PskSecret {
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
+    #[cfg(not(mls_build_async))]
     use core::iter;
     use serde::{Deserialize, Serialize};
 
     use crate::{
         crypto::test_utils::try_test_cipher_suite_provider,
         psk::ExternalPskId,
-        psk::{test_utils::make_nonce, JustPreSharedKeyID, PreSharedKeyID, PskNonce},
+        psk::{JustPreSharedKeyID, PreSharedKeyID, PskNonce},
         CipherSuiteProvider,
     };
 
@@ -160,7 +161,7 @@ mod tests {
                 || PskInfo {
                     id: make_external_psk_id(cs).to_vec(),
                     psk: cs.random_bytes_vec(cs.kdf_extract_size()).unwrap(),
-                    nonce: make_nonce(cs.cipher_suite()).0,
+                    nonce: crate::psk::test_utils::make_nonce(cs.cipher_suite()).0,
                 },
             )
             .take(n)

--- a/mls-rs/src/test_utils/mod.rs
+++ b/mls-rs/src/test_utils/mod.rs
@@ -2,10 +2,10 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-#[cfg(feature = "benchmark_util")]
+#[cfg(all(feature = "benchmark_util", not(mls_build_async)))]
 pub mod benchmarks;
 
-#[cfg(feature = "fuzz_util")]
+#[cfg(all(feature = "fuzz_util", not(mls_build_async)))]
 pub mod fuzz_tests;
 
 use mls_rs_core::{

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -51,7 +51,6 @@ pub use update_path::*;
 
 use tree_index::*;
 
-use self::path_secret::{PathSecret, PathSecretGenerator};
 pub mod kem;
 pub mod leaf_node;
 pub mod leaf_node_validator;

--- a/mls-rs/src/tree_kem/private.rs
+++ b/mls-rs/src/tree_kem/private.rs
@@ -1,10 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
+use alloc::{vec, vec::Vec};
 
-use crate::crypto::CipherSuiteProvider;
+use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
+use mls_rs_core::crypto::HpkeSecretKey;
 
-use super::*;
+use crate::{client::MlsError, crypto::CipherSuiteProvider};
+
+use super::{
+    math::leaf_lca_level,
+    node::LeafIndex,
+    path_secret::{PathSecret, PathSecretGenerator},
+    TreeKemPublic,
+};
 
 #[derive(Clone, Debug, MlsEncode, MlsDecode, MlsSize, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -40,8 +49,7 @@ impl TreeKemPrivate {
         // Identify the lowest common
         // ancestor of the leaves at index and at GroupInfo.signer_index. Set the private key
         // for this node to the private key derived from the path_secret.
-        let lca_index =
-            tree_math::leaf_lca_level(self.self_index.into(), signer_index.into()) as usize - 2;
+        let lca_index = leaf_lca_level(self.self_index.into(), signer_index.into()) as usize - 2;
 
         // For each parent of the common ancestor, up to the root of the tree, derive a new
         // path secret and set the private key for the node to the private key derived from the


### PR DESCRIPTION
Add macros to make the SQLite build in the async mode. This way it can be used e.g. with async identity or crypto providers. Build WebCrypto provider only for wasm arch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
