### PR TITLE
Add APIs to client to expose the internal storages so that they may be consulted directly.

### DIFF
--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -707,6 +707,27 @@ where
     pub fn key_package_extensions(&self) -> ExtensionList {
         self.config.key_package_extensions()
     }
+
+    /// The [KeyPackageStorage](crate::KeyPackageStorage) that
+    /// this client was configured to use.
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
+    pub fn key_package_store(&self) -> <C as ClientConfig>::KeyPackageRepository {
+        self.config.key_package_repo()
+    }
+
+    /// The [PreSharedKeyStorage](crate::PreSharedKeyStorage) that
+    /// this client was configured to use.
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
+    pub fn secret_store(&self) -> <C as ClientConfig>::PskStore {
+        self.config.secret_store()
+    }
+
+    /// The [GroupStateStorage](crate::GroupStateStorage) that
+    /// this client was configured to use.
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
+    pub fn group_state_storage(&self) -> <C as ClientConfig>::GroupStateStorage {
+        self.config.group_state_storage()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Issues:

Resolves #99 

### Description of changes:

#94 made the API for storage simply expose Vec<u8>s which is perfect for importing and exporting data. Unfortunately, there is no current way to access the underlying storage of the group other than setting a storage directly on the config builder, which requires a use of `clone` and most importantly, that the group storage being set have some kind of internal mutability. This PR adds APIs to the Client which expose the storages.

### Call-outs:

While only access to group state storage is needed for this feature, it seems prudent to expose the other storages in case they are needed in the future. I'm happy to revert those changes if we prefer however.

### Testing:

The change simply exposes some internal values, It does not therefore add any tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
