### PR TITLE
Modify state storage to handle multiple members in the same group

### DIFF
--- a/mls-rs-uniffi/src/lib.rs
+++ b/mls-rs-uniffi/src/lib.rs
@@ -526,9 +526,9 @@ async fn signing_identity_to_identifier(
 impl Group {
     /// Write the current state of the group to storage defined by
     /// [`ClientConfig::group_state_storage`]
-    pub async fn write_to_storage(&self) -> Result<(), Error> {
+    pub async fn write_to_storage(&self) -> Result<Vec<u8>, Error> {
         let mut group = self.inner().await;
-        group.write_to_storage().await.map_err(Into::into)
+        Ok(group.write_to_storage().await?.to_vec())
     }
 
     /// Perform a commit of received proposals (or an empty commit).

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -606,11 +606,11 @@ where
     /// this client was configured to use.
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     #[inline(never)]
-    pub async fn load_group(&self, group_id: &[u8]) -> Result<Group<C>, MlsError> {
+    pub async fn load_group(&self, group_state_id: &[u8]) -> Result<Group<C>, MlsError> {
         let snapshot = self
             .config
             .group_state_storage()
-            .state(group_id)
+            .state(group_state_id)
             .await
             .map_err(|e| MlsError::GroupStorageError(e.into_any_error()))?
             .ok_or(MlsError::GroupNotFound)?;

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -259,6 +259,13 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             )
             .await?;
 
+        #[cfg(feature = "prior_epoch")]
+        {
+            let repo = &mut group.state_repo;
+            let id = &group.state.context.group_id;
+            repo.set_group_state_id(id, group.private_tree.self_index)?;
+        }
+
         group.apply_pending_commit().await?;
 
         Ok((group, commit_output.commit_message))


### PR DESCRIPTION
In general, there is no reason why a storage can't support multiple members in a single group. The new group state identifier is therefore `(group_id, leaf_index)` instead of just `group_id`.

Group states stored in the old way can be recovered using `load_group(group_id)`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
