### PR TITLE
Customize debug output of byte arrays

### DIFF
--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -18,8 +18,8 @@ std = ["mls-rs-codec/std", "zeroize/std", "safer-ffi-gen?/std", "dep:thiserror",
 rfc_compliant = ["x509"]
 ffi = ["dep:safer-ffi", "dep:safer-ffi-gen"]
 x509 = []
-test_suite = ["dep:serde", "dep:serde_json", "dep:hex", "dep:itertools"]
-serde = ["dep:serde", "zeroize/serde", "dep:hex", "dep:serde_bytes"]
+test_suite = ["serde", "dep:serde_json", "dep:itertools"]
+serde = ["dep:serde", "zeroize/serde", "hex/serde", "dep:serde_bytes"]
 
 [dependencies]
 mls-rs-codec = { version = "0.5.0", path = "../mls-rs-codec", default-features = false}
@@ -32,7 +32,7 @@ maybe-async = "0.2.7"
 
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
 serde_json = { version = "^1.0", optional = true }
-hex = { version = "^0.4.3", default-features = false, features = ["serde", "alloc"], optional = true }
+hex = { version = "^0.4.3", default-features = false, features = ["alloc"] }
 itertools = { version = "0.12", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 

--- a/mls-rs-core/src/crypto.rs
+++ b/mls-rs-core/src/crypto.rs
@@ -5,7 +5,10 @@
 use crate::error::IntoAnyError;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use zeroize::{ZeroizeOnDrop, Zeroizing};
 
@@ -15,7 +18,7 @@ pub use self::cipher_suite::*;
 #[cfg(feature = "test_suite")]
 pub mod test_suite;
 
-#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Ciphertext produced by [`CipherSuiteProvider::hpke_seal`]
@@ -28,9 +31,18 @@ pub struct HpkeCiphertext {
     pub ciphertext: Vec<u8>,
 }
 
+impl Debug for HpkeCiphertext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HpkeCiphertext")
+            .field("kem_output", &crate::debug::pretty_bytes(&self.kem_output))
+            .field("ciphertext", &crate::debug::pretty_bytes(&self.ciphertext))
+            .finish()
+    }
+}
+
 /// Byte representation of an HPKE public key. For ciphersuites using elliptic curves,
 /// the public key should be represented in the uncompressed format.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, MlsSize, MlsDecode, MlsEncode)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, MlsSize, MlsDecode, MlsEncode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     all(feature = "ffi", not(test)),
@@ -42,6 +54,14 @@ pub struct HpkePublicKey(
     #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for HpkePublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::debug::pretty_bytes(&self.0)
+            .named("HpkePublicKey")
+            .fmt(f)
+    }
+}
 
 impl From<Vec<u8>> for HpkePublicKey {
     fn from(data: Vec<u8>) -> Self {
@@ -70,7 +90,7 @@ impl AsRef<[u8]> for HpkePublicKey {
 }
 
 /// Byte representation of an HPKE secret key.
-#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode, ZeroizeOnDrop)]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode, ZeroizeOnDrop)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     all(feature = "ffi", not(test)),
@@ -82,6 +102,14 @@ pub struct HpkeSecretKey(
     #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for HpkeSecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::debug::pretty_bytes(&self.0)
+            .named("HpkeSecretKey")
+            .fmt(f)
+    }
+}
 
 impl From<Vec<u8>> for HpkeSecretKey {
     fn from(data: Vec<u8>) -> Self {
@@ -148,7 +176,7 @@ pub trait HpkeContextR {
 
 /// Byte representation of a signature public key. For ciphersuites using elliptic curves,
 /// the public key should be represented in the uncompressed format.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::ffi_type(opaque))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -157,6 +185,14 @@ pub struct SignaturePublicKey(
     #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for SignaturePublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::debug::pretty_bytes(&self.0)
+            .named("SignaturePublicKey")
+            .fmt(f)
+    }
+}
 
 #[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
 impl SignaturePublicKey {
@@ -198,12 +234,20 @@ impl From<Vec<u8>> for SignaturePublicKey {
     all(feature = "ffi", not(test)),
     ::safer_ffi_gen::ffi_type(clone, opaque)
 )]
-#[derive(Clone, Debug, PartialEq, Eq, ZeroizeOnDrop, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, ZeroizeOnDrop, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SignatureSecretKey {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
     bytes: Vec<u8>,
+}
+
+impl Debug for SignatureSecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::debug::pretty_bytes(&self.bytes)
+            .named("SignatureSecretKey")
+            .fmt(f)
+    }
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]

--- a/mls-rs-core/src/debug.rs
+++ b/mls-rs-core/src/debug.rs
@@ -1,0 +1,130 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright by contributors to this project.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+use core::fmt::{self, Debug};
+
+const DEFAULT_BYTES_TYPE_NAME: &str = "Bytes";
+
+pub fn pretty_bytes(bytes: &[u8]) -> PrettyBytes<'_> {
+    PrettyBytes {
+        ty: None,
+        bytes,
+        show_len: true,
+        show_raw: false,
+    }
+}
+
+pub struct PrettyBytes<'a> {
+    ty: Option<&'a str>,
+    bytes: &'a [u8],
+    show_len: bool,
+    show_raw: bool,
+}
+
+impl<'a> PrettyBytes<'a> {
+    pub fn named(self, ty: &'a str) -> Self {
+        Self {
+            ty: Some(ty),
+            ..self
+        }
+    }
+
+    pub fn show_len(self, show: bool) -> Self {
+        Self {
+            show_len: show,
+            ..self
+        }
+    }
+
+    pub fn show_raw(self, show: bool) -> Self {
+        Self {
+            show_raw: show,
+            ..self
+        }
+    }
+}
+
+impl Debug for PrettyBytes<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let show_raw = self.show_raw || f.alternate();
+        match (self.ty, self.show_len, show_raw) {
+            (_, false, false) => show_only_type(self.ty, f),
+            (None, false, true) => show_only_raw(self.bytes, f),
+            (Some(ty), false, true) => show_newtype(ty, self.bytes, f),
+            (_, true, _) => show_struct(self.ty, self.bytes, show_raw, f),
+        }
+    }
+}
+
+fn show_only_type(ty: Option<&str>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(ty.unwrap_or(DEFAULT_BYTES_TYPE_NAME))
+}
+
+fn show_only_raw(bytes: &[u8], f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(&hex::encode(bytes))
+}
+
+fn show_newtype(ty: &str, bytes: &[u8], f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{ty}({})", hex::encode(bytes))
+}
+
+fn show_struct(
+    ty: Option<&str>,
+    bytes: &[u8],
+    show_raw: bool,
+    f: &mut fmt::Formatter<'_>,
+) -> fmt::Result {
+    let ty = ty.unwrap_or(DEFAULT_BYTES_TYPE_NAME);
+    let mut out = f.debug_struct(ty);
+    out.field("len", &bytes.len());
+    if show_raw {
+        out.field("raw", &hex::encode(bytes));
+    }
+    out.finish()
+}
+
+pub fn pretty_with<F>(f: F) -> impl Debug
+where
+    F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    PrettyWith(f)
+}
+
+struct PrettyWith<F>(F);
+
+impl<F> Debug for PrettyWith<F>
+where
+    F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0(f)
+    }
+}
+
+pub fn pretty_group_id(id: &[u8]) -> impl Debug + '_ {
+    pretty_bytes(id).show_len(false).show_raw(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::debug::pretty_bytes;
+
+    #[test]
+    fn default_format_contains_only_length() {
+        let bytes = pretty_bytes(b"foobar");
+        let output = format!("{bytes:?}");
+        assert!(output.contains("len"));
+        assert!(!output.contains("raw"));
+        assert!(!output.contains(&hex::encode(b"foobar")));
+    }
+
+    #[test]
+    fn alternate_format_contains_length_and_hex_encoded_bytes() {
+        let bytes = pretty_bytes(b"foobar");
+        let output = format!("{bytes:#?}");
+        assert!(output.contains("len"));
+        assert!(output.contains("raw"));
+        assert!(output.contains(&hex::encode(b"foobar")));
+    }
+}

