### PR TITLE
Add `client_config_default` function for easy client configuration

### DIFF
--- a/mls-rs-uniffi/src/config.rs
+++ b/mls-rs-uniffi/src/config.rs
@@ -1,12 +1,14 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
+use std::sync::Arc;
 
 use mls_rs::{
     client_builder::{self, WithGroupStateStorage},
     identity::basic,
+    storage_provider::in_memory::InMemoryGroupStateStorage,
 };
 use mls_rs_crypto_openssl::OpensslCryptoProvider;
 
-use self::group_state::GroupStateStorage;
+use self::group_state::{GroupStateStorage, GroupStateStorageAdapter};
 use crate::Error;
 
 pub mod group_state;
@@ -62,4 +64,16 @@ pub type UniFFIConfig = client_builder::WithIdentityProvider<
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct ClientConfig {
     pub group_state_storage: Arc<dyn GroupStateStorage>,
+}
+
+// TODO(mgeisler): turn into an associated function when UniFFI
+// supports them: https://github.com/mozilla/uniffi-rs/issues/1074.
+/// Create a client config with an in-memory group state storage.
+#[uniffi::export]
+pub fn client_config_default() -> ClientConfig {
+    ClientConfig {
+        group_state_storage: Arc::new(GroupStateStorageAdapter::new(
+            InMemoryGroupStateStorage::new(),
+        )),
+    }
 }

--- a/mls-rs-uniffi/src/config.rs
+++ b/mls-rs-uniffi/src/config.rs
@@ -4,30 +4,11 @@ use mls_rs::{
     client_builder::{self, WithGroupStateStorage},
     identity::basic,
 };
-use mls_rs_core::error::IntoAnyError;
 use mls_rs_crypto_openssl::OpensslCryptoProvider;
 
 use self::group_state::{GroupStateStorage, GroupStateStorageWrapper};
 
 pub mod group_state;
-
-#[derive(Debug, thiserror::Error, uniffi::Error)]
-#[uniffi(flat_error)]
-#[non_exhaustive]
-pub enum FFICallbackError {
-    #[error("data preparation error")]
-    DataPreparationError {
-        #[from]
-        inner: mls_rs_core::mls_rs_codec::Error,
-    },
-    #[error("unexpected callback error")]
-    UnexpectedCallbackError {
-        #[from]
-        inner: uniffi::UnexpectedUniFFICallbackError,
-    },
-}
-
-impl IntoAnyError for FFICallbackError {}
 
 pub type UniFFIConfig = client_builder::WithIdentityProvider<
     basic::BasicIdentityProvider,

--- a/mls-rs-uniffi/src/config.rs
+++ b/mls-rs-uniffi/src/config.rs
@@ -6,15 +6,56 @@ use mls_rs::{
 };
 use mls_rs_crypto_openssl::OpensslCryptoProvider;
 
-use self::group_state::{GroupStateStorage, GroupStateStorageWrapper};
+use self::group_state::GroupStateStorage;
+use crate::Error;
 
 pub mod group_state;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ClientGroupStorage(Arc<dyn GroupStateStorage>);
+
+impl From<Arc<dyn GroupStateStorage>> for ClientGroupStorage {
+    fn from(value: Arc<dyn GroupStateStorage>) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(mls_build_async, maybe_async::must_be_async)]
+impl mls_rs_core::group::GroupStateStorage for ClientGroupStorage {
+    type Error = Error;
+
+    async fn state(&self, group_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.0.state(group_id.to_vec())
+    }
+
+    async fn epoch(&self, group_id: &[u8], epoch_id: u64) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.0.epoch(group_id.to_vec(), epoch_id)
+    }
+
+    async fn write(
+        &mut self,
+        state: mls_rs_core::group::GroupState,
+        inserts: Vec<mls_rs_core::group::EpochRecord>,
+        updates: Vec<mls_rs_core::group::EpochRecord>,
+    ) -> Result<(), Self::Error> {
+        self.0.write(
+            state.into(),
+            inserts.into_iter().map(Into::into).collect(),
+            updates.into_iter().map(Into::into).collect(),
+        )
+    }
+
+    async fn max_epoch_id(&self, group_id: &[u8]) -> Result<Option<u64>, Self::Error> {
+        self.0.max_epoch_id(group_id.to_vec())
+    }
+}
 
 pub type UniFFIConfig = client_builder::WithIdentityProvider<
     basic::BasicIdentityProvider,
     client_builder::WithCryptoProvider<
         OpensslCryptoProvider,
-        WithGroupStateStorage<GroupStateStorageWrapper, client_builder::BaseConfig>,
+        WithGroupStateStorage<ClientGroupStorage, client_builder::BaseConfig>,
     >,
 >;
 

--- a/mls-rs-uniffi/src/config/group_state.rs
+++ b/mls-rs-uniffi/src/config/group_state.rs
@@ -1,4 +1,6 @@
+use mls_rs::error::IntoAnyError;
 use std::fmt::Debug;
+use std::sync::Mutex;
 
 use crate::Error;
 
