### PR TITLE
Added import and export functions to the GroupStateStorage api

### DIFF
--- a/mls-rs-core/src/group/group_state.rs
+++ b/mls-rs-core/src/group/group_state.rs
@@ -82,4 +82,16 @@ pub trait GroupStateStorage: Send + Sync {
     /// The [`EpochRecord::id`] value that is associated with a stored
     /// prior epoch for a particular group.
     async fn max_epoch_id(&self, group_id: &[u8]) -> Result<Option<u64>, Self::Error>;
+
+
+    async fn export_snapshot_data(
+        &self,
+        group_id: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    async fn import_snapshot_data(
+        &self,
+        group_id: &[u8],
+        group_snapshot: Vec<u8>,
+    ) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
### Issues:

Resolves #99 

### Description of changes:

Currently, there is no way to public import/export private group state from the mls crate as a whole. This PR adds import/export functionality to the GroupStateStorage trait and its implementations.

### Call-outs:

After implementing this. I'm more and more convinced that perhaps option 1 in #99 would be a better approach. The current impl forces every new impl of GroupStateStorage to implement and test import/export logic which is duplicative and the inability to verify the validity of the imported bytes is particularly dangerous imo. Please let me know if you would like me to pivot to option 1.

### Testing:

Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
