### PR TITLE
Run all matrix builds to completion

### DIFF
--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Description of changes:

When working with platform specific code (such as adding Kotlin tests to the CI), it is very convenient to let the matrix builds run to completion so you can get a full overview of the platforms where things work and where they fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
