### PR TITLE
[uniffi] Enable coverage for Python tests

### DIFF
--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -57,7 +57,13 @@ jobs:
       - name: Setup code coverage
         run: cargo install cargo-llvm-cov
       - name: Run code coverage
-        run: cargo llvm-cov --lcov --features "test_util" --output-path lcov.info
+        # Using `cargo llvm-cov show-env` lets us capture coverage
+        # information from Python integration tests.
+        run: |
+          source <(cargo llvm-cov show-env --export-prefix)
+          cargo llvm-cov clean --workspace
+          cargo test --features "test_util"
+          cargo llvm-cov report --lcov --output-path lcov.info
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
Setting a few environment variables should be enough to give us coverage information for the Python integration tests. Based on

  https://github.com/taiki-e/cargo-llvm-cov#get-coverage-of-external-tests

Related to #81.

### Issues:

Addresses #81

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
