### PR TITLE
[crypto-rustcrypto]: remove unused custom feature

### DIFF
--- a/.github/workflows/no_std_build.yml
+++ b/.github/workflows/no_std_build.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Build MLS Embedded Full RFC Compliance
       run: cargo +nightly build --package mls-rs --lib --no-default-features --features rfc_compliant --target thumbv6m-none-eabi
     - name: Build rust crypto embedded
-      run: cargo +nightly build --package mls-rs-crypto-rustcrypto --no-default-features --target thumbv6m-none-eabi
+      run: cargo +nightly build --package mls-rs-crypto-rustcrypto --no-default-features --features "getrandom/custom" --target thumbv6m-none-eabi

--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = { version = "1.0.40", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 
 # Random
-getrandom = { version = "0.2", default-features = false, features = ["custom"] }
+getrandom = { version = "0.2", default-features = false, optional = true }
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 
 # AEAD


### PR DESCRIPTION


### Description of changes:

We don’t actually use the “custom” feature of the getrandom crate. We don't have the feature enabled in all the places where I'm trying to use mls-rs, so it would be nice if this crate doesn't require it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
