### PR TITLE
Add new job for lint and formatting checks

### DIFF
--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -28,8 +28,6 @@ jobs:
         if: runner.os == 'Windows'
       - run: echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
-      - name: Rust Fmt
-        run: cargo fmt --all -- --check
       - name: Clippy Full RFC Compliance
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
       - name: Clippy Bare Bones
@@ -49,6 +47,13 @@ jobs:
       - name: Examples
         working-directory: mls-rs
         run: cargo run --example basic_usage
+  Formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Rust Fmt
+        run: cargo fmt --all -- --check
   CodeCoverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -28,10 +28,6 @@ jobs:
         if: runner.os == 'Windows'
       - run: echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
-      - name: Clippy Full RFC Compliance
-        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
-      - name: Clippy Bare Bones
-        run: cargo clippy --all-targets --no-default-features --features std,test_util --workspace -- -D warnings
       - name: Test Full RFC Compliance
         run: cargo test --all-features --verbose --workspace
       - name: Test Bare Bones
@@ -47,13 +43,21 @@ jobs:
       - name: Examples
         working-directory: mls-rs
         run: cargo run --example basic_usage
-  Formatting:
+  LintAndFormatting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: arduino/setup-protoc@v2
+        with:
+          version: "25.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Rust Fmt
         run: cargo fmt --all -- --check
+      - name: Clippy Full RFC Compliance
+        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+      - name: Clippy Bare Bones
+        run: cargo clippy --all-targets --no-default-features --features std,test_util --workspace -- -D warnings
   CodeCoverage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description of changes:

The lint and formatting checks don't depend on the operating system. We can therefore save some time by running it just once (and running in parallel with the other jobs).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