--- a/mls-rs-core/src/extension.rs
+++ b/mls-rs-core/src/extension.rs
@@ -2,7 +2,10 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 
 use crate::error::{AnyError, IntoAnyError};
 use alloc::vec::Vec;
@@ -90,7 +93,7 @@ impl IntoAnyError for ExtensionError {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     all(feature = "ffi", not(test)),
@@ -109,6 +112,18 @@ pub struct Extension {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
     pub extension_data: Vec<u8>,
+}
+
+impl Debug for Extension {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Extension")
+            .field("extension_type", &self.extension_type)
+            .field(
+                "extension_data",
+                &crate::debug::pretty_bytes(&self.extension_data),
+            )
+            .finish()
+    }
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]

--- a/mls-rs-core/src/identity/basic.rs
+++ b/mls-rs-core/src/identity/basic.rs
@@ -2,14 +2,17 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use core::convert::Infallible;
+use core::{
+    convert::Infallible,
+    fmt::{self, Debug},
+};
 
 use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
 use super::{Credential, CredentialType, MlsCredential};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     all(feature = "ffi", not(test)),
@@ -31,6 +34,14 @@ pub struct BasicCredential {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
     pub identifier: Vec<u8>,
+}
+
+impl Debug for BasicCredential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::debug::pretty_bytes(&self.identifier)
+            .named("BasicCredential")
+            .fmt(f)
+    }
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]

--- a/mls-rs-core/src/identity/credential.rs
+++ b/mls-rs-core/src/identity/credential.rs
@@ -2,7 +2,10 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 
 use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
@@ -55,7 +58,7 @@ impl Deref for CredentialType {
     }
 }
 
-#[derive(Clone, Debug, MlsSize, MlsEncode, MlsDecode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, MlsSize, MlsEncode, MlsDecode, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     all(feature = "ffi", not(test)),
@@ -76,6 +79,15 @@ pub struct CustomCredential {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
     pub data: Vec<u8>,
+}
+
+impl Debug for CustomCredential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CustomCredential")
+            .field("credential_type", &self.credential_type)
+            .field("data", &crate::debug::pretty_bytes(&self.data))
+            .finish()
+    }
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]

--- a/mls-rs-core/src/identity/x509.rs
+++ b/mls-rs-core/src/identity/x509.rs
@@ -4,6 +4,7 @@
 
 use core::{
     convert::Infallible,
+    fmt::{self, Debug},
     ops::{Deref, DerefMut},
 };
 
@@ -12,7 +13,7 @@ use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
 use super::{Credential, CredentialType, MlsCredential};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     all(feature = "ffi", not(test)),
@@ -25,6 +26,14 @@ pub struct DerCertificate(
     #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for DerCertificate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::debug::pretty_bytes(&self.0)
+            .named("DerCertificate")
+            .fmt(f)
+    }
+}
 
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
 impl DerCertificate {

--- a/mls-rs-core/src/key_package.rs
+++ b/mls-rs-core/src/key_package.rs
@@ -5,11 +5,12 @@
 #[cfg(mls_build_async)]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
 use crate::{crypto::HpkeSecretKey, error::IntoAnyError};
 
-#[derive(Debug, Clone, PartialEq, Eq, MlsEncode, MlsDecode, MlsSize)]
+#[derive(Clone, PartialEq, Eq, MlsEncode, MlsDecode, MlsSize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 /// Representation of a generated key package and secret keys.
@@ -19,6 +20,20 @@ pub struct KeyPackageData {
     pub init_key: HpkeSecretKey,
     pub leaf_node_key: HpkeSecretKey,
     pub expiration: u64,
+}
+
+impl Debug for KeyPackageData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeyPackageData")
+            .field(
+                "key_package_bytes",
+                &crate::debug::pretty_bytes(&self.key_package_bytes),
+            )
+            .field("init_key", &self.init_key)
+            .field("leaf_node_key", &self.leaf_node_key)
+            .field("expiration", &self.expiration)
+            .finish()
+    }
 }
 
 impl KeyPackageData {

--- a/mls-rs-core/src/lib.rs
+++ b/mls-rs-core/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 pub mod crypto;
+pub mod debug;
 pub mod error;
 pub mod extension;
 pub mod group;

--- a/mls-rs-core/src/psk.rs
+++ b/mls-rs-core/src/psk.rs
@@ -6,11 +6,14 @@ use crate::error::IntoAnyError;
 #[cfg(mls_build_async)]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use zeroize::Zeroizing;
 
-#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Wrapper type that holds a pre-shared key value and zeroizes on drop.
 pub struct PreSharedKey(
@@ -18,6 +21,14 @@ pub struct PreSharedKey(
     #[cfg_attr(feature = "serde", serde(with = "crate::zeroizing_serde"))]
     Zeroizing<Vec<u8>>,
 );
+
+impl Debug for PreSharedKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::debug::pretty_bytes(&self.0)
+            .named("PreSharedKey")
+            .fmt(f)
+    }
+}
 
 impl PreSharedKey {
     /// Create a new PreSharedKey.
@@ -57,7 +68,7 @@ impl Deref for PreSharedKey {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, Eq, Hash, Ord, PartialOrd, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     all(feature = "ffi", not(test)),
@@ -70,6 +81,14 @@ pub struct ExternalPskId(
     #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for ExternalPskId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::debug::pretty_bytes(&self.0)
+            .named("ExternalPskId")
+            .fmt(f)
+    }
+}
 
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
 impl ExternalPskId {

--- a/mls-rs-core/src/secret.rs
+++ b/mls-rs-core/src/secret.rs
@@ -3,16 +3,25 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
-use core::ops::{Deref, DerefMut};
+use core::{
+    fmt::{self, Debug},
+    ops::{Deref, DerefMut},
+};
 use zeroize::Zeroizing;
 
 #[cfg_attr(
     all(feature = "ffi", not(test)),
     safer_ffi_gen::ffi_type(clone, opaque)
 )]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 /// Wrapper struct that represents a zeroize-on-drop `Vec<u8>`
 pub struct Secret(Zeroizing<Vec<u8>>);
