### PR TITLE
Execute UniFFI bindings via a simple Python test

### DIFF
--- a/mls-rs-uniffi/Cargo.toml
+++ b/mls-rs-uniffi/Cargo.toml
@@ -24,3 +24,7 @@ uniffi = "0.26.0"
 
 [target.'cfg(mls_build_async)'.dependencies]
 tokio = { version = "1.36.0", features = ["sync"] }
+
+[dev-dependencies]
+tempfile = "3.10.0"
+uniffi_bindgen = "0.26.0"

--- a/mls-rs-uniffi/src/lib.rs
+++ b/mls-rs-uniffi/src/lib.rs
@@ -17,6 +17,9 @@
 //!
 //! [UniFFI]: https://mozilla.github.io/uniffi-rs/
 
+#[cfg(test)]
+pub mod test_utils;
+
 use std::sync::Arc;
 
 #[cfg(not(mls_build_async))]
@@ -570,5 +573,22 @@ impl Group {
                 Ok(ReceivedMessage::KeyPackage { key_package })
             }
         }
+    }
+}
+
+#[cfg(all(test, not(mls_build_async)))]
+mod sync_tests {
+    use crate::test_utils::run_python;
+
+    #[test]
+    fn test_generate_signature_keypair() -> Result<(), Box<dyn std::error::Error>> {
+        run_python(
+            r#"
+from mls_rs_uniffi import CipherSuite, generate_signature_keypair
+
+signature_keypair = generate_signature_keypair(CipherSuite.CURVE25519_AES128)
+assert signature_keypair.cipher_suite == CipherSuite.CURVE25519_AES128
+"#,
+        )
     }
 }

--- a/mls-rs-uniffi/src/test_utils.rs
+++ b/mls-rs-uniffi/src/test_utils.rs
@@ -1,0 +1,21 @@
+use uniffi_bindgen::bindings::python;
+
+/// Run Python code in `script`.
+///
+/// The script can use `import mls_rs_uniffi` to get access to the
+/// Python bindings.
+pub fn run_python(script: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_dir = tempfile::TempDir::with_prefix("run-python-")?;
+    let script_path = tmp_dir.path().join("script.py");
+    std::fs::write(&script_path, script)?;
+
+    python::run_script(
+        tmp_dir.path().to_str().unwrap(),
+        "mls-rs-uniffi",
+        script_path.to_str().unwrap(),
+        vec![],
+        &uniffi_bindgen::bindings::RunScriptOptions::default(),
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
### Issues:

Addresses #81

### Description of changes:

This uses the UniFFI test helpers to compile and make the `libmls_rs_uniffi.so` file available to the Python script.

The test is very simple here: it simply executes the Python script, which then has to return with a zero exit code. If it fails, the output is printed and you then have to debug the Python code by hand.

There is no facility to pass data back to the Rust unit test — it would be great to have this, but right now it's a one-way communication only.

### Call-outs:

I would have liked to use `$CARGO_TARGET_TMPDIR` to place the temporary files in a stable place under `target/`. However, this variable is only set for integration tests, not unit tests. So the script now ends up somewhere in your system temp directory.

We could decide to only use integration tests for these tests, let me know what you think! We could also write a bit more code to find a good place under `target/` without relying on the environment variable.

### Testing:

Use `cargo test`!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
