### PR TITLE
Make `ExternalGroup::propose` public

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.39.3"
+version = "0.39.4"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -414,9 +414,14 @@ impl<C: ExternalClientConfig + Clone> ExternalGroup<C> {
             .await
     }
 
+    /// Issue an external proposal.
+    ///
+    /// This function is useful for reissuing external proposals that
+    /// are returned in [CommitMessageDescription::unused_proposals]
+    /// after a commit is processed.
     #[cfg(feature = "by_ref_proposal")]
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
-    async fn propose(
+    pub async fn propose(
         &mut self,
         proposal: Proposal,
         authenticated_data: Vec<u8>,


### PR DESCRIPTION
### Description of changes:

We had a function that sends a generic `Proposal` enum as an external proposal but it was not public. This made re-sending unused proposals difficult

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
