### PR TITLE
Add key package count to sqlite provider

### DIFF
--- a/mls-rs-ffi/Cargo.toml
+++ b/mls-rs-ffi/Cargo.toml
@@ -22,6 +22,6 @@ x509 = ["mls-rs-identity-x509"]
 mls-rs = { path = "../mls-rs", version = "0.39.0", features = ["ffi"] }
 mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.9.0", optional = true }
 mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.11.0", optional = true }
-mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.11.0", default-features = false, optional = true }
+mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.12.0", default-features = false, optional = true }
 safer-ffi = { version = "0.1.7", default-features = false }
 safer-ffi-gen = { version = "0.9.2", default-features = false }

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-provider-sqlite"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "SQLite based state storage for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -63,7 +63,7 @@ spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin
 maybe-async = { version = "0.2.10" }
 
 # Optional dependencies
-mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.11.0", default-features = false, optional = true }
+mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.12.0", default-features = false, optional = true }
 mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", optional = true, version = "0.9.0" }
 # TODO: https://github.com/GoogleChromeLabs/wasm-bindgen-rayon
 rayon = { version = "1", optional = true }


### PR DESCRIPTION
### Description of changes:

It is useful to know how many key packages remain unused in your storage in order to keep a pool of a certain size populated.

### Testing:

Added unit test for the new function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
