### PR TITLE
Add support for encoding and decoding u128 primitives

### DIFF
--- a/mls-rs-codec/src/stdint.rs
+++ b/mls-rs-codec/src/stdint.rs
@@ -32,6 +32,7 @@ impl_stdint!(u8);
 impl_stdint!(u16);
 impl_stdint!(u32);
 impl_stdint!(u64);
+impl_stdint!(u128);
 
 #[cfg(test)]
 mod tests {
@@ -80,5 +81,18 @@ mod tests {
         let recovered = u64::mls_decode(&mut &*serialized).unwrap();
 
         assert_eq!(recovered, 100000000000u64);
+    }
+
+    #[test]
+    fn u128_round_trip() {
+        let serialized = 10000000000000000u128.mls_encode_to_vec().unwrap();
+        assert_eq!(
+            serialized,
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 35, 134, 242, 111, 193, 0, 0]
+        );
+
+        let recovered = u128::mls_decode(&mut &*serialized).unwrap();
+
+        assert_eq!(recovered, 10000000000000000u128);
     }
 }


### PR DESCRIPTION
### Issues:

Resolves #144 

### Description of changes:

one liner to add support for encoding/decodinb u128s

### Testing:

Added a basic round trip test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
