### PR TITLE
Add more caching to the CI

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install cargo-hack
         run: cargo install cargo-hack
       - name: Build one feature at a time

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
       - name: Rust Fmt on fuzz targets

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -18,6 +18,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ilammy/setup-nasm@v1
         if: runner.os == 'Windows'
       - run: |
@@ -50,6 +52,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ilammy/setup-nasm@v1
         if: runner.os == 'Windows'
       - run: |
@@ -73,6 +77,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Rust Fmt
         run: cargo fmt --all -- --check
       - name: Clippy Full RFC Compliance
@@ -85,6 +91,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Setup code coverage
         run: cargo install cargo-llvm-cov
       - name: Run code coverage

--- a/.github/workflows/no_std_build.yml
+++ b/.github/workflows/no_std_build.yml
@@ -12,6 +12,9 @@ jobs:
       with:
         targets: thumbv6m-none-eabi
         components: clippy
+    - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Clippy
       run: cargo +stable clippy --no-default-features -p mls-rs -- -D warnings
     - name: Test
@@ -22,5 +25,5 @@ jobs:
       run: cargo +nightly build --package mls-rs --lib --no-default-features --target thumbv6m-none-eabi
     - name: Build MLS Embedded Full RFC Compliance
       run: cargo +nightly build --package mls-rs --lib --no-default-features --features rfc_compliant --target thumbv6m-none-eabi
-    - name: Build rust crypto embedded 
+    - name: Build rust crypto embedded
       run: cargo +nightly build --package mls-rs-crypto-rustcrypto --no-default-features --target thumbv6m-none-eabi


### PR DESCRIPTION
### Description of changes:

This is a followup to #137 to make the caching more consistent across the different CI jobs.

I’ve noticed from other projects that it’s not very useful to cache the build artifacts for each branch: that just ends up polluting the 10 GB cache GitHub provides us with. So saving the cache is now disabled on non-main branches (the cache will still be read on all PRs from all branches).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
