### PR TITLE
[uniffi] Expose `RosterUpdate` on `Commit`

### DIFF
--- a/mls-rs-uniffi/tests/roster_update_sync.py
+++ b/mls-rs-uniffi/tests/roster_update_sync.py
@@ -1,0 +1,22 @@
+from mls_rs_uniffi import Client, CipherSuite, generate_signature_keypair, client_config_default
+
+client_config = client_config_default()
+alice = Client(b'alice', generate_signature_keypair(CipherSuite.CURVE25519_AES128), client_config)
+bob = Client(b'bob', generate_signature_keypair(CipherSuite.CURVE25519_AES128), client_config)
+carla = Client(b'carla', generate_signature_keypair(CipherSuite.CURVE25519_AES128), client_config)
+
+# Alice creates a group and adds Bob.
+alice_group = alice.create_group(None)
+output = alice_group.add_members([bob.generate_key_package_message()])
+alice_group.process_incoming_message(output.commit_message)
+
+# Bob join the group and adds Carla.
+bob_group = bob.join_group(None, output.welcome_messages[0]).group
+output = bob_group.add_members([carla.generate_key_package_message()])
+bob_group.process_incoming_message(output.commit_message)
+
+# Alice learns that Carla has been added to the group.
+received = alice_group.process_incoming_message(output.commit_message)
+assert received.roster_update.added == [carla.signing_identity()]
+assert received.roster_update.removed == []
+assert received.roster_update.updated == []

--- a/mls-rs-uniffi/tests/roster_update_sync.py
+++ b/mls-rs-uniffi/tests/roster_update_sync.py
@@ -11,7 +11,7 @@ output = alice_group.add_members([bob.generate_key_package_message()])
 alice_group.process_incoming_message(output.commit_message)
 
 # Bob join the group and adds Carla.
-bob_group = bob.join_group(None, output.welcome_messages[0]).group
+bob_group = bob.join_group(None, output.welcome_message).group
 output = bob_group.add_members([carla.generate_key_package_message()])
 bob_group.process_incoming_message(output.commit_message)
 

--- a/mls-rs-uniffi/tests/scenarios.rs
+++ b/mls-rs-uniffi/tests/scenarios.rs
@@ -50,3 +50,4 @@ generate_python_tests!(client_config_default_sync, client_config_default_async);
 generate_python_tests!(custom_storage_sync, None);
 generate_python_tests!(simple_scenario_sync, simple_scenario_async);
 generate_python_tests!(ratchet_tree_sync, ratchet_tree_async);
+generate_python_tests!(roster_update_sync, None);

--- a/mls-rs-uniffi/tests/simple_scenario_async.py
+++ b/mls-rs-uniffi/tests/simple_scenario_async.py
@@ -18,7 +18,7 @@ async def scenario():
 
     commit = await alice.add_members([message])
     await alice.process_incoming_message(commit.commit_message)
-    bob = (await bob.join_group(None, commit.welcome_messages[0])).group
+    bob = (await bob.join_group(None, commit.welcome_message)).group
 
     msg = await alice.encrypt_application_message(b'hello, bob')
     output = await bob.process_incoming_message(msg)


### PR DESCRIPTION
### Issues:

Addresses #81.

### Description of changes:

More infrastructure to let us talk about roster updates on a group.

### Call-outs:

The deep clones are potentially worry-some here. The clone in `signing_identity` is also annoying. I don't know if it'll be a problem yet, but because we cannot return borrowed data across the FFI boundary, this is probably the best we can do right now.

### Testing:

New integration test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
