### PR TITLE
[uniffi] Remove `KeyPackage` from the API

### DIFF
--- a/mls-rs-uniffi/tests/simple_scenario_sync.py
+++ b/mls-rs-uniffi/tests/simple_scenario_sync.py
@@ -70,11 +70,6 @@ bob = Client(b'bob', key, client_config)
 
 alice = alice.create_group(None)
 message = bob.generate_key_package_message()
-key_package = message.into_key_package()
-assert key_package.version() == ProtocolVersion.MLS10
-assert key_package.cipher_suite() == CipherSuite.CURVE25519_AES128
-assert len(key_package.hpke_init_key().key) == 32
-assert len(key_package.signature()) == 64
 
 commit = alice.add_members([message])
 alice.process_incoming_message(commit.commit_message())


### PR DESCRIPTION
### Issues:

Addresses #81

### Description of changes:

We don’t think people will need to access the key packages and their fields. As an example, when adding members to a group, you use messages, not key packages.

Related to #81, reverts most of #102. I left the `ProtocolVersion` behind, but I can remove it too if people think we don’t need it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
