### PR TITLE
[uniffi] Setup CI for the Kotlin code

### DIFF
--- a/.github/workflows/install-kotlin-deps/action.yml
+++ b/.github/workflows/install-kotlin-deps/action.yml
@@ -1,0 +1,27 @@
+# This action downloads the Kotlin dependencies using Maven. This
+# fails on Windows for some unknown reason:
+#
+#   The goal you specified requires a project to execute but there is
+#   no POM in this directory
+#
+# For now, it seems okay to just run the tests on Linux and macOS.
+name: Install Kotlin dependencies
+description: Install Kotlin dependencies for UniFFI generated code.
+runs:
+  using: composite
+  steps:
+    - name: Install JNA
+      run: |
+        mvn --no-transfer-progress dependency:copy \
+          -Dartifact=net.java.dev.jna:jna:5.14.0 \
+          -Dmdep.stripVersion=true -DoutputDirectory=$PWD
+        echo "CLASSPATH=$PWD/jna.jar:$CLASSPATH" >> "$GITHUB_ENV"
+      shell: bash
+
+    - name: Install Kotlin Test
+      run: |
+        mvn --no-transfer-progress dependency:copy \
+          -Dartifact=org.jetbrains.kotlin:kotlin-test:1.9.23 \
+          -Dmdep.stripVersion=true -DoutputDirectory=$PWD
+        echo "CLASSPATH=$PWD/kotlin-test.jar:$CLASSPATH" >> "$GITHUB_ENV"
+      shell: bash

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -7,7 +7,7 @@ jobs:
   SyncBuildAndTestS:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -20,6 +20,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install Kotlin dependencies
+        uses: ./.github/workflows/install-kotlin-deps
+        if: runner.os != 'Windows'
       - uses: ilammy/setup-nasm@v1
         if: runner.os == 'Windows'
       - run: |
@@ -79,6 +82,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install Kotlin dependencies
+        uses: ./.github/workflows/install-kotlin-deps
       - name: Rust Fmt
         run: cargo fmt --all -- --check
       - name: Clippy Full RFC Compliance
@@ -95,6 +100,8 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Setup code coverage
         run: cargo install cargo-llvm-cov
+      - name: Install Kotlin dependencies
+        uses: ./.github/workflows/install-kotlin-deps
       - name: Run code coverage
         # Using `cargo llvm-cov show-env` lets us capture coverage
         # information from Python integration tests.

--- a/mls-rs-uniffi/Cargo.toml
+++ b/mls-rs-uniffi/Cargo.toml
@@ -21,10 +21,10 @@ mls-rs = { version = "0.39.0", path = "../mls-rs" }
 mls-rs-core = { version = "0.18.0", path = "../mls-rs-core" }
 mls-rs-crypto-openssl = { version = "0.9.0", path = "../mls-rs-crypto-openssl" }
 thiserror = "1.0.57"
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "6b09f11", version = "0.26.0" }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "eeb785c", version = "0.27.0" }
 
 [target.'cfg(mls_build_async)'.dependencies]
 tokio = { version = "1.36.0", features = ["sync"] }
 
 [dev-dependencies]
-uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs/", rev = "6b09f11", version = "0.26.0" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs/", rev = "eeb785c", version = "0.27.0" }

--- a/mls-rs-uniffi/tests/kotlin_scenarios.rs
+++ b/mls-rs-uniffi/tests/kotlin_scenarios.rs
@@ -1,0 +1,41 @@
+// These tests are only enabled on Linux and macOS because they don't
+// run on the Windows runner in GitHub's CI. See #133.
+#![cfg(unix)]
+
+macro_rules! generate_kotlin_tests {
+    ($sync_scenario:ident, None) => {
+        #[cfg(not(mls_build_async))]
+        generate_kotlin_tests!($sync_scenario);
+    };
+
+    (None, $async_scenario:ident) => {
+        #[cfg(mls_build_async)]
+        generate_kotlin_tests!($async_scenario);
+    };
+
+    ($sync_scenario:ident, $async_scenario:ident) => {
+        #[cfg(not(mls_build_async))]
+        generate_kotlin_tests!($sync_scenario);
+
+        #[cfg(mls_build_async)]
+        generate_kotlin_tests!($async_scenario);
+    };
+
+    ($scenario:ident) => {
+        #[test]
+        fn $scenario() -> Result<(), Box<dyn std::error::Error>> {
+            let target_dir = env!("CARGO_TARGET_TMPDIR");
+            let script_path = format!("tests/{}.kts", stringify!($scenario));
+            uniffi_bindgen::bindings::kotlin::run_script(
+                &target_dir,
+                "mls-rs-uniffi",
+                &script_path,
+                vec![],
+                &uniffi_bindgen::bindings::RunScriptOptions::default(),
+            )
+            .map_err(Into::into)
+        }
+    };
+}
+
+generate_kotlin_tests!(simple_scenario_sync, None);

--- a/mls-rs-uniffi/tests/simple_scenario_sync.kts
+++ b/mls-rs-uniffi/tests/simple_scenario_sync.kts
@@ -1,0 +1,25 @@
+import uniffi.mls_rs_uniffi.*
+import kotlin.test.*
+
+val clientConfig = clientConfigDefault()
+
+val aliceKey = generateSignatureKeypair(CipherSuite.CURVE25519_AES128)
+val alice = Client("alice".toByteArray(), aliceKey, clientConfig)
+
+val bobKey = generateSignatureKeypair(CipherSuite.CURVE25519_AES128)
+val bob = Client("bob".toByteArray(), bobKey, clientConfig)
+
+val aliceGroup = alice.createGroup(null)
+val message = bob.generateKeyPackageMessage()
+
+val commit = aliceGroup.addMembers(listOf(message))
+aliceGroup.processIncomingMessage(commit.commitMessage)
+val bobGroup = bob.joinGroup(null, commit.welcomeMessage!!).group
+
+val encrypted = aliceGroup.encryptApplicationMessage("hello, bob".toByteArray())
+val receivedMessage = bobGroup.processIncomingMessage(encrypted!!)
+val decrypted = assertIs<ReceivedMessage.ApplicationMessage>(receivedMessage)
+assertEquals(decrypted.data.decodeToString(), "hello, bob")
+
+aliceGroup.writeToStorage()
+bobGroup.writeToStorage()

--- a/mls-rs-uniffi/tests/simple_scenario_sync.py
+++ b/mls-rs-uniffi/tests/simple_scenario_sync.py
@@ -18,7 +18,7 @@ bob = bob.join_group(None, commit.welcome_message).group
 
 msg = alice.encrypt_application_message(b'hello, bob')
 output = bob.process_incoming_message(msg)
+assert output.data == b'hello, bob'
 
 alice.write_to_storage()
-
-assert output.data == b'hello, bob'
+bob.write_to_storage()

--- a/mls-rs-uniffi/uniffi-bindgen/Cargo.toml
+++ b/mls-rs-uniffi/uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "6b09f11", version = "0.26.0", features = ["cli"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "eeb785c", version = "0.27.0", features = ["cli"] }


### PR DESCRIPTION
### Issues:

Resolves #103.

### Description of changes:

This sets up a simple CI pipeline for the generated Kotlin code. This would have allowed us to find and fix #101 and mozilla/uniffi-rs#2032 sooner.

### Call-outs:

Note that this updates the UniFFI dependency to the latest commit on `main` (which includes mozilla/uniffi-rs#2032 to fix the `Error` inheritance loop).

### Testing:

I still need to update the CI a bit to make the tests pass in all configurations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
