### PR TITLE
Make GroupInfo public and fix docs

### DIFF
--- a/mls-rs-uniffi/src/lib.rs
+++ b/mls-rs-uniffi/src/lib.rs
@@ -21,7 +21,9 @@ mod config;
 
 use std::sync::Arc;
 
-use config::{ClientConfig, UniFFIConfig};
+pub use config::ClientConfig;
+use config::UniFFIConfig;
+
 #[cfg(not(mls_build_async))]
 use std::sync::Mutex;
 #[cfg(mls_build_async)]

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -708,8 +708,7 @@ where
         self.config.key_package_extensions()
     }
 
-    /// The [KeyPackageStorage](crate::KeyPackageStorage) that
-    /// this client was configured to use.
+    /// The [KeyPackageStorage] that this client was configured to use.
     #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
     pub fn key_package_store(&self) -> <C as ClientConfig>::KeyPackageRepository {
         self.config.key_package_repo()
@@ -722,8 +721,7 @@ where
         self.config.secret_store()
     }
 
-    /// The [GroupStateStorage](crate::GroupStateStorage) that
-    /// this client was configured to use.
+    /// The [GroupStateStorage] that this client was configured to use.
     #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
     pub fn group_state_storage(&self) -> <C as ClientConfig>::GroupStateStorage {
         self.config.group_state_storage()

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -93,7 +93,7 @@ use self::message_processor::{EventOrContent, MessageProcessor, ProvisionalState
 #[cfg(feature = "by_ref_proposal")]
 use self::proposal_ref::ProposalRef;
 use self::state_repo::GroupStateRepository;
-pub(crate) use group_info::GroupInfo;
+pub use group_info::GroupInfo;
 
 pub use self::framing::{ContentType, Sender};
 pub use commit::*;

--- a/mls-rs/src/group/proposal.rs
+++ b/mls-rs/src/group/proposal.rs
@@ -27,32 +27,32 @@ use crate::psk::{ExternalPskId, JustPreSharedKeyID, PreSharedKeyID};
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A proposal that adds a member to a [`Group`].
+/// A proposal that adds a member to a [`Group`](crate::group::Group).
 pub struct AddProposal {
     pub(crate) key_package: KeyPackage,
 }
 
 impl AddProposal {
-    /// The [`SigningIdentity`]
-    /// of the [`Member`] that will be added by this proposal.
+    /// The [`SigningIdentity`] of the [`Member`](mls_rs_core::group::Member)
+    /// that will be added by this proposal.
     pub fn signing_identity(&self) -> &SigningIdentity {
         self.key_package.signing_identity()
     }
 
-    /// Client [`Capabilities`] of the
-    /// [`Member`] that will be added by this proposal.
+    /// Client [`Capabilities`] of the [`Member`](mls_rs_core::group::Member)
+    /// that will be added by this proposal.
     pub fn capabilities(&self) -> Capabilities {
         self.key_package.leaf_node.ungreased_capabilities()
     }
 
     /// Key package extensions that are assoiciated with the
-    /// [`Member`] that will be added by this proposal.
+    /// [`Member`](mls_rs_core::group::Member) that will be added by this proposal.
     pub fn key_package_extensions(&self) -> ExtensionList {
         self.key_package.ungreased_extensions()
     }
 
     /// Leaf node extensions that will be entered into the group state for the
-    /// [`Member`] that will be added.
+    /// [`Member`](mls_rs_core::group::Member) that will be added.
     pub fn leaf_node_extensions(&self) -> ExtensionList {
         self.key_package.leaf_node.ungreased_extensions()
     }
@@ -79,28 +79,28 @@ impl TryFrom<MlsMessage> for AddProposal {
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A proposal that will update an existing [`Member`] of a
-/// [`Group`]
+/// A proposal that will update an existing [`Member`](mls_rs_core::group::Member) of a
+/// [`Group`](crate::group::Group).
 pub struct UpdateProposal {
     pub(crate) leaf_node: LeafNode,
 }
 
 #[cfg(feature = "by_ref_proposal")]
 impl UpdateProposal {
-    /// The new [`SigningIdentity`]
-    /// of the [`Member`] that is being updated by this proposal.
+    /// The new [`SigningIdentity`] of the [`Member`](mls_rs_core::group::Member)
+    /// that is being updated by this proposal.
     pub fn signing_identity(&self) -> &SigningIdentity {
         &self.leaf_node.signing_identity
     }
 
-    /// New Client [`Capabilities`] of the
-    /// [`Member`] that will be updated by this proposal.
+    /// New Client [`Capabilities`] of the [`Member`](mls_rs_core::group::Member)
+    /// that will be updated by this proposal.
     pub fn capabilities(&self) -> Capabilities {
         self.leaf_node.ungreased_capabilities()
     }
 
     /// New Leaf node extensions that will be entered into the group state for the
-    /// [`Member`] that is being updated by this proposal.
+    /// [`Member`](mls_rs_core::group::Member) that is being updated by this proposal.
     pub fn leaf_node_extensions(&self) -> ExtensionList {
         self.leaf_node.ungreased_extensions()
     }
@@ -109,14 +109,14 @@ impl UpdateProposal {
 #[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A proposal to remove an existing [`Member`] of a
-/// [`Group`].
+/// A proposal to remove an existing [`Member`](mls_rs_core::group::Member) of a
+/// [`Group`](crate::group::Group).
 pub struct RemoveProposal {
     pub(crate) to_remove: LeafIndex,
 }
 
 impl RemoveProposal {
-    /// The index of the [`Member`] that will be removed by
+    /// The index of the [`Member`](mls_rs_core::group::Member) that will be removed by
     /// this proposal.
     pub fn to_remove(&self) -> u32 {
         *self.to_remove


### PR DESCRIPTION
`GroupInfo` is in one variant of the public `ReceivedMessage` enum, so should be public. Also `ClientConfig` in UniFFI should be public, I think.

Also fixed all warnings generated by `cago doc --all-features`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
