### PR TITLE
[SqLite Provider] Don't take ownership when not needed

### DIFF
--- a/mls-rs-provider-sqlite/src/psk.rs
+++ b/mls-rs-provider-sqlite/src/psk.rs
@@ -24,7 +24,7 @@ impl SqLitePreSharedKeyStorage {
     }
 
     /// Insert a pre-shared key into storage.
-    pub fn insert(&self, psk_id: Vec<u8>, psk: PreSharedKey) -> Result<(), SqLiteDataStorageError> {
+    pub fn insert(&self, psk_id: &[u8], psk: &PreSharedKey) -> Result<(), SqLiteDataStorageError> {
         let connection = self.connection.lock().unwrap();
 
         // Upsert into the database
@@ -103,7 +103,7 @@ mod tests {
         let (psk_id, psk) = test_psk();
         let storage = test_storage();
 
-        storage.insert(psk_id.clone(), psk.clone()).unwrap();
+        storage.insert(&psk_id, &psk).unwrap();
 
         let from_storage = storage.get(&psk_id).unwrap().unwrap();
         assert_eq!(from_storage, psk);
@@ -116,8 +116,8 @@ mod tests {
 
         let storage = test_storage();
 
-        storage.insert(psk_id.clone(), psk).unwrap();
-        storage.insert(psk_id.clone(), new_psk.clone()).unwrap();
+        storage.insert(&psk_id, &psk).unwrap();
+        storage.insert(&psk_id, &new_psk).unwrap();
 
         let from_storage = storage.get(&psk_id).unwrap().unwrap();
         assert_eq!(from_storage, new_psk);
@@ -128,7 +128,7 @@ mod tests {
         let (psk_id, psk) = test_psk();
         let storage = test_storage();
 
-        storage.insert(psk_id.clone(), psk).unwrap();
+        storage.insert(&psk_id, &psk).unwrap();
         storage.delete(&psk_id).unwrap();
 
         assert!(storage.get(&psk_id).unwrap().is_none());


### PR DESCRIPTION
Taking references is good for security because the calling code can clear memory after storing secrets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
