### PR TITLE
[uniffi] Add `simple_scenario` unit test

### DIFF
--- a/mls-rs-uniffi/src/config.rs
+++ b/mls-rs-uniffi/src/config.rs
@@ -9,7 +9,7 @@ use mls_rs_crypto_openssl::OpensslCryptoProvider;
 
 use self::group_state::{GroupStateStorage, GroupStateStorageWrapper};
 
-mod group_state;
+pub mod group_state;
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi(flat_error)]

--- a/mls-rs-uniffi/src/config/group_state.rs
+++ b/mls-rs-uniffi/src/config/group_state.rs
@@ -13,7 +13,7 @@ pub struct GroupState {
     pub data: Vec<u8>,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, uniffi::Record)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, uniffi::Record)]
 pub struct EpochRecord {
     /// A unique epoch identifier within a particular group.
     pub id: u64,


### PR DESCRIPTION
This simply exercises the new code from Rust. In doing so, I noticed that the `GroupState` type is inside a private module, which seems wrong or at least odd. I guess it works from Python because the privacy of types isn't enforced when calling from another language.

### Issues:

Addresses #81

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
