### PR TITLE
[crypto-awslc] update aws-lc-rs to 1.7.3

### DIFF
--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-awslc"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 description = "AWS-LC based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -9,8 +9,8 @@ keywords = ["mls", "mls-rs", "aws-lc"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-aws-lc-rs = "1.7.0"
-aws-lc-sys = { version = "0.17.0" }
+aws-lc-rs = "=1.7.3"
+aws-lc-sys = { version = "0.18.0" }
 mls-rs-core = { path = "../mls-rs-core", version = "=0.18.0" }
 mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.9.0" }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.10.0" }

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -445,7 +445,6 @@ where
             cipher_suite_provider: &cipher_suite_provider,
             signing_key: self.signer()?,
             signing_identity,
-            identity_provider: &self.config.identity_provider(),
         };
 
         let key_pkg_gen = key_package_generator

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -3580,7 +3580,6 @@ mod tests {
             cipher_suite_provider: &test_cipher_suite_provider(TEST_CIPHER_SUITE),
             signing_identity: &signing_identity,
             signing_key: &secret_key,
-            identity_provider: &BasicWithCustomProvider::new(BasicIdentityProvider::new()),
         };
 
         generator

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -19,7 +19,6 @@ use crate::{
     client_builder::test_utils::{TestClientBuilder, TestClientConfig},
     crypto::test_utils::test_cipher_suite_provider,
     extension::ExtensionType,
-    identity::basic::BasicIdentityProvider,
     identity::test_utils::get_test_signing_identity,
     key_package::{KeyPackageGeneration, KeyPackageGenerator},
     mls_rules::{CommitOptions, DefaultMlsRules},
@@ -210,7 +209,6 @@ pub(crate) async fn test_member(
         cipher_suite_provider: &test_cipher_suite_provider(cipher_suite),
         signing_identity: &signing_identity,
         signing_key: &signing_key,
-        identity_provider: &BasicIdentityProvider,
     };
 
     let key_package = key_package_generator

--- a/mls-rs/src/key_package/generator.rs
+++ b/mls-rs/src/key_package/generator.rs
@@ -5,7 +5,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode};
-use mls_rs_core::{error::IntoAnyError, identity::IdentityProvider, key_package::KeyPackageData};
+use mls_rs_core::{error::IntoAnyError, key_package::KeyPackageData};
 
 use crate::client::MlsError;
 use crate::{
@@ -24,16 +24,14 @@ use crate::{
 use super::{KeyPackage, KeyPackageRef};
 
 #[derive(Clone, Debug)]
-pub struct KeyPackageGenerator<'a, IP, CP>
+pub struct KeyPackageGenerator<'a, CP>
 where
-    IP: IdentityProvider,
     CP: CipherSuiteProvider,
 {
     pub protocol_version: ProtocolVersion,
     pub cipher_suite_provider: &'a CP,
     pub signing_identity: &'a SigningIdentity,
     pub signing_key: &'a SignatureSecretKey,
-    pub identity_provider: &'a IP,
 }
 
 #[derive(Clone, Debug)]
@@ -75,9 +73,8 @@ impl KeyPackageGeneration {
     }
 }
 
-impl<'a, IP, CP> KeyPackageGenerator<'a, IP, CP>
+impl<'a, CP> KeyPackageGenerator<'a, CP>
 where
-    IP: IdentityProvider,
     CP: CipherSuiteProvider,
 {
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
@@ -199,7 +196,6 @@ mod tests {
                 cipher_suite_provider: &cipher_suite_provider,
                 signing_identity: &signing_identity,
                 signing_key: &signing_key,
-                identity_provider: &BasicIdentityProvider,
             };
 
             let mut capabilities = get_test_capabilities();
@@ -300,7 +296,6 @@ mod tests {
                 cipher_suite_provider: &test_cipher_suite_provider(cipher_suite),
                 signing_identity: &signing_identity,
                 signing_key: &signing_key,
-                identity_provider: &BasicIdentityProvider,
             };
 
             let first_key_package = test_generator

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -173,7 +173,6 @@ pub(crate) mod test_utils {
     use crate::{
         crypto::test_utils::test_cipher_suite_provider,
         group::framing::MlsMessagePayload,
-        identity::basic::BasicIdentityProvider,
         identity::test_utils::get_test_signing_identity,
         tree_kem::{leaf_node::test_utils::get_test_capabilities, Lifetime},
         MlsMessage,
@@ -206,7 +205,6 @@ pub(crate) mod test_utils {
             cipher_suite_provider: &test_cipher_suite_provider(cipher_suite),
             signing_identity: &signing_identity,
             signing_key: &secret_key,
-            identity_provider: &BasicIdentityProvider,
         };
 
         let key_package = generator


### PR DESCRIPTION
### Description of changes:

Update to aws-lc-rs 1.7.3 and pin to it so we don't get drifting aws-lc-sys versions again

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