+
+impl Debug for Secret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::debug::pretty_bytes(&self.0).named("Secret").fmt(f)
+    }
+}
 
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
 impl Secret {

--- a/mls-rs-crypto-hpke/src/context.rs
+++ b/mls-rs-crypto-hpke/src/context.rs
@@ -11,13 +11,27 @@ use mls_rs_crypto_traits::{AeadType, KdfType};
 use crate::{hpke::HpkeError, kdf::HpkeKdf};
 
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 
 /// A type representing an HPKE context
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(super) struct Context<KDF: KdfType, AEAD: AeadType> {
     exporter_secret: Vec<u8>,
     encryption_context: Option<EncryptionContext<AEAD>>,
     kdf: HpkeKdf<KDF>,
+}
+
+impl<KDF: KdfType + Debug, AEAD: AeadType + Debug> Debug for Context<KDF, AEAD> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Context")
+            .field(
+                "exporter_secret",
+                &mls_rs_core::debug::pretty_bytes(&self.exporter_secret),
+            )
+            .field("encryption_context", &self.encryption_context)
+            .field("kdf", &self.kdf)
+            .finish()
+    }
 }
 
 impl<KDF: KdfType, AEAD: AeadType> Context<KDF, AEAD> {
@@ -122,12 +136,29 @@ impl<KDF: KdfType, AEAD: AeadType> HpkeContextR for ContextR<KDF, AEAD> {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub(super) struct EncryptionContext<AEAD: AeadType> {
     base_nonce: Vec<u8>,
     seq_number: u64,
     aead: AEAD,
     aead_key: Vec<u8>,
+}
+
+impl<AEAD: AeadType + Debug> Debug for EncryptionContext<AEAD> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EncryptionContext")
+            .field(
+                "base_nonce",
+                &mls_rs_core::debug::pretty_bytes(&self.base_nonce),
+            )
+            .field("seq_number", &self.seq_number)
+            .field("aead", &self.aead)
+            .field(
+                "aead_key",
+                &mls_rs_core::debug::pretty_bytes(&self.aead_key),
+            )
+            .finish()
+    }
 }
 
 impl<AEAD: AeadType> EncryptionContext<AEAD> {

--- a/mls-rs-crypto-hpke/src/kdf.rs
+++ b/mls-rs-crypto-hpke/src/kdf.rs
@@ -5,11 +5,24 @@
 use mls_rs_crypto_traits::KdfType;
 
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub(crate) struct HpkeKdf<K: KdfType> {
     suite_id: Vec<u8>,
     kdf: K,
+}
+
+impl<K: KdfType + Debug> Debug for HpkeKdf<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HpkeKdf")
+            .field(
+                "suite_id",
+                &mls_rs_core::debug::pretty_bytes(&self.suite_id),
+            )
+            .field("kdf", &self.kdf)
+            .finish()
+    }
 }
 
 impl<K: KdfType> HpkeKdf<K> {

--- a/mls-rs-crypto-openssl/src/ec.rs
+++ b/mls-rs-crypto-openssl/src/ec.rs
@@ -2,6 +2,7 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+use core::fmt::{self, Debug};
 use mls_rs_crypto_traits::Curve;
 use thiserror::Error;
 
@@ -46,10 +47,19 @@ pub fn generate_keypair(curve: Curve) -> Result<KeyPair, EcError> {
     Ok(KeyPair { public, secret })
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default)]
 pub struct KeyPair {
     pub public: Vec<u8>,
     pub secret: Vec<u8>,
+}
+
+impl Debug for KeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeyPair")
+            .field("public", &mls_rs_core::debug::pretty_bytes(&self.public))
+            .field("secret", &mls_rs_core::debug::pretty_bytes(&self.secret))
+            .finish()
+    }
 }
 
 fn pub_key_from_uncompressed_nist(bytes: &[u8], nid: Nid) -> Result<EcPublicKey, ErrorStack> {

--- a/mls-rs-crypto-rustcrypto/src/ec.rs
+++ b/mls-rs-crypto-rustcrypto/src/ec.rs
@@ -14,6 +14,7 @@ use std::array::TryFromSliceError;
 #[cfg(not(feature = "std"))]
 use core::array::TryFromSliceError;
 
+use core::fmt::{self, Debug};
 use ed25519_dalek::Signer;
 use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use rand_core::OsRng;
@@ -256,10 +257,19 @@ pub fn generate_keypair(curve: Curve) -> Result<KeyPair, EcError> {
     Ok(KeyPair { public, secret })
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default)]
 pub struct KeyPair {
     pub public: Vec<u8>,
     pub secret: Vec<u8>,
+}
+
+impl Debug for KeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeyPair")
+            .field("public", &mls_rs_core::debug::pretty_bytes(&self.public))
+            .field("secret", &mls_rs_core::debug::pretty_bytes(&self.secret))
+            .finish()
+    }
 }
 
 pub fn private_key_bytes_to_public(secret_key: &[u8], curve: Curve) -> Result<Vec<u8>, EcError> {

--- a/mls-rs-crypto-rustcrypto/src/x509/validator.rs
+++ b/mls-rs-crypto-rustcrypto/src/x509/validator.rs
@@ -2,11 +2,13 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use std::collections::HashMap;
-
 use mls_rs_core::{crypto::SignaturePublicKey, time::MlsTime};
 use mls_rs_identity_x509::{CertificateChain, DerCertificate, X509CredentialValidator};
 use spki::der::{Decode, Encode};
+use std::{
+    collections::HashMap,
+    fmt::{self, Debug},
+};
 use x509_cert::Certificate;
 
 use crate::{
@@ -16,11 +18,32 @@ use crate::{
 
 use super::X509Error;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct X509Validator {
     root_ca_list: HashMap<Vec<u8>, DerCertificate>,
     pinned_cert: Option<DerCertificate>,
     allow_self_signed: bool,
+}
+
+impl Debug for X509Validator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("X509Validator")
+            .field(
+                "root_ca_list",
+                &mls_rs_core::debug::pretty_with(|f| {
+                    f.debug_map()
+                        .entries(
+                            self.root_ca_list
+                                .iter()
+                                .map(|(k, v)| (mls_rs_core::debug::pretty_bytes(k), v)),
+                        )
+                        .finish()
+                }),
+            )
+            .field("pinned_cert", &self.pinned_cert)
+            .field("allow_self_signed", &self.allow_self_signed)
+            .finish()
+    }
 }
 
 impl X509Validator {

--- a/mls-rs-identity-x509/src/lib.rs
+++ b/mls-rs-identity-x509/src/lib.rs
@@ -12,6 +12,7 @@ mod traits;
 mod util;
 
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 
 pub use error::*;
 pub use identity_extractor::*;
@@ -20,10 +21,18 @@ pub use traits::*;
 
 pub use mls_rs_core::identity::{CertificateChain, DerCertificate};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// X.509 certificate request in DER format.
 pub struct DerCertificateRequest(Vec<u8>);
+
+impl Debug for DerCertificateRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("DerCertificateRequest")
+            .fmt(f)
+    }
+}
 
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
 impl DerCertificateRequest {

--- a/mls-rs-provider-sqlite/src/application.rs
+++ b/mls-rs-provider-sqlite/src/application.rs
@@ -2,7 +2,10 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use std::sync::{Arc, Mutex};
+use std::{
+    fmt::{self, Debug},
+    sync::{Arc, Mutex},
+};
 
 use rusqlite::{params, Connection, OptionalExtension};
 
@@ -98,10 +101,19 @@ fn sanitize(string: &str) -> String {
     string.replace('_', "$_").replace('%', "$%")
 }
 
-#[derive(Debug, Clone, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Item {
     pub key: String,
     pub value: Vec<u8>,
+}
+
+impl Debug for Item {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Item")
+            .field("key", &self.key)
+            .field("value", &mls_rs_core::debug::pretty_bytes(&self.value))
+            .finish()
+    }
 }
 
 impl Item {

--- a/mls-rs-provider-sqlite/src/group_state.rs
+++ b/mls-rs-provider-sqlite/src/group_state.rs
@@ -7,16 +7,28 @@ use mls_rs_core::{
     mls_rs_codec::{MlsDecode, MlsEncode},
 };
 use rusqlite::{params, Connection, OptionalExtension};
-use std::sync::{Arc, Mutex};
+use std::{
+    fmt::{self, Debug},
+    sync::{Arc, Mutex},
+};
 
 use crate::SqLiteDataStorageError;
 
 pub(crate) const DEFAULT_EPOCH_RETENTION_LIMIT: u64 = 3;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct StoredEpoch {
     data: Vec<u8>,
     id: u64,
+}
+
+impl Debug for StoredEpoch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StoredEpoch")
+            .field("data", &mls_rs_core::debug::pretty_bytes(&self.data))
+            .field("id", &self.id)
+            .finish()
+    }
 }
 
 impl StoredEpoch {

--- a/mls-rs/src/extension/built_in.rs
+++ b/mls-rs/src/extension/built_in.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::extension::{ExtensionType, MlsCodecExtension};
 
@@ -27,11 +28,22 @@ use mls_rs_core::crypto::HpkePublicKey;
     all(feature = "ffi", not(test)),
     safer_ffi_gen::ffi_type(clone, opaque)
 )]
-#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 pub struct ApplicationIdExt {
     /// Application level identifier presented by this extension.
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     pub identifier: Vec<u8>,
+}
+
+impl Debug for ApplicationIdExt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApplicationIdExt")
+            .field(
+                "identifier",
+                &mls_rs_core::debug::pretty_bytes(&self.identifier),
+            )
+            .finish()
+    }
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]

