### PR TITLE
Add `has_pending_commit` function to `Group`

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.39.0"
+version = "0.39.1"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1260,6 +1260,12 @@ where
         self.process_commit(pending_commit.content, None).await
     }
 
+    /// Returns true if a commit has been created but not yet applied
+    /// with [`Group::apply_pending_commit`] or cleared with [`Group::clear_pending_commit`]
+    pub fn has_pending_commit(&self) -> bool {
+        self.pending_commit.is_some()
+    }
+
     /// Clear the currently pending commit.
     ///
     /// This function will automatically be called in the event that a
@@ -1936,6 +1942,8 @@ mod tests {
             #[cfg(feature = "by_ref_proposal")]
             assert!(group.pending_updates.is_empty());
 
+            assert!(!group.has_pending_commit());
+
             assert_eq!(
                 group.private_tree.self_index.0,
                 group.current_member_index()
@@ -1973,6 +1981,8 @@ mod tests {
 
         // We should be able to send application messages after a commit
         test_group.group.commit(vec![]).await.unwrap();
+
+        assert!(test_group.group.has_pending_commit());
 
         test_group.group.apply_pending_commit().await.unwrap();
 


### PR DESCRIPTION
### Description of changes:

It is useful to be able to see that a commit is pending for a group

### Testing:

Incorporated exercising this function into existing tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
