### PR TITLE
[uniffi] Turn more types into UniFFI records

### DIFF
--- a/mls-rs-uniffi/src/lib.rs
+++ b/mls-rs-uniffi/src/lib.rs
@@ -388,46 +388,18 @@ impl Client {
     }
 }
 
-#[derive(Clone, Debug, uniffi::Object)]
+#[derive(Clone, Debug, uniffi::Record)]
 pub struct RatchetTree {
-    inner: mls_rs::group::ExportedTree<'static>,
+    pub bytes: Vec<u8>,
 }
 
-impl From<mls_rs::group::ExportedTree<'static>> for RatchetTree {
-    fn from(inner: mls_rs::group::ExportedTree<'static>) -> Self {
-        Self { inner }
-    }
-}
+impl TryFrom<mls_rs::group::ExportedTree<'static>> for RatchetTree {
+    type Error = Error;
 
-#[uniffi::export]
-impl RatchetTree {
-    /// Encode the ratchet tree in MLS encoding.
-    pub fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        self.inner.to_bytes().map_err(Into::into)
+    fn try_from(exported_tree: mls_rs::group::ExportedTree<'static>) -> Result<Self, Error> {
+        let bytes = exported_tree.to_bytes()?;
+        Ok(Self { bytes })
     }
-
-    /// Return size of ratchet tree in MLS encoding.
-    pub fn byte_size(&self) -> u64 {
-        self.inner.byte_size().try_into().unwrap()
-    }
-}
-
-impl RatchetTree {
-    // TODO(mgeisler): merge with #[uniffi::export] impl above when
-    // https://github.com/mozilla/uniffi-rs/issues/1074 is fixed.
-    /// Decode a ratched tree from its MLS encoding.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let exported_tree = mls_rs::group::ExportedTree::from_bytes(bytes)?;
-        Ok(exported_tree.into())
-    }
-}
-
-// TODO(mgeisler): remove this when associated functions are supported
-// by UniFFI: https://github.com/mozilla/uniffi-rs/issues/1074.
-#[uniffi::export]
-/// Decode a ratched tree from its MLS encoding.
-pub fn ratchet_tree_from_bytes(bytes: &[u8]) -> Result<RatchetTree, Error> {
-    RatchetTree::from_bytes(bytes)
 }
 
 #[derive(Clone, Debug, uniffi::Record)]
@@ -440,7 +412,7 @@ pub struct CommitOutput {
 
     /// Ratchet tree that can be sent out of band if the ratchet tree
     /// extension is not used.
-    pub ratchet_tree: Option<Arc<RatchetTree>>,
+    pub ratchet_tree: Option<RatchetTree>,
 
     /// A group info that can be provided to new members in order to
     /// enable external commit functionality.
@@ -449,8 +421,10 @@ pub struct CommitOutput {
     // as well.
 }
 
-impl From<mls_rs::group::CommitOutput> for CommitOutput {
-    fn from(commit_output: mls_rs::group::CommitOutput) -> Self {
+impl TryFrom<mls_rs::group::CommitOutput> for CommitOutput {
+    type Error = Error;
+
+    fn try_from(commit_output: mls_rs::group::CommitOutput) -> Result<Self, Error> {
         let commit_message = Arc::new(commit_output.commit_message.into());
         let welcome_messages = commit_output
             .welcome_messages
@@ -459,17 +433,18 @@ impl From<mls_rs::group::CommitOutput> for CommitOutput {
             .collect::<Vec<_>>();
         let ratchet_tree = commit_output
             .ratchet_tree
-            .map(|ratchet_tree| Arc::new(ratchet_tree.into()));
+            .map(TryInto::try_into)
+            .transpose()?;
         let group_info = commit_output
             .external_commit_group_info
             .map(|group_info| Arc::new(group_info.into()));
 
-        Self {
+        Ok(Self {
             commit_message,
             welcome_messages,
             ratchet_tree,
             group_info,
-        }
+        })
     }
 }
 
@@ -551,7 +526,7 @@ impl Group {
     pub async fn commit(&self) -> Result<CommitOutput, Error> {
         let mut group = self.inner().await;
         let commit_output = group.commit(Vec::new()).await?;
-        Ok(commit_output.into())
+        commit_output.try_into()
     }
 
     /// Commit the addition of one or more members.
@@ -570,7 +545,7 @@ impl Group {
             commit_builder = commit_builder.add_member(arc_unwrap_or_clone(key_package).inner)?;
         }
         let commit_output = commit_builder.build().await?;
-        Ok(commit_output.into())
+        commit_output.try_into()
     }
 
     /// Propose to add one or more members to this group.
@@ -619,7 +594,7 @@ impl Group {
             commit_builder = commit_builder.remove_member(index)?;
         }
         let commit_output = commit_builder.build().await?;
-        Ok(commit_output.into())
+        commit_output.try_into()
     }
 
     /// Propose to remove one or more members from this group.

--- a/mls-rs-uniffi/tests/simple_scenario_sync.py
+++ b/mls-rs-uniffi/tests/simple_scenario_sync.py
@@ -72,8 +72,8 @@ alice = alice.create_group(None)
 message = bob.generate_key_package_message()
 
 commit = alice.add_members([message])
-alice.process_incoming_message(commit.commit_message())
-bob = bob.join_group(commit.welcome_messages()[0]).group
+alice.process_incoming_message(commit.commit_message)
+bob = bob.join_group(commit.welcome_messages[0]).group
 
 msg = alice.encrypt_application_message(b'hello, bob')
 output = bob.process_incoming_message(msg)


### PR DESCRIPTION
### Issues:

Addresses #81.

### Description of changes:

As discussed in https://github.com/awslabs/mls-rs/pull/112#issuecomment-1994270332 onwards, the Kotlin code generated by UniFFI becomes simpler when we use `uniffi::Record` instead of `uniffi::Object`. This PR turns `CommitOutput`, `SignaturePublicKey`, `SignatureSecretKey`, and `RatchetTree` into records.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
