### PR TITLE
[uniffi] Introduce a `GroupId` newtype wrapper

### DIFF
--- a/mls-rs-uniffi/src/config.rs
+++ b/mls-rs-uniffi/src/config.rs
@@ -9,7 +9,7 @@ use mls_rs::{
 use mls_rs_crypto_openssl::OpensslCryptoProvider;
 
 use self::group_state::{GroupStateStorage, GroupStateStorageAdapter};
-use crate::Error;
+use crate::{Error, GroupId};
 
 pub mod group_state;
 
@@ -28,11 +28,11 @@ impl mls_rs_core::group::GroupStateStorage for ClientGroupStorage {
     type Error = Error;
 
     async fn state(&self, group_id: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.0.state(group_id.to_vec()).await
+        self.0.state(GroupId::from(group_id)).await
     }
 
     async fn epoch(&self, group_id: &[u8], epoch_id: u64) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.0.epoch(group_id.to_vec(), epoch_id).await
+        self.0.epoch(GroupId::from(group_id), epoch_id).await
     }
 
     async fn write(
@@ -43,7 +43,7 @@ impl mls_rs_core::group::GroupStateStorage for ClientGroupStorage {
     ) -> Result<(), Self::Error> {
         self.0
             .write(
-                state.id,
+                GroupId::new(state.id),
                 state.data,
                 inserts.into_iter().map(Into::into).collect(),
                 updates.into_iter().map(Into::into).collect(),
@@ -52,7 +52,7 @@ impl mls_rs_core::group::GroupStateStorage for ClientGroupStorage {
     }
 
     async fn max_epoch_id(&self, group_id: &[u8]) -> Result<Option<u64>, Self::Error> {
-        self.0.max_epoch_id(group_id.to_vec()).await
+        self.0.max_epoch_id(GroupId::from(group_id)).await
     }
 }
 

--- a/mls-rs-uniffi/src/config/group_state.rs
+++ b/mls-rs-uniffi/src/config/group_state.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 #[cfg(mls_build_async)]
 use tokio::sync::Mutex;
 
-use crate::Error;
+use crate::{Error, GroupId};
 
 // TODO(mulmarta): we'd like to use EpochRecord from mls-rs-core but
 // this breaks the Python tests because using two crates makes UniFFI
@@ -40,18 +40,16 @@ impl From<EpochRecord> for mls_rs_core::group::EpochRecord {
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
 #[cfg_attr(not(mls_build_async), uniffi::export(with_foreign))]
 pub trait GroupStateStorage: Send + Sync + Debug {
-    async fn state(&self, group_id: Vec<u8>) -> Result<Option<Vec<u8>>, Error>;
-    async fn epoch(&self, group_id: Vec<u8>, epoch_id: u64) -> Result<Option<Vec<u8>>, Error>;
-
+    async fn state(&self, group_id: GroupId) -> Result<Option<Vec<u8>>, Error>;
+    async fn epoch(&self, group_id: GroupId, epoch_id: u64) -> Result<Option<Vec<u8>>, Error>;
     async fn write(
         &self,
-        group_id: Vec<u8>,
+        group_id: GroupId,
         group_state: Vec<u8>,
         epoch_inserts: Vec<EpochRecord>,
         epoch_updates: Vec<EpochRecord>,
     ) -> Result<(), Error>;
-
-    async fn max_epoch_id(&self, group_id: Vec<u8>) -> Result<Option<u64>, Error>;
+    async fn max_epoch_id(&self, group_id: GroupId) -> Result<Option<u64>, Error>;
 }
 
 /// Adapt a mls-rs `GroupStateStorage` implementation.
@@ -85,7 +83,7 @@ where
     S: mls_rs::GroupStateStorage<Error = Err> + Debug,
     Err: IntoAnyError,
 {
-    async fn state(&self, group_id: Vec<u8>) -> Result<Option<Vec<u8>>, Error> {
+    async fn state(&self, group_id: GroupId) -> Result<Option<Vec<u8>>, Error> {
         self.inner()
             .await
             .state(&group_id)
@@ -93,7 +91,7 @@ where
             .map_err(|err| err.into_any_error().into())
     }
 
-    async fn epoch(&self, group_id: Vec<u8>, epoch_id: u64) -> Result<Option<Vec<u8>>, Error> {
+    async fn epoch(&self, group_id: GroupId, epoch_id: u64) -> Result<Option<Vec<u8>>, Error> {
         self.inner()
             .await
             .epoch(&group_id, epoch_id)
@@ -103,7 +101,7 @@ where
 
     async fn write(
         &self,
-        id: Vec<u8>,
+        group_id: GroupId,
         data: Vec<u8>,
         epoch_inserts: Vec<EpochRecord>,
         epoch_updates: Vec<EpochRecord>,
@@ -111,7 +109,10 @@ where
         self.inner()
             .await
             .write(
-                mls_rs_core::group::GroupState { id, data },
+                mls_rs_core::group::GroupState {
+                    id: group_id.into(),
+                    data,
+                },
                 epoch_inserts.into_iter().map(Into::into).collect(),
                 epoch_updates.into_iter().map(Into::into).collect(),
             )
@@ -119,7 +120,7 @@ where
             .map_err(|err| err.into_any_error().into())
     }
 
-    async fn max_epoch_id(&self, group_id: Vec<u8>) -> Result<Option<u64>, Error> {
+    async fn max_epoch_id(&self, group_id: GroupId) -> Result<Option<u64>, Error> {
         self.inner()
             .await
             .max_epoch_id(&group_id)

--- a/mls-rs-uniffi/tests/custom_storage_sync.py
+++ b/mls-rs-uniffi/tests/custom_storage_sync.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 
 from mls_rs_uniffi import CipherSuite, generate_signature_keypair, Client, \
-    GroupStateStorage, EpochRecord, ClientConfig, ProtocolVersion
+    GroupId, GroupStateStorage, EpochRecord, ClientConfig, ProtocolVersion
 
 
 @dataclass
@@ -15,15 +15,15 @@ class PythonGroupStateStorage(GroupStateStorage):
     def __init__(self):
         self.groups: dict[str, GroupStateData] = {}
 
-    def state(self, group_id: bytes):
-        group = self.groups.get(group_id.hex())
+    def state(self, group_id: GroupId):
+        group = self.groups.get(group_id.id)
         if group == None:
             return None
 
         return group.state
 
-    def epoch(self, group_id: bytes, epoch_id: int):
-        group = self.groups.get(group_id.hex())
+    def epoch(self, group_id: GroupId, epoch_id: int):
+        group = self.groups.get(group_id.id)
         if group == None:
             return None
 
@@ -33,12 +33,12 @@ class PythonGroupStateStorage(GroupStateStorage):
 
         return None
 
-    def write(self, group_id: bytes, group_state: bytes,
+    def write(self, group_id: GroupId, group_state: bytes,
               epoch_inserts: list[EpochRecord],
               epoch_updates: list[EpochRecord]):
-        if group_id.hex() not in self.groups:
-            self.groups[group_id.hex()] = GroupStateData(group_state)
-        group = self.groups[group_id.hex()]
+        if group_id.id not in self.groups:
+            self.groups[group_id.id] = GroupStateData(group_state)
+        group = self.groups[group_id.id]
 
         for insert in epoch_inserts:
             group.epoch_data.append(insert)
@@ -48,8 +48,8 @@ class PythonGroupStateStorage(GroupStateStorage):
                 if group.epoch_data[i].id == update.id:
                     group.epoch_data[i] = update
 
-    def max_epoch_id(self, group_id: bytes):
-        group = self.groups.get(group_id.hex())
+    def max_epoch_id(self, group_id: GroupId):
+        group = self.groups.get(group_id.id)
         if group == None:
             return None
 


### PR DESCRIPTION
### Issues:

Addresses #81.

### Description of changes:

This case up during our API review: instead of exposing a `Vec<u8>`, we can let the API use a `GroupId` newtype wrapper.

### Call-outs:

A downside of this is that UniFFI doesn’t support exposing traits like `Hash` on its record types (see
https://github.com/mozilla/uniffi-rs/issues/2043). A consequence of this is that the Python `GroupId` type is not hashable. I therefore ended up accessing the `.id` attribute directly in the integration test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
