### PR TITLE
[uniffi] Remove `GroupState` type from storage trait

### DIFF
--- a/mls-rs-uniffi/src/config.rs
+++ b/mls-rs-uniffi/src/config.rs
@@ -42,7 +42,8 @@ impl mls_rs_core::group::GroupStateStorage for ClientGroupStorage {
         updates: Vec<mls_rs_core::group::EpochRecord>,
     ) -> Result<(), Self::Error> {
         self.0.write(
-            state.into(),
+            state.id,
+            state.data,
             inserts.into_iter().map(Into::into).collect(),
             updates.into_iter().map(Into::into).collect(),
         )

--- a/mls-rs-uniffi/src/lib.rs
+++ b/mls-rs-uniffi/src/lib.rs
@@ -704,7 +704,7 @@ impl Group {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::group_state::{EpochRecord, GroupState, GroupStateStorage};
+    use crate::config::group_state::{EpochRecord, GroupStateStorage};
     use std::collections::HashMap;
 
     #[test]
@@ -754,14 +754,15 @@ mod tests {
 
             fn write(
                 &self,
-                state: GroupState,
+                group_id: Vec<u8>,
+                group_state: Vec<u8>,
                 epoch_inserts: Vec<EpochRecord>,
                 epoch_updates: Vec<EpochRecord>,
             ) -> Result<(), Error> {
                 let mut groups = self.lock();
 
-                let group = groups.entry(state.id).or_default();
-                group.state = state.data;
+                let group = groups.entry(group_id).or_default();
+                group.state = group_state;
                 for insert in epoch_inserts {
                     group.epoch_data.push(insert);
                 }

--- a/mls-rs-uniffi/tests/simple_scenario_sync.py
+++ b/mls-rs-uniffi/tests/simple_scenario_sync.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 
 from mls_rs_uniffi import CipherSuite, generate_signature_keypair, Client, \
-    GroupStateStorage, GroupState, EpochRecord, ClientConfig, ProtocolVersion
+    GroupStateStorage, EpochRecord, ClientConfig, ProtocolVersion
 
 @dataclass
 class GroupStateData:
@@ -32,11 +32,11 @@ class PythonGroupStateStorage(GroupStateStorage):
 
         return None
 
-    def write(self, state: GroupState, epoch_inserts: list[EpochRecord], epoch_updates: list[EpochRecord]):
-        if self.groups.get(state.id.hex()) == None:
-            self.groups[state.id.hex()] = GroupStateData(state.data)
+    def write(self, group_id: bytes, group_state: bytes, epoch_inserts: list[EpochRecord], epoch_updates: list[EpochRecord]):
+        if self.groups.get(group_id.hex()) == None:
+            self.groups[group_id.hex()] = GroupStateData(group_state)
 
-        group = self.groups[state.id.hex()]
+        group = self.groups[group_id.hex()]
 
         for insert in epoch_inserts:
             group.epoch_data.append(insert)


### PR DESCRIPTION
### Issues:

Addresses #81 

### Description of changes:

This removes the `GroupState` type from the `GroupStateStorage` trait in mls-rs-uniffi. This is done for two reasons:

- It makes all methods on the trait consistent in the way that they take a `group_id` as the first argument.

- Fewer types means less boiler-plate generated by the UniFFI bindings generator (`Vec<u8>` is a built-in type in UniFFI).

### Call-outs:

The `EpochRecord` type stays: I don’t think we have a different way of passing in a vector of epochs IDs with their data.

I could apply this change to mls-rs too, but it doesn’t seem useful there since it’s cheap and easy to create a new type in Rust.

### Testing:

Updated tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
