### PR TITLE
[uniffi] Make mls-rs-crypto-openssl optional

### DIFF
--- a/mls-rs-uniffi/Cargo.toml
+++ b/mls-rs-uniffi/Cargo.toml
@@ -14,14 +14,19 @@ rust-version = "1.68.2"
 crate-type = ["lib", "cdylib"]
 name = "mls_rs_uniffi"
 
+[features]
+openssl = ["mls-rs-crypto-openssl"]
+default = ["openssl"]
+
 [dependencies]
 async-trait = "0.1.77"
 maybe-async = "0.2.10"
 mls-rs = { version = "0.39.0", path = "../mls-rs" }
 mls-rs-core = { version = "0.18.0", path = "../mls-rs-core" }
-mls-rs-crypto-openssl = { version = "0.9.0", path = "../mls-rs-crypto-openssl" }
 thiserror = "1.0.57"
 uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "eeb785c", version = "0.27.0" }
+
+mls-rs-crypto-openssl = { version = "0.9.0", path = "../mls-rs-crypto-openssl", optional = true }
 
 [target.'cfg(mls_build_async)'.dependencies]
 tokio = { version = "1.36.0", features = ["sync"] }

--- a/mls-rs-uniffi/src/config.rs
+++ b/mls-rs-uniffi/src/config.rs
@@ -6,9 +6,8 @@ use mls_rs::{
     identity::basic,
     storage_provider::in_memory::InMemoryGroupStateStorage,
 };
-use mls_rs_crypto_openssl::OpensslCryptoProvider;
 
-use self::group_state::{GroupStateStorage, GroupStateStorageAdapter};
+use crate::config::group_state::{GroupStateStorage, GroupStateStorageAdapter};
 use crate::Error;
 
 pub mod group_state;
@@ -56,10 +55,19 @@ impl mls_rs_core::group::GroupStateStorage for ClientGroupStorage {
     }
 }
 
+#[cfg(not(any(feature = "openssl")))]
+compile_error!(
+    "The crypto provider must be set by enabling exactly one of the \
+     following Cargo features: [\"openssl\"]."
+);
+
+#[cfg(feature = "openssl")]
+pub type UniFFICryptoProvider = mls_rs_crypto_openssl::OpensslCryptoProvider;
+
 pub type UniFFIConfig = client_builder::WithIdentityProvider<
     basic::BasicIdentityProvider,
     client_builder::WithCryptoProvider<
-        OpensslCryptoProvider,
+        UniFFICryptoProvider,
         WithGroupStateStorage<ClientGroupStorage, client_builder::BaseConfig>,
     >,
 >;


### PR DESCRIPTION
### Issues:

Addresses #81.

### Description of changes:

For Android, we will be using a crypto provider based on BoringSSL. It is therefore important that mls-rs-uniffi becomes agnostic to the crypto provider.

This PR handles this very simply: by requiring two things:

- the user sets a Cargo feature to depend on the right crypto provider implementation,
- that the crypto provider has a suitable `new()` method that can be used to instantiate it.

fail because the `CryptoProvider` trait has an associated type, which I cannot specify at this point.

### Call-outs:

A better alternative would be to make the choice of crypto provider dynamic via a trait. Unfortunately, I don’t think this is supported with UniFFI because it doesn’t support associated types in exported traits and because it also doesn’t support generic exported types.

Making a single non-generic type which uses

```rust
struct CryptoProviderAdapter {
    crypto_provider: Box<dyn CryptoProvider>
}
```

doesn't compile because I need to specify the `CipherSuiteProvider` associated type. I don't know how I can do this in a non-generic way?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