@@ -21,20 +23,26 @@ pub struct EpochRecord {
 }
 
 impl From<mls_rs_core::group::GroupState> for GroupState {
-    fn from(value: mls_rs_core::group::GroupState) -> Self {
-        Self {
-            id: value.id,
-            data: value.data,
-        }
+    fn from(mls_rs_core::group::GroupState { id, data }: mls_rs_core::group::GroupState) -> Self {
+        Self { id, data }
+    }
+}
+
+impl From<GroupState> for mls_rs_core::group::GroupState {
+    fn from(GroupState { id, data }: GroupState) -> Self {
+        Self { id, data }
     }
 }
 
 impl From<mls_rs_core::group::EpochRecord> for EpochRecord {
-    fn from(value: mls_rs_core::group::EpochRecord) -> Self {
-        Self {
-            id: value.id,
-            data: value.data,
-        }
+    fn from(mls_rs_core::group::EpochRecord { id, data }: mls_rs_core::group::EpochRecord) -> Self {
+        Self { id, data }
+    }
+}
+
+impl From<EpochRecord> for mls_rs_core::group::EpochRecord {
+    fn from(EpochRecord { id, data }: EpochRecord) -> Self {
+        Self { id, data }
     }
 }
 
@@ -53,4 +61,63 @@ pub trait GroupStateStorage: Send + Sync + Debug {
     ) -> Result<(), Error>;
 
     async fn max_epoch_id(&self, group_id: Vec<u8>) -> Result<Option<u64>, Error>;
+}
+
+/// Adapt a mls-rs `GroupStateStorage` implementation.
+///
+/// This is used to adapt a mls-rs `GroupStateStorage` implementation
+/// to our own `GroupStateStorage` trait. This way we can use any
+/// standard mls-rs group state storage from the FFI layer.
+#[derive(Debug)]
+pub(crate) struct GroupStateStorageAdapter<S>(Mutex<S>);
+
+impl<S> GroupStateStorageAdapter<S> {
+    pub fn new(group_state_storage: S) -> GroupStateStorageAdapter<S> {
+        Self(Mutex::new(group_state_storage))
+    }
+
+    fn inner(&self) -> std::sync::MutexGuard<'_, S> {
+        self.0.lock().unwrap()
+    }
+}
+
+#[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+#[cfg_attr(mls_build_async, maybe_async::must_be_async)]
+impl<S, Err> GroupStateStorage for GroupStateStorageAdapter<S>
+where
+    S: mls_rs::GroupStateStorage<Error = Err> + Debug,
+    Err: IntoAnyError,
+{
+    async fn state(&self, group_id: Vec<u8>) -> Result<Option<Vec<u8>>, Error> {
+        self.inner()
+            .state(&group_id)
+            .map_err(|err| err.into_any_error().into())
+    }
+
+    async fn epoch(&self, group_id: Vec<u8>, epoch_id: u64) -> Result<Option<Vec<u8>>, Error> {
+        self.inner()
+            .epoch(&group_id, epoch_id)
+            .map_err(|err| err.into_any_error().into())
+    }
+
+    async fn write(
+        &self,
+        state: GroupState,
+        epoch_inserts: Vec<EpochRecord>,
+        epoch_updates: Vec<EpochRecord>,
+    ) -> Result<(), Error> {
+        self.inner()
+            .write(
+                state.into(),
+                epoch_inserts.into_iter().map(Into::into).collect(),
+                epoch_updates.into_iter().map(Into::into).collect(),
+            )
+            .map_err(|err| err.into_any_error().into())
+    }
+
+    async fn max_epoch_id(&self, group_id: Vec<u8>) -> Result<Option<u64>, Error> {
+        self.inner()
+            .max_epoch_id(&group_id)
+            .map_err(|err| err.into_any_error().into())
+    }
 }

--- a/mls-rs-uniffi/tests/client_config_default_sync.py
+++ b/mls-rs-uniffi/tests/client_config_default_sync.py
@@ -1,0 +1,8 @@
+from mls_rs_uniffi import Client, CipherSuite, generate_signature_keypair, client_config_default
+
+client_config = client_config_default()
+key = generate_signature_keypair(CipherSuite.CURVE25519_AES128)
+alice = Client(b'alice', key, client_config)
+
+group = alice.create_group(None)
+group.write_to_storage()

--- a/mls-rs-uniffi/tests/scenarios.rs
+++ b/mls-rs-uniffi/tests/scenarios.rs
@@ -43,6 +43,7 @@ macro_rules! generate_python_tests {
 }
 
 generate_python_tests!(generate_signature_keypair, None);
+generate_python_tests!(client_config_default_sync, None);
 
 // TODO(mulmarta): it'll break if we use async trait which will be
 // supported in the next UniFFI release


### PR DESCRIPTION
### Issues:

Addresses #81.

### Description of changes:

The goal of this PR is to simply the steps needed to setup a simple client. It adds a new function which returns a default client config with an in-memory group state storage backend.

The new `GroupStateStorageAdapter` struct allows us to use any mls-rs group state storage, so we could easily surface the Sqlite storage as well now.

Since I was working with the storage trait, I also took the opportunity to flatten the errors a little. Right now, we don't seem to have a use case for separate errors, so I feel this makes things a little simpler overall.

### Testing:

New Python integration test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
