### PR TITLE
[uniffi] Rename enum variants to avoid collision

### DIFF
--- a/mls-rs-uniffi/src/lib.rs
+++ b/mls-rs-uniffi/src/lib.rs
@@ -175,8 +175,10 @@ pub enum ReceivedMessage {
     /// A new commit was processed creating a new group state.
     Commit { committer: Arc<SigningIdentity> },
 
+    // TODO(mgeisler): rename to `Proposal` when
+    // https://github.com/awslabs/mls-rs/issues/98 is fixed.
     /// A proposal was received.
-    Proposal {
+    ReceivedProposal {
         sender: Arc<SigningIdentity>,
         proposal: Arc<Proposal>,
     },
@@ -186,8 +188,10 @@ pub enum ReceivedMessage {
     /// Validated welcome message.
     Welcome,
 
+    // TODO(mgeisler): rename to `KeyPackage` when
+    // https://github.com/awslabs/mls-rs/issues/98 is fixed.
     /// Validated key package.
-    KeyPackage { key_package: Arc<KeyPackage> },
+    ValidatedKeyPackage { key_package: Arc<KeyPackage> },
 }
 
 /// Supported cipher suites.
@@ -581,7 +585,7 @@ impl Group {
                     _ => todo!("External and NewMember proposal senders are not supported"),
                 };
                 let proposal = Arc::new(proposal_message.proposal.into());
-                Ok(ReceivedMessage::Proposal { sender, proposal })
+                Ok(ReceivedMessage::ReceivedProposal { sender, proposal })
             }
             // TODO: group::ReceivedMessage::GroupInfo does not have any
             // public methods (unless the "ffi" Cargo feature is set).
@@ -590,7 +594,7 @@ impl Group {
             group::ReceivedMessage::Welcome => Ok(ReceivedMessage::Welcome),
             group::ReceivedMessage::KeyPackage(key_package) => {
                 let key_package = Arc::new(key_package.into());
-                Ok(ReceivedMessage::KeyPackage { key_package })
+                Ok(ReceivedMessage::ValidatedKeyPackage { key_package })
             }
         }
     }


### PR DESCRIPTION
Because of mozilla/uniffi-rs#1853, our enum variants must have names that are different from all top-level types.

I simply added a `_`, but other ideas are of course very welcome.

### Issues:

Resolves #98

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
