### PR TITLE
[uniffi] Use mls-rs-crypto-rustcrypto by default

### DIFF
--- a/mls-rs-uniffi/Cargo.toml
+++ b/mls-rs-uniffi/Cargo.toml
@@ -14,12 +14,18 @@ rust-version = "1.68.2"
 crate-type = ["lib", "cdylib"]
 name = "mls_rs_uniffi"
 
+[features]
+default = ["rustcrypto"]
+openssl = ["dep:mls-rs-crypto-openssl"]
+rustcrypto = ["dep:mls-rs-crypto-rustcrypto"]
+
 [dependencies]
 async-trait = "0.1.77"
 maybe-async = "0.2.10"
 mls-rs = { path = "../mls-rs" }
 mls-rs-core = { path = "../mls-rs-core" }
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl" }
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", optional = true }
+mls-rs-crypto-rustcrypto = { path = "../mls-rs-crypto-rustcrypto", optional = true }
 thiserror = "1.0.57"
 uniffi = "0.26.0"
 

--- a/mls-rs-uniffi/src/config.rs
+++ b/mls-rs-uniffi/src/config.rs
@@ -6,7 +6,6 @@ use mls_rs::{
     identity::basic,
     storage_provider::in_memory::InMemoryGroupStateStorage,
 };
-use mls_rs_crypto_openssl::OpensslCryptoProvider;
 
 use self::group_state::{GroupStateStorage, GroupStateStorageAdapter};
 use crate::Error;
@@ -53,10 +52,15 @@ impl mls_rs_core::group::GroupStateStorage for ClientGroupStorage {
     }
 }
 
+#[cfg(feature = "rustcrypto")]
+pub(crate) type UniFFICryptoProvider = mls_rs_crypto_rustcrypto::RustCryptoProvider;
+#[cfg(feature = "openssl")]
+pub(crate) type UniFFICryptoProvider = mls_rs_crypto_openssl::OpensslCryptoProvider;
+
 pub type UniFFIConfig = client_builder::WithIdentityProvider<
     basic::BasicIdentityProvider,
     client_builder::WithCryptoProvider<
-        OpensslCryptoProvider,
+        UniFFICryptoProvider,
         WithGroupStateStorage<ClientGroupStorage, client_builder::BaseConfig>,
     >,
 >;

--- a/mls-rs-uniffi/src/lib.rs
+++ b/mls-rs-uniffi/src/lib.rs
@@ -21,7 +21,7 @@ mod config;
 
 use std::sync::Arc;
 
-use config::{ClientConfig, UniFFIConfig};
+use config::{ClientConfig, UniFFIConfig, UniFFICryptoProvider};
 #[cfg(not(mls_build_async))]
 use std::sync::Mutex;
 #[cfg(mls_build_async)]
@@ -33,7 +33,6 @@ use mls_rs::identity::basic;
 use mls_rs::{CipherSuiteProvider, CryptoProvider};
 use mls_rs_core::identity;
 use mls_rs_core::identity::{BasicCredential, IdentityProvider};
-use mls_rs_crypto_openssl::OpensslCryptoProvider;
 
 uniffi::setup_scaffolding!();
 
@@ -249,7 +248,7 @@ impl TryFrom<mls_rs::CipherSuite> for CipherSuite {
 pub async fn generate_signature_keypair(
     cipher_suite: CipherSuite,
 ) -> Result<SignatureKeypair, Error> {
-    let crypto_provider = mls_rs_crypto_openssl::OpensslCryptoProvider::default();
+    let crypto_provider = UniFFICryptoProvider::default();
     let cipher_suite_provider = crypto_provider
         .cipher_suite_provider(cipher_suite.into())
         .ok_or(MlsError::UnsupportedCipherSuite(cipher_suite.into()))?;
@@ -292,7 +291,7 @@ impl Client {
         let cipher_suite = signature_keypair.cipher_suite;
         let public_key = arc_unwrap_or_clone(signature_keypair.public_key);
         let secret_key = arc_unwrap_or_clone(signature_keypair.secret_key);
-        let crypto_provider = OpensslCryptoProvider::new();
+        let crypto_provider = UniFFICryptoProvider::default();
         let basic_credential = BasicCredential::new(id);
         let signing_identity =
             identity::SigningIdentity::new(basic_credential.into_credential(), public_key.inner);


### PR DESCRIPTION
### Issues:

Addresses #81.

### Description of changes:

It is still possible to use mls-rs-crypto-openssl if one prefers this. This is controlled with two new Cargo features: “rustcrypto” and “openssl”.

I’m not sure if this is the best way to do this kind of compile-time switching, but this seems to be fairly simple while also working in my testing.

I’m of course happy to rename things if people have better ideas for the feature names!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
