### PR TITLE
Add IdentityProvider getter on Client + ExternalClient

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.39.2"
+version = "0.39.3"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -725,6 +725,12 @@ where
     pub fn group_state_storage(&self) -> <C as ClientConfig>::GroupStateStorage {
         self.config.group_state_storage()
     }
+
+    /// The [IdentityProvider] that this client was configured to use.
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
+    pub fn identity_provider(&self) -> <C as ClientConfig>::IdentityProvider {
+        self.config.identity_provider()
+    }
 }
 
 #[cfg(test)]

--- a/mls-rs/src/external_client.rs
+++ b/mls-rs/src/external_client.rs
@@ -120,6 +120,11 @@ where
 
         Ok(key_package)
     }
+
+    /// The [IdentityProvider] that this client was configured to use.
+    pub fn identity_provider(&self) -> <C as ExternalClientConfig>::IdentityProvider {
+        self.config.identity_provider()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Description of changes:

We didn't have a way to retrieve the currently configured IdentityProvider on clients

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
