### PR TITLE
Update aws-lc

### DIFF
--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-awslc"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 description = "AWS-LC based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -9,8 +9,8 @@ keywords = ["mls", "mls-rs", "aws-lc"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-aws-lc-rs = "1.6.4"
-aws-lc-sys = { version = "0.14.1" }
+aws-lc-rs = "1.7.0"
+aws-lc-sys = { version = "0.15.0" }
 mls-rs-core = { path = "../mls-rs-core", version = "0.18.0" }
 mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.9.0" }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.10.0" }


### PR DESCRIPTION
The version mismatch with aws-lc-sys (again) causes fails on windows https://github.com/awslabs/mls-rs/actions/runs/8723361360/job/23931412208