--- a/mls-rs/src/external_client/builder.rs
+++ b/mls-rs/src/external_client/builder.rs
@@ -19,7 +19,10 @@ use crate::{
     tree_kem::Capabilities,
     CryptoProvider, Sealed,
 };
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    fmt::{self, Debug},
+};
 
 /// Base client configuration type when instantiating `ExternalClientBuilder`
 pub type ExternalBaseConfig = Config<Missing, DefaultMlsRules, Missing>;
@@ -467,7 +470,7 @@ impl<T: MlsConfig> ExternalClientConfig for T {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct Settings {
     pub(crate) extension_types: Vec<ExtensionType>,
     pub(crate) custom_proposal_types: Vec<ProposalType>,
@@ -475,6 +478,30 @@ pub(crate) struct Settings {
     pub(crate) external_signing_keys: HashMap<Vec<u8>, SignaturePublicKey>,
     pub(crate) max_epoch_jitter: Option<u64>,
     pub(crate) cache_proposals: bool,
+}
+
+impl Debug for Settings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Settings")
+            .field("extension_types", &self.extension_types)
+            .field("custom_proposal_types", &self.custom_proposal_types)
+            .field("protocol_versions", &self.protocol_versions)
+            .field(
+                "external_signing_keys",
+                &mls_rs_core::debug::pretty_with(|f| {
+                    f.debug_map()
+                        .entries(
+                            self.external_signing_keys
+                                .iter()
+                                .map(|(k, v)| (mls_rs_core::debug::pretty_bytes(k), v)),
+                        )
+                        .finish()
+                }),
+            )
+            .field("max_epoch_jitter", &self.max_epoch_jitter)
+            .field("cache_proposals", &self.cache_proposals)
+            .finish()
+    }
 }
 
 impl Default for Settings {

--- a/mls-rs/src/group/ciphertext_processor/sender_data_key.rs
+++ b/mls-rs/src/group/ciphertext_processor/sender_data_key.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 use zeroize::Zeroizing;
@@ -23,7 +24,7 @@ pub(crate) struct SenderData {
     pub reuse_guard: ReuseGuard,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 pub(crate) struct SenderDataAAD {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     pub group_id: Vec<u8>,
@@ -31,11 +32,33 @@ pub(crate) struct SenderDataAAD {
     pub content_type: ContentType,
 }
 
-#[derive(Debug)]
+impl Debug for SenderDataAAD {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SenderDataAAD")
+            .field(
+                "group_id",
+                &mls_rs_core::debug::pretty_group_id(&self.group_id),
+            )
+            .field("epoch", &self.epoch)
+            .field("content_type", &self.content_type)
+            .finish()
+    }
+}
+
 pub(crate) struct SenderDataKey<'a, CP: CipherSuiteProvider> {
     pub(crate) key: Zeroizing<Vec<u8>>,
     pub(crate) nonce: Zeroizing<Vec<u8>>,
     cipher_suite_provider: &'a CP,
+}
+
+impl<CP: CipherSuiteProvider + Debug> Debug for SenderDataKey<'_, CP> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SenderDataKey")
+            .field("key", &mls_rs_core::debug::pretty_bytes(&self.key))
+            .field("nonce", &mls_rs_core::debug::pretty_bytes(&self.nonce))
+            .field("cipher_suite_provider", self.cipher_suite_provider)
+            .finish()
+    }
 }
 
 impl<'a, CP: CipherSuiteProvider> SenderDataKey<'a, CP> {

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -4,6 +4,7 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::{
     crypto::{CipherSuiteProvider, SignatureSecretKey},
@@ -73,13 +74,21 @@ pub(super) struct CommitGeneration {
     pub commit_message_hash: CommitHash,
 }
 
-#[derive(Clone, PartialEq, Debug, MlsEncode, MlsDecode, MlsSize)]
+#[derive(Clone, PartialEq, MlsEncode, MlsDecode, MlsSize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct CommitHash(
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for CommitHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("CommitHash")
+            .fmt(f)
+    }
+}
 
 impl CommitHash {
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]

--- a/mls-rs/src/group/confirmation_tag.rs
+++ b/mls-rs/src/group/confirmation_tag.rs
@@ -5,11 +5,14 @@
 use crate::CipherSuiteProvider;
 use crate::{client::MlsError, group::transcript_hash::ConfirmedTranscriptHash};
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 
-#[derive(Debug, Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfirmationTag(
@@ -17,6 +20,14 @@ pub struct ConfirmationTag(
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for ConfirmationTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("ConfirmationTag")
+            .fmt(f)
+    }
+}
 
 impl Deref for ConfirmationTag {
     type Target = Vec<u8>;

--- a/mls-rs/src/group/context.rs
+++ b/mls-rs/src/group/context.rs
@@ -4,13 +4,14 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
 use crate::{cipher_suite::CipherSuite, protocol_version::ProtocolVersion, ExtensionList};
 
 use super::ConfirmedTranscriptHash;
 
-#[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     all(feature = "ffi", not(test)),
@@ -29,6 +30,26 @@ pub struct GroupContext {
     pub(crate) tree_hash: Vec<u8>,
     pub(crate) confirmed_transcript_hash: ConfirmedTranscriptHash,
     pub(crate) extensions: ExtensionList,
+}
+
+impl Debug for GroupContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GroupContext")
+            .field("protocol_version", &self.protocol_version)
+            .field("cipher_suite", &self.cipher_suite)
+            .field(
+                "group_id",
+                &mls_rs_core::debug::pretty_group_id(&self.group_id),
+            )
+            .field("epoch", &self.epoch)
+            .field(
+                "tree_hash",
+                &mls_rs_core::debug::pretty_bytes(&self.tree_hash),
+            )
+            .field("confirmed_transcript_hash", &self.confirmed_transcript_hash)
+            .field("extensions", &self.extensions)
+            .finish()
+    }
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]

--- a/mls-rs/src/group/epoch.rs
+++ b/mls-rs/src/group/epoch.rs
@@ -9,7 +9,10 @@ use crate::tree_kem::node::NodeIndex;
 #[cfg(feature = "prior_epoch")]
 use crate::{crypto::SignaturePublicKey, group::GroupContext, tree_kem::node::LeafIndex};
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use zeroize::Zeroizing;
 
@@ -73,13 +76,21 @@ pub(crate) struct EpochSecrets {
     pub(crate) secret_tree: SecretTree<NodeIndex>,
 }
 
-#[derive(Clone, Debug, PartialEq, MlsEncode, MlsDecode, MlsSize)]
+#[derive(Clone, PartialEq, MlsEncode, MlsDecode, MlsSize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct SenderDataSecret(
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::zeroizing_serde"))]
     Zeroizing<Vec<u8>>,
 );
