### PR TITLE
Expose the key_package on AddProposal

### DIFF
--- a/mls-rs/src/group/proposal.rs
+++ b/mls-rs/src/group/proposal.rs
@@ -33,6 +33,12 @@ pub struct AddProposal {
 }
 
 impl AddProposal {
+    /// The [`KeyPackage`] used by this proposal to add
+    /// a [`Member`](mls_rs_core::group::Member) to the group.
+    pub fn key_package(&self) -> &KeyPackage {
+        &self.key_package
+    }
+
     /// The [`SigningIdentity`] of the [`Member`](mls_rs_core::group::Member)
     /// that will be added by this proposal.
     pub fn signing_identity(&self) -> &SigningIdentity {


### PR DESCRIPTION
### Issues:

Resolves #165

### Description of changes:

This PR adds a public method `AddProposal::key_package`, which will allow crate consumers to read the `KeyPackage` held by the proposal.

### Testing:

Surrounding getter methods had no unit tests, thus I skipped writing them for this method, too. Please let me know if you'd like me to add a test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
