### PR TITLE
[Bugfix] Derive external pub extension from the new and not old key schedule

### DIFF
--- a/.github/workflows/no_std_build.yml
+++ b/.github/workflows/no_std_build.yml
@@ -7,16 +7,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
     - uses: dtolnay/rust-toolchain@nightly
       with:
         targets: thumbv6m-none-eabi
         components: clippy
     - name: Clippy
-      run: cargo +nightly clippy --no-default-features -p mls-rs -- -D warnings
+      run: cargo +stable clippy --no-default-features -p mls-rs -- -D warnings
     - name: Test
-      run: cargo +nightly test --no-default-features --features test_util --verbose -p mls-rs --lib --test '*'
+      run: cargo +stable test --no-default-features --features test_util --verbose -p mls-rs --lib --test '*'
     - name: Test Full RFC Compliance
-      run: cargo +nightly test --no-default-features --features rfc_compliant,test_util --verbose -p mls-rs
+      run: cargo +stable test --no-default-features --features rfc_compliant,test_util --verbose -p mls-rs
     - name: Build MLS Embedded
       run: cargo +nightly build --package mls-rs --lib --no-default-features --target thumbv6m-none-eabi
     - name: Build MLS Embedded Full RFC Compliance

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -644,7 +644,8 @@ where
                 let mut extensions = ExtensionList::new();
 
                 extensions.set_from({
-                    self.key_schedule
+                    key_schedule_result
+                        .key_schedule
                         .get_external_key_pair_ext(&self.cipher_suite_provider)
                         .await?
                 })?;

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -819,7 +819,7 @@ async fn fake_key_package(id: usize) -> MlsMessage {
 
 #[maybe_async::test(not(mls_build_async), async(mls_build_async, futures_test))]
 async fn external_info_from_commit_allows_to_join() {
-    let cs = CipherSuite::CURVE25519_AES128;
+    let cs = CipherSuite::P256_AES128;
     let version = ProtocolVersion::MLS_10;
 
     let mut alice = mls_rs::test_utils::get_test_groups(

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -9,6 +9,7 @@ use mls_rs::error::MlsError;
 use mls_rs::group::proposal::Proposal;
 use mls_rs::group::ReceivedMessage;
 use mls_rs::identity::SigningIdentity;
+use mls_rs::mls_rules::CommitOptions;
 use mls_rs::ExtensionList;
 use mls_rs::MlsMessage;
 use mls_rs::ProtocolVersion;
@@ -814,4 +815,32 @@ async fn fake_key_package(id: usize) -> MlsMessage {
         .generate_key_package_message()
         .await
         .unwrap()
+}
+
+#[maybe_async::test(not(mls_build_async), async(mls_build_async, futures_test))]
+async fn external_info_from_commit_allows_to_join() {
+    let cs = CipherSuite::CURVE25519_AES128;
+    let version = ProtocolVersion::MLS_10;
+
+    let mut alice = mls_rs::test_utils::get_test_groups(
+        version,
+        cs,
+        1,
+        Some(CommitOptions::new().with_allow_external_commit(true)),
+        false,
+        &TestCryptoProvider::default(),
+    )
+    .await
+    .remove(0);
+
+    let commit = alice.commit(vec![]).await.unwrap();
+    alice.apply_pending_commit().await.unwrap();
+    let bob = generate_client(cs, version, 0xdead, false).await;
+
+    let (_bob, commit) = bob
+        .commit_external(commit.external_commit_group_info.unwrap())
+        .await
+        .unwrap();
+
+    alice.process_incoming_message(commit).await.unwrap();
 }


### PR DESCRIPTION
The added test fails on main with `InvalidConfirmationTag`. The reason is generating external join info using old epoch's key schedule.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