+
+impl Debug for SenderDataSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("SenderDataSecret")
+            .fmt(f)
+    }
+}
 
 impl AsRef<[u8]> for SenderDataSecret {
     fn as_ref(&self) -> &[u8] {

--- a/mls-rs/src/group/framing.rs
+++ b/mls-rs/src/group/framing.rs
@@ -12,6 +12,7 @@ use super::{Commit, FramedContentAuthData, GroupInfo, MembershipTag, Welcome};
 use crate::{group::Proposal, mls_rules::ProposalRef};
 
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::{
     crypto::{CipherSuite, CipherSuiteProvider},
@@ -86,7 +87,7 @@ impl From<u32> for Sender {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode, ZeroizeOnDrop)]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode, ZeroizeOnDrop)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ApplicationData(
@@ -94,6 +95,14 @@ pub struct ApplicationData(
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for ApplicationData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("ApplicationData")
+            .fmt(f)
+    }
+}
 
 impl From<Vec<u8>> for ApplicationData {
     fn from(data: Vec<u8>) -> Self {
@@ -251,7 +260,7 @@ impl PrivateMessageContent {
 }
 
 #[cfg(feature = "private_message")]
-#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 pub struct PrivateContentAAD {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     pub group_id: Vec<u8>,
@@ -262,7 +271,25 @@ pub struct PrivateContentAAD {
 }
 
 #[cfg(feature = "private_message")]
-#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
+impl Debug for PrivateContentAAD {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PrivateContentAAD")
+            .field(
+                "group_id",
+                &mls_rs_core::debug::pretty_group_id(&self.group_id),
+            )
+            .field("epoch", &self.epoch)
+            .field("content_type", &self.content_type)
+            .field(
+                "authenticated_data",
+                &mls_rs_core::debug::pretty_bytes(&self.authenticated_data),
+            )
+            .finish()
+    }
+}
+
+#[cfg(feature = "private_message")]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct PrivateMessage {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
@@ -275,6 +302,32 @@ pub struct PrivateMessage {
     pub encrypted_sender_data: Vec<u8>,
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     pub ciphertext: Vec<u8>,
+}
+
+#[cfg(feature = "private_message")]
+impl Debug for PrivateMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PrivateMessage")
+            .field(
+                "group_id",
+                &mls_rs_core::debug::pretty_group_id(&self.group_id),
+            )
+            .field("epoch", &self.epoch)
+            .field("content_type", &self.content_type)
+            .field(
+                "authenticated_data",
+                &mls_rs_core::debug::pretty_bytes(&self.authenticated_data),
+            )
+            .field(
+                "encrypted_sender_data",
+                &mls_rs_core::debug::pretty_bytes(&self.encrypted_sender_data),
+            )
+            .field(
+                "ciphertext",
+                &mls_rs_core::debug::pretty_bytes(&self.ciphertext),
+            )
+            .finish()
+    }
 }
 
 #[cfg(feature = "private_message")]
@@ -513,7 +566,7 @@ pub enum WireFormat {
     KeyPackage = 5u16,
 }
 
-#[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct FramedContent {
@@ -526,6 +579,24 @@ pub(crate) struct FramedContent {
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     pub authenticated_data: Vec<u8>,
     pub content: Content,
+}
+
+impl Debug for FramedContent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FramedContent")
+            .field(
+                "group_id",
+                &mls_rs_core::debug::pretty_group_id(&self.group_id),
+            )
+            .field("epoch", &self.epoch)
+            .field("sender", &self.sender)
+            .field(
+                "authenticated_data",
+                &mls_rs_core::debug::pretty_bytes(&self.authenticated_data),
+            )
+            .field("content", &self.content)
+            .finish()
+    }
 }
 
 impl FramedContent {

--- a/mls-rs/src/group/group_info.rs
+++ b/mls-rs/src/group/group_info.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::extension::ExtensionList;
 
@@ -10,7 +11,7 @@ use crate::{signer::Signable, tree_kem::node::LeafIndex};
 
 use super::{ConfirmationTag, GroupContext};
 
-#[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     all(feature = "ffi", not(test)),
@@ -23,6 +24,21 @@ pub struct GroupInfo {
     pub(crate) signer: LeafIndex,
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     pub(crate) signature: Vec<u8>,
+}
+
+impl Debug for GroupInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GroupInfo")
+            .field("group_context", &self.group_context)
+            .field("extensions", &self.extensions)
+            .field("confirmation_tag", &self.confirmation_tag)
+            .field("signer", &self.signer)
+            .field(
+                "signature",
+                &mls_rs_core::debug::pretty_bytes(&self.signature),
+            )
+            .finish()
+    }
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]

