### PR TITLE
[uniffi] Use a single welcome message in our API

### DIFF
--- a/mls-rs-uniffi/tests/custom_storage_sync.py
+++ b/mls-rs-uniffi/tests/custom_storage_sync.py
@@ -76,7 +76,7 @@ message = bob.generate_key_package_message()
 
 output = alice.add_members([message])
 alice.process_incoming_message(output.commit_message)
-bob = bob.join_group(None, output.welcome_messages[0]).group
+bob = bob.join_group(None, output.welcome_message).group
 
 msg = alice.encrypt_application_message(b'hello, bob')
 output = bob.process_incoming_message(msg)

--- a/mls-rs-uniffi/tests/simple_scenario_sync.py
+++ b/mls-rs-uniffi/tests/simple_scenario_sync.py
@@ -14,7 +14,7 @@ message = bob.generate_key_package_message()
 
 commit = alice.add_members([message])
 alice.process_incoming_message(commit.commit_message)
-bob = bob.join_group(None, commit.welcome_messages[0]).group
+bob = bob.join_group(None, commit.welcome_message).group
 
 msg = alice.encrypt_application_message(b'hello, bob')
 output = bob.process_incoming_message(msg)


### PR DESCRIPTION
### Issues:

Addresses #81 

### Description of changes:

We have an expectation that all participants implement the functionalities the way we do (but not necessarily using mls-rs-uniffi as the underlying library). So if we make the assumption that `single_welcome_message = true` is always set, we can simplify the API.

### Call-outs:

I'm not super sure what the implication is of throwing away the rest of the welcome messages if someone should send us more than one?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
