### PR TITLE
Remove nightly Rust clippy test

### DIFF
--- a/.github/workflows/no_std_build.yml
+++ b/.github/workflows/no_std_build.yml
@@ -10,9 +10,6 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
       with:
         targets: thumbv6m-none-eabi
-        components: clippy
-    - name: Clippy
-      run: cargo +nightly clippy --no-default-features -p mls-rs -- -D warnings
     - name: Test
       run: cargo +nightly test --no-default-features --features test_util --verbose -p mls-rs --lib --test '*'
     - name: Test Full RFC Compliance


### PR DESCRIPTION
### Description of changes:

All PRs currently fail due to a Clippy lint:

```
warning: assigning the result of `Clone::clone()` may be inefficient
   --> mls-rs/src/tree_kem/tree_hash.rs:193:13
    |
193 |             filtered_sets[n] = filtered_sets[p as usize].clone();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `filtered_sets[n].clone_from(&filtered_sets[p as usize])`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `#[warn(clippy::assigning_clones)]` on by default
```

Trying to fix this as recommended results in a compilation error since we cannot call a mutating method on `filtered_sets` while we also read from it…

In general, Nightly Rust is a moving target (moving faster much than stable) and as such, it’s inconvenient to have Clippy fail builds due to new (experimental) lints being enabled there.

There are already two Clippy runs (using stable Rust) in the `native_build.yml` file, so I simply removed the unstable Rust run from `no_std__build.yml`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