--- a/mls-rs/src/group/membership_tag.rs
+++ b/mls-rs/src/group/membership_tag.rs
@@ -7,7 +7,10 @@ use crate::crypto::CipherSuiteProvider;
 use crate::group::message_signature::{AuthenticatedContentTBS, FramedContentAuthData};
 use crate::group::GroupContext;
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 
@@ -35,9 +38,17 @@ impl<'a> AuthenticatedContentTBM<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MembershipTag(#[mls_codec(with = "mls_rs_codec::byte_vec")] Vec<u8>);
+
+impl Debug for MembershipTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("MembershipTag")
+            .fmt(f)
+    }
+}
 
 impl Deref for MembershipTag {
     type Target = Vec<u8>;

--- a/mls-rs/src/group/message_processor.rs
+++ b/mls-rs/src/group/message_processor.rs
@@ -32,6 +32,7 @@ use crate::{
 #[cfg(mls_build_async)]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_core::{
     identity::IdentityProvider, protocol_version::ProtocolVersion, psk::PreSharedKeyStorage,
 };
@@ -238,7 +239,7 @@ impl From<KeyPackage> for ReceivedMessage {
     all(feature = "ffi", not(test)),
     safer_ffi_gen::ffi_type(clone, opaque)
 )]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 /// Description of a MLS application message.
 pub struct ApplicationMessageDescription {
     /// Index of this user in the group state.
@@ -247,6 +248,19 @@ pub struct ApplicationMessageDescription {
     data: ApplicationData,
     /// Plaintext authenticated data in the received MLS packet.
     pub authenticated_data: Vec<u8>,
+}
+
+impl Debug for ApplicationMessageDescription {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApplicationMessageDescription")
+            .field("sender_index", &self.sender_index)
+            .field("data", &self.data)
+            .field(
+                "authenticated_data",
+                &mls_rs_core::debug::pretty_bytes(&self.authenticated_data),
+            )
+            .finish()
+    }
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
@@ -260,7 +274,7 @@ impl ApplicationMessageDescription {
     all(feature = "ffi", not(test)),
     safer_ffi_gen::ffi_type(clone, opaque)
 )]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 #[non_exhaustive]
 /// Description of a processed MLS commit message.
 pub struct CommitMessageDescription {
@@ -272,6 +286,20 @@ pub struct CommitMessageDescription {
     pub state_update: StateUpdate,
     /// Plaintext authenticated data in the received MLS packet.
     pub authenticated_data: Vec<u8>,
+}
+
+impl Debug for CommitMessageDescription {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CommitMessageDescription")
+            .field("is_external", &self.is_external)
+            .field("committer", &self.committer)
+            .field("state_update", &self.state_update)
+            .field(
+                "authenticated_data",
+                &mls_rs_core::debug::pretty_bytes(&self.authenticated_data),
+            )
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -306,7 +334,7 @@ impl TryFrom<Sender> for ProposalSender {
     all(feature = "ffi", not(test)),
     safer_ffi_gen::ffi_type(clone, opaque)
 )]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[non_exhaustive]
 /// Description of a processed MLS proposal message.
 pub struct ProposalMessageDescription {
@@ -318,6 +346,21 @@ pub struct ProposalMessageDescription {
     pub authenticated_data: Vec<u8>,
     /// Proposal reference.
     pub proposal_ref: ProposalRef,
+}
+
+#[cfg(feature = "by_ref_proposal")]
+impl Debug for ProposalMessageDescription {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProposalMessageDescription")
+            .field("sender", &self.sender)
+            .field("proposal", &self.proposal)
+            .field(
+                "authenticated_data",
+                &mls_rs_core::debug::pretty_bytes(&self.authenticated_data),
+            )
+            .field("proposal_ref", &self.proposal_ref)
+            .finish()
+    }
 }
 
 #[cfg(feature = "by_ref_proposal")]

--- a/mls-rs/src/group/message_signature.rs
+++ b/mls-rs/src/group/message_signature.rs
@@ -11,7 +11,10 @@ use crate::signer::Signable;
 use crate::CipherSuiteProvider;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::protocol_version::ProtocolVersion;
 
@@ -233,7 +236,7 @@ impl<'a> Signable<'a> for AuthenticatedContent {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MessageSignature(
@@ -241,6 +244,14 @@ pub struct MessageSignature(
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for MessageSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("MessageSignature")
+            .fmt(f)
+    }
+}
 
 impl MessageSignature {
     pub(crate) fn empty() -> Self {

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2,9 +2,9 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 use mls_rs_core::secret::Secret;
@@ -95,7 +95,6 @@ use self::proposal_ref::ProposalRef;
 use self::state_repo::GroupStateRepository;
 pub(crate) use group_info::GroupInfo;
 
-use self::framing::MlsMessage;
 pub use self::framing::{ContentType, Sender};
 pub use commit::*;
 pub use context::GroupContext;
@@ -188,13 +187,26 @@ pub(crate) struct EncryptedGroupSecrets {
     pub encrypted_group_secrets: HpkeCiphertext,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, Eq, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub(crate) struct Welcome {
     pub cipher_suite: CipherSuite,
     pub secrets: Vec<EncryptedGroupSecrets>,
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     pub encrypted_group_info: Vec<u8>,
+}
+
+impl Debug for Welcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Welcome")
+            .field("cipher_suite", &self.cipher_suite)
+            .field("secrets", &self.secrets)
+            .field(
+                "encrypted_group_info",
+                &mls_rs_core::debug::pretty_bytes(&self.encrypted_group_info),
+            )
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -35,6 +35,9 @@ use mls_rs_core::{
 };
 
 #[cfg(feature = "by_ref_proposal")]
+use core::fmt::{self, Debug};
+
+#[cfg(feature = "by_ref_proposal")]
 #[derive(Debug, Clone, MlsSize, MlsEncode, MlsDecode, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CachedProposal {
@@ -43,7 +46,7 @@ pub struct CachedProposal {
 }
 
 #[cfg(feature = "by_ref_proposal")]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub(crate) struct ProposalCache {
     protocol_version: ProtocolVersion,
     group_id: Vec<u8>,
@@ -51,6 +54,20 @@ pub(crate) struct ProposalCache {
     pub(crate) proposals: HashMap<ProposalRef, CachedProposal>,
     #[cfg(not(feature = "std"))]
     pub(crate) proposals: Vec<(ProposalRef, CachedProposal)>,
+}
+
+#[cfg(feature = "by_ref_proposal")]
+impl Debug for ProposalCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProposalCache")
+            .field("protocol_version", &self.protocol_version)
+            .field(
+                "group_id",
+                &mls_rs_core::debug::pretty_group_id(&self.group_id),
+            )
+            .field("proposals", &self.proposals)
+            .finish()
+    }
 }
 
 #[cfg(feature = "by_ref_proposal")]

--- a/mls-rs/src/group/proposal_ref.rs
+++ b/mls-rs/src/group/proposal_ref.rs
@@ -49,6 +49,7 @@ impl ProposalRef {
 pub(crate) mod test_utils {
     use super::*;
     use crate::group::test_utils::{random_bytes, TEST_GROUP};
+    use alloc::boxed::Box;
 
     impl ProposalRef {
         pub fn new_fake(bytes: Vec<u8>) -> Self {
@@ -86,6 +87,7 @@ mod test {
         key_package::test_utils::test_key_package,
         tree_kem::leaf_node::test_utils::get_basic_test_node,
     };
+    use alloc::boxed::Box;
 
     use crate::extension::RequiredCapabilitiesExt;
 

--- a/mls-rs/src/group/state_repo.rs
+++ b/mls-rs/src/group/state_repo.rs
@@ -7,6 +7,7 @@ use crate::{group::PriorEpoch, key_package::KeyPackageRef};
 
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_core::{error::IntoAnyError, group::GroupStateStorage, key_package::KeyPackageStorage};
 
 use super::snapshot::Snapshot;
@@ -25,7 +26,7 @@ struct EpochStorageCommit {
     pub(crate) updates: Vec<PriorEpoch>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct GroupStateRepository<S, K>
 where
     S: GroupStateStorage,
@@ -36,6 +37,28 @@ where
     group_id: Vec<u8>,
     storage: S,
     key_package_repo: K,
+}
+
+impl<S, K> Debug for GroupStateRepository<S, K>
+where
+    S: GroupStateStorage + Debug,
+    K: KeyPackageStorage + Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GroupStateRepository")
+            .field("pending_commit", &self.pending_commit)
+            .field(
+                "pending_key_package_removal",
+                &self.pending_key_package_removal,
+            )
+            .field(
+                "group_id",
+                &mls_rs_core::debug::pretty_group_id(&self.group_id),
+            )
+            .field("storage", &self.storage)
+            .field("key_package_repo", &self.key_package_repo)
+            .finish()
+    }
 }
 
 impl<S, K> GroupStateRepository<S, K>

--- a/mls-rs/src/group/transcript_hash.rs
+++ b/mls-rs/src/group/transcript_hash.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::{crypto::CipherSuiteProvider, error::IntoAnyError};
@@ -16,7 +19,7 @@ use crate::{
 
 use super::{AuthenticatedContent, ConfirmationTag};
 
-#[derive(Debug, Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfirmedTranscriptHash(
@@ -24,6 +27,14 @@ pub struct ConfirmedTranscriptHash(
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for ConfirmedTranscriptHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("ConfirmedTranscriptHash")
+            .fmt(f)
+    }
+}
 
 impl Deref for ConfirmedTranscriptHash {
     type Target = Vec<u8>;
@@ -73,13 +84,21 @@ impl ConfirmedTranscriptHash {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct InterimTranscriptHash(
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for InterimTranscriptHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("InterimTranscriptHash")
+            .fmt(f)
+    }
+}
 
 impl Deref for InterimTranscriptHash {
     type Target = Vec<u8>;

--- a/mls-rs/src/hash_reference.rs
+++ b/mls-rs/src/hash_reference.rs
@@ -2,7 +2,10 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 
 use crate::client::MlsError;
 use crate::CipherSuiteProvider;
@@ -10,7 +13,7 @@ use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 
-#[derive(Debug, MlsSize, MlsEncode)]
+#[derive(MlsSize, MlsEncode)]
 struct RefHashInput<'a> {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     pub label: &'a [u8],
@@ -18,7 +21,16 @@ struct RefHashInput<'a> {
     pub value: &'a [u8],
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, MlsSize, MlsEncode, MlsDecode)]
+impl Debug for RefHashInput<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RefHashInput")
+            .field("label", &mls_rs_core::debug::pretty_bytes(self.label))
+            .field("value", &mls_rs_core::debug::pretty_bytes(self.value))
+            .finish()
+    }
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HashReference(
@@ -26,6 +38,14 @@ pub struct HashReference(
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for HashReference {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("HashReference")
+            .fmt(f)
+    }
+}
 
 impl Deref for HashReference {
     type Target = [u8];

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -12,7 +12,10 @@ use crate::signer::Signable;
 use crate::tree_kem::leaf_node::{LeafNode, LeafNodeSource};
 use crate::CipherSuiteProvider;
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 use mls_rs_codec::MlsDecode;
 use mls_rs_codec::MlsEncode;
 use mls_rs_codec::MlsSize;
@@ -25,7 +28,7 @@ pub(crate) mod generator;
 pub(crate) use generator::*;
 
 #[non_exhaustive]
-#[derive(Clone, Debug, MlsSize, MlsEncode, MlsDecode, PartialEq)]
+#[derive(Clone, MlsSize, MlsEncode, MlsDecode, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     all(feature = "ffi", not(test)),
@@ -41,6 +44,22 @@ pub struct KeyPackage {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     pub signature: Vec<u8>,
+}
+
+impl Debug for KeyPackage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeyPackage")
+            .field("version", &self.version)
+            .field("cipher_suite", &self.cipher_suite)
+            .field("hpke_init_key", &self.hpke_init_key)
+            .field("leaf_node", &self.leaf_node)
+            .field("extensions", &self.extensions)
+            .field(
+                "signature",
+                &mls_rs_core::debug::pretty_bytes(&self.signature),
+            )
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, MlsSize, MlsEncode, MlsDecode)]

--- a/mls-rs/src/psk.rs
+++ b/mls-rs/src/psk.rs
@@ -14,6 +14,7 @@ use mls_rs_core::psk::PreSharedKeyStorage;
 
 #[cfg(any(test, feature = "external_client"))]
 use core::convert::Infallible;
+use core::fmt::{self, Debug};
 
 #[cfg(feature = "psk")]
 use crate::{client::MlsError, CipherSuiteProvider};
@@ -58,7 +59,7 @@ pub(crate) enum JustPreSharedKeyID {
     Resumption(ResumptionPsk) = 2u8,
 }
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, Eq, Hash, Ord, PartialOrd, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct PskGroupId(
@@ -67,7 +68,15 @@ pub(crate) struct PskGroupId(
     pub Vec<u8>,
 );
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, MlsSize, MlsEncode, MlsDecode)]
+impl Debug for PskGroupId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("PskGroupId")
+            .fmt(f)
+    }
+}
+
+#[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct PskNonce(
@@ -75,6 +84,14 @@ pub(crate) struct PskNonce(
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     pub Vec<u8>,
 );
+
+impl Debug for PskNonce {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("PskNonce")
+            .fmt(f)
+    }
+}
 
 #[cfg(feature = "psk")]
 impl PskNonce {

--- a/mls-rs/src/psk/secret.rs
+++ b/mls-rs/src/psk/secret.rs
@@ -4,7 +4,10 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 use mls_rs_core::crypto::CipherSuiteProvider;
 use zeroize::Zeroizing;
 
@@ -28,8 +31,16 @@ pub(crate) struct PskSecretInput {
     pub psk: PreSharedKey,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub(crate) struct PskSecret(Zeroizing<Vec<u8>>);
+
+impl Debug for PskSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("PskSecret")
+            .fmt(f)
+    }
+}
 
 #[cfg(test)]
 impl From<Vec<u8>> for PskSecret {

--- a/mls-rs/src/signer.rs
+++ b/mls-rs/src/signer.rs
@@ -3,18 +3,28 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 
 use crate::client::MlsError;
 use crate::crypto::{CipherSuiteProvider, SignaturePublicKey, SignatureSecretKey};
 
-#[derive(Debug, Clone, MlsSize, MlsEncode)]
+#[derive(Clone, MlsSize, MlsEncode)]
 struct SignContent {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     label: Vec<u8>,
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     content: Vec<u8>,
+}
+
+impl Debug for SignContent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SignContent")
+            .field("label", &mls_rs_core::debug::pretty_bytes(&self.label))
+            .field("content", &mls_rs_core::debug::pretty_bytes(&self.content))
+            .finish()
+    }
 }
 
 impl SignContent {

--- a/mls-rs/src/storage_provider/group_state.rs
+++ b/mls-rs/src/storage_provider/group_state.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::MlsEncode;
 pub use mls_rs_core::group::{EpochRecord, GroupState};
 
@@ -24,10 +25,19 @@ impl GroupState for Snapshot {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct EpochData {
     pub(crate) id: u64,
     pub(crate) data: Vec<u8>,
+}
+
+impl Debug for EpochData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EpochData")
+            .field("id", &self.id)
+            .field("data", &mls_rs_core::debug::pretty_bytes(&self.data))
+            .finish()
+    }
 }
 
 impl EpochData {

--- a/mls-rs/src/storage_provider/in_memory/group_state_storage.rs
+++ b/mls-rs/src/storage_provider/in_memory/group_state_storage.rs
@@ -10,6 +10,7 @@ use alloc::sync::Arc;
 #[cfg(mls_build_async)]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode};
 use mls_rs_core::group::{EpochRecord, GroupState, GroupStateStorage};
 #[cfg(not(target_has_atomic = "ptr"))]
@@ -31,10 +32,22 @@ use spin::Mutex;
 
 pub(crate) const DEFAULT_EPOCH_RETENTION_LIMIT: usize = 3;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct InMemoryGroupData {
     pub(crate) state_data: Vec<u8>,
     pub(crate) epoch_data: VecDeque<EpochData>,
+}
+
+impl Debug for InMemoryGroupData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InMemoryGroupData")
+            .field(
+                "state_data",
+                &mls_rs_core::debug::pretty_bytes(&self.state_data),
+            )
+            .field("epoch_data", &self.epoch_data)
+            .finish()
+    }
 }
 
 impl InMemoryGroupData {
@@ -81,7 +94,7 @@ impl InMemoryGroupData {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 /// In memory group state storage backed by a HashMap.
 ///
 /// All clones of an instance of this type share the same underlying HashMap.
@@ -91,6 +104,26 @@ pub struct InMemoryGroupStateStorage {
     #[cfg(not(feature = "std"))]
     pub(crate) inner: Arc<Mutex<BTreeMap<Vec<u8>, InMemoryGroupData>>>,
     pub(crate) max_epoch_retention: usize,
+}
+
+impl Debug for InMemoryGroupStateStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InMemoryGroupStateStorage")
+            .field(
+                "inner",
+                &mls_rs_core::debug::pretty_with(|f| {
+                    f.debug_map()
+                        .entries(
+                            self.lock()
+                                .iter()
+                                .map(|(k, v)| (mls_rs_core::debug::pretty_bytes(k), v)),
+                        )
+                        .finish()
+                }),
+            )
+            .field("max_epoch_retention", &self.max_epoch_retention)
+            .finish()
+    }
 }
 
 impl InMemoryGroupStateStorage {
@@ -115,20 +148,22 @@ impl InMemoryGroupStateStorage {
 
     /// Get the set of unique group ids that have data stored.
     pub fn stored_groups(&self) -> Vec<Vec<u8>> {
-        #[cfg(feature = "std")]
-        let res = self.inner.lock().unwrap().keys().cloned().collect();
-        #[cfg(not(feature = "std"))]
-        let res = self.inner.lock().keys().cloned().collect();
-
-        res
+        self.lock().keys().cloned().collect()
     }
 
     /// Delete all data corresponding to `group_id`.
     pub fn delete_group(&self, group_id: &[u8]) {
-        #[cfg(feature = "std")]
-        self.inner.lock().unwrap().remove(group_id);
-        #[cfg(not(feature = "std"))]
-        self.inner.lock().remove(group_id);
+        self.lock().remove(group_id);
+    }
+
+    #[cfg(feature = "std")]
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<Vec<u8>, InMemoryGroupData>> {
+        self.inner.lock().unwrap()
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn lock(&self) -> spin::mutex::MutexGuard<'_, BTreeMap<Vec<u8>, InMemoryGroupData>> {
+        self.inner.lock()
     }
 }
 
@@ -144,13 +179,8 @@ impl GroupStateStorage for InMemoryGroupStateStorage {
     type Error = mls_rs_codec::Error;
 
     async fn max_epoch_id(&self, group_id: &[u8]) -> Result<Option<u64>, Self::Error> {
-        #[cfg(feature = "std")]
-        let lock = self.inner.lock().unwrap();
-
-        #[cfg(not(feature = "std"))]
-        let lock = self.inner.lock();
-
-        Ok(lock
+        Ok(self
+            .lock()
             .get(group_id)
             .and_then(|group_data| group_data.epoch_data.back().map(|e| e.id)))
     }
@@ -159,12 +189,8 @@ impl GroupStateStorage for InMemoryGroupStateStorage {
     where
         T: mls_rs_core::group::GroupState + MlsDecode,
     {
-        #[cfg(feature = "std")]
-        let lock = self.inner.lock().unwrap();
-        #[cfg(not(feature = "std"))]
-        let lock = self.inner.lock();
-
-        lock.get(group_id)
+        self.lock()
+            .get(group_id)
             .map(|v| T::mls_decode(&mut v.state_data.as_slice()))
             .transpose()
             .map_err(Into::into)
@@ -174,13 +200,8 @@ impl GroupStateStorage for InMemoryGroupStateStorage {
     where
         T: mls_rs_core::group::EpochRecord + MlsEncode + MlsDecode,
     {
-        #[cfg(feature = "std")]
-        let lock = self.inner.lock().unwrap();
-
-        #[cfg(not(feature = "std"))]
-        let lock = self.inner.lock();
-
-        lock.get(group_id)
+        self.lock()
+            .get(group_id)
             .and_then(|group_data| group_data.get_epoch(epoch_id))
             .map(|v| T::mls_decode(&mut v.data.as_slice()))
             .transpose()
@@ -197,12 +218,7 @@ impl GroupStateStorage for InMemoryGroupStateStorage {
         ST: GroupState + MlsEncode + MlsDecode + Send + Sync,
         ET: EpochRecord + MlsEncode + MlsDecode + Send + Sync,
     {
-        #[cfg(feature = "std")]
-        let mut group_map = self.inner.lock().unwrap();
-
-        #[cfg(not(feature = "std"))]
-        let mut group_map = self.inner.lock();
-
+        let mut group_map = self.lock();
         let state_data = state.mls_encode_to_vec()?;
 
         let group_data = match group_map.entry(state.id()) {
@@ -251,12 +267,7 @@ mod tests {
 
     impl InMemoryGroupStateStorage {
         fn test_data(&self) -> InMemoryGroupData {
-            #[cfg(feature = "std")]
-            let storage = self.inner.lock().unwrap();
-            #[cfg(not(feature = "std"))]
-            let storage = self.inner.lock();
-
-            storage.get(TEST_GROUP).unwrap().clone()
+            self.lock().get(TEST_GROUP).unwrap().clone()
         }
     }
 

--- a/mls-rs/src/tree_kem/hpke_encryption.rs
+++ b/mls-rs/src/tree_kem/hpke_encryption.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsEncode, MlsSize};
 use mls_rs_core::{
     crypto::{CipherSuiteProvider, HpkeCiphertext, HpkePublicKey, HpkeSecretKey},
@@ -12,12 +13,21 @@ use zeroize::Zeroizing;
 
 use crate::client::MlsError;
 
-#[derive(Debug, Clone, MlsSize, MlsEncode)]
+#[derive(Clone, MlsSize, MlsEncode)]
 struct EncryptContext<'a> {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     label: Vec<u8>,
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     context: &'a [u8],
+}
+
+impl Debug for EncryptContext<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EncryptContext")
+            .field("label", &mls_rs_core::debug::pretty_bytes(&self.label))
+            .field("context", &mls_rs_core::debug::pretty_bytes(self.context))
+            .finish()
+    }
 }
 
 impl<'a> EncryptContext<'a> {

--- a/mls-rs/src/tree_kem/leaf_node.rs
+++ b/mls-rs/src/tree_kem/leaf_node.rs
@@ -7,6 +7,7 @@ use crate::client::MlsError;
 use crate::crypto::{CipherSuiteProvider, HpkePublicKey, HpkeSecretKey, SignatureSecretKey};
 use crate::{identity::SigningIdentity, signer::Signable, ExtensionList};
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 
@@ -20,7 +21,7 @@ pub enum LeafNodeSource {
     Commit(ParentHash) = 3u8,
 }
 
-#[derive(Debug, Clone, MlsSize, MlsEncode, MlsDecode, PartialEq)]
+#[derive(Clone, MlsSize, MlsEncode, MlsDecode, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
@@ -33,6 +34,22 @@ pub struct LeafNode {
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     pub signature: Vec<u8>,
+}
+
+impl Debug for LeafNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LeafNode")
+            .field("public_key", &self.public_key)
+            .field("signing_identity", &self.signing_identity)
+            .field("capabilities", &self.capabilities)
+            .field("leaf_node_source", &self.leaf_node_source)
+            .field("extensions", &self.extensions)
+            .field(
+                "signature",
+                &mls_rs_core::debug::pretty_bytes(&self.signature),
+            )
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/mls-rs/src/tree_kem/parent_hash.rs
+++ b/mls-rs/src/tree_kem/parent_hash.rs
@@ -8,7 +8,10 @@ use crate::tree_kem::math as tree_math;
 use crate::tree_kem::node::{LeafIndex, Node, NodeIndex};
 use crate::tree_kem::TreeKemPublic;
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 use tree_math::TreeIndex;
@@ -31,7 +34,7 @@ struct ParentHashInput<'a> {
     original_sibling_tree_hash: &'a [u8],
 }
 
-#[derive(Clone, Debug, MlsSize, MlsEncode, MlsDecode, PartialEq, Eq)]
+#[derive(Clone, MlsSize, MlsEncode, MlsDecode, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ParentHash(
@@ -39,6 +42,14 @@ pub struct ParentHash(
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for ParentHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("ParentHash")
+            .fmt(f)
+    }
+}
 
 impl From<Vec<u8>> for ParentHash {
     fn from(v: Vec<u8>) -> Self {

--- a/mls-rs/src/tree_kem/path_secret.rs
+++ b/mls-rs/src/tree_kem/path_secret.rs
@@ -7,20 +7,31 @@ use crate::crypto::{CipherSuiteProvider, HpkePublicKey, HpkeSecretKey};
 use crate::group::key_schedule::kdf_derive_secret;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::ops::Deref;
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 use zeroize::Zeroizing;
 
 use super::hpke_encryption::HpkeEncryptable;
 
-#[derive(Debug, Clone, Eq, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, Eq, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PathSecret(
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::zeroizing_serde"))]
     Zeroizing<Vec<u8>>,
 );
+
+impl Debug for PathSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("PathSecret")
+            .fmt(f)
+    }
+}
 
 impl Deref for PathSecret {
     type Target = Vec<u8>;

--- a/mls-rs/src/tree_kem/tree_hash.rs
+++ b/mls-rs/src/tree_kem/tree_hash.rs
@@ -13,6 +13,7 @@ use crate::tree_kem::TreeKemPublic;
 use alloc::collections::VecDeque;
 use alloc::vec;
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use itertools::Itertools;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
@@ -20,13 +21,21 @@ use tree_math::TreeIndex;
 
 use core::ops::Deref;
 
-#[derive(Clone, Debug, Default, MlsSize, MlsEncode, MlsDecode, PartialEq)]
+#[derive(Clone, Default, MlsSize, MlsEncode, MlsDecode, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct TreeHash(
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     Vec<u8>,
 );
+
+impl Debug for TreeHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("TreeHash")
+            .fmt(f)
+    }
+}
 
 impl Deref for TreeHash {
     type Target = [u8];

--- a/mls-rs/src/tree_kem/tree_index.rs
+++ b/mls-rs/src/tree_kem/tree_index.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use super::*;
+#[cfg(feature = "tree_index")]
+use core::fmt::{self, Debug};
 
 #[cfg(all(feature = "tree_index", feature = "custom_proposal"))]
 use crate::group::proposal::ProposalType;
@@ -29,10 +31,17 @@ use alloc::collections::BTreeSet;
 use mls_rs_core::crypto::HpkePublicKey;
 
 #[cfg(feature = "tree_index")]
-#[derive(
-    Clone, Debug, Default, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode, Hash, PartialOrd, Ord,
-)]
+#[derive(Clone, Default, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode, Hash, PartialOrd, Ord)]
 pub struct Identifier(#[mls_codec(with = "mls_rs_codec::byte_vec")] Vec<u8>);
+
+#[cfg(feature = "tree_index")]
+impl Debug for Identifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        mls_rs_core::debug::pretty_bytes(&self.0)
+            .named("Identifier")
+            .fmt(f)
+    }
+}
 
 #[cfg(all(feature = "tree_index", feature = "std"))]
 #[derive(Clone, Debug, Default, PartialEq, MlsSize, MlsEncode, MlsDecode)]


### PR DESCRIPTION
This should help reduce the noise when troubleshooting issues and debug-printing values.

By default byte arrays are written with their length only, unless the alternate debug format is requested (`"{:#?}"`), in which case the bytes are also written in hex format. Group IDs should usually be short and their bytes are always written.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
