### PR TITLE
Add a Replace proposal

### DIFF
--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -20,6 +20,7 @@ ffi = ["dep:safer-ffi", "dep:safer-ffi-gen"]
 x509 = []
 test_suite = ["serde", "dep:serde_json", "dep:itertools"]
 serde = ["dep:serde", "zeroize/serde", "hex/serde", "dep:serde_bytes"]
+replace_proposal = []
 
 [dependencies]
 mls-rs-codec = { version = "0.5.2", path = "../mls-rs-codec", default-features = false}

--- a/mls-rs-core/src/extension.rs
+++ b/mls-rs-core/src/extension.rs
@@ -34,6 +34,12 @@ impl ExtensionType {
     pub const EXTERNAL_PUB: ExtensionType = ExtensionType(4);
     pub const EXTERNAL_SENDERS: ExtensionType = ExtensionType(5);
 
+    // XXX(RLB): This value is chosen from the vendor range, since this is an experimental
+    // implementation that is only intended to work between `mls-rs` instances.  Once a real value
+    // is assigned by IANA, this code will need to be updated.
+    #[cfg(feature = "replace_proposal")]
+    pub const LEAF_NODE_EPOCH: ExtensionType = ExtensionType(0xFF01);
+
     /// Default extension types defined
     /// in [RFC 9420](https://www.rfc-editor.org/rfc/rfc9420.html#name-leaf-node-contents)
     pub const DEFAULT: &'static [ExtensionType] = &[

--- a/mls-rs-core/src/group/proposal_type.rs
+++ b/mls-rs-core/src/group/proposal_type.rs
@@ -57,6 +57,9 @@ impl ProposalType {
     pub const EXTERNAL_INIT: ProposalType = ProposalType(6);
     pub const GROUP_CONTEXT_EXTENSIONS: ProposalType = ProposalType(7);
 
+    #[cfg(feature = "replace_proposal")]
+    pub const REPLACE: ProposalType = ProposalType(8);
+
     /// Default proposal types defined
     /// in [RFC 9420](https://www.rfc-editor.org/rfc/rfc9420.html#name-leaf-node-contents)
     pub const DEFAULT: &'static [ProposalType] = &[

--- a/mls-rs-crypto-cryptokit/Cargo.toml
+++ b/mls-rs-crypto-cryptokit/Cargo.toml
@@ -26,6 +26,7 @@ uniffi = { version = "0.27.2", features = ["build"] }
 maybe-async = "0.2.10"
 mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.18.0" }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.10.0" }
+thiserror = "1.0.61"
 uniffi = "0.27.2"
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 
@@ -35,3 +36,4 @@ async-trait = "0.1.74"
 [[bin]]
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
+required-features = ["uniffi/cli"]

--- a/mls-rs-crypto-cryptokit/Cargo.toml
+++ b/mls-rs-crypto-cryptokit/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/awslabs/mls-rs"
 keywords = ["mls", "mls-rs", "CryptoKit"]
 license = "Apache-2.0 OR MIT"
 
+[lib]
+crate-type = ["staticlib", "cdylib"]
+
 [build-dependencies]
 # For parsing Swift outputs to build and link the bridge library
 serde = { version = "1.0", features = ["derive"] }
@@ -17,12 +20,18 @@ serde_json = "1.0"
 hex-literal = "0.4.1"
 assert_matches = "1.5.0"
 mls-rs-core = { path = "../mls-rs-core", version = "0.18.0", features = ["test_suite"] }
+uniffi = { version = "0.27.2", features = ["build"] }
 
 [dependencies]
 maybe-async = "0.2.10"
 mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.18.0" }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.10.0" }
+uniffi = "0.27.2"
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"
+
+[[bin]]
+name = "uniffi-bindgen"
+path = "uniffi-bindgen.rs"

--- a/mls-rs-crypto-cryptokit/src/lib.rs
+++ b/mls-rs-crypto-cryptokit/src/lib.rs
@@ -23,6 +23,17 @@ use zeroize::Zeroizing;
 
 uniffi::setup_scaffolding!();
 
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum UniFfiCompatibleError {
+    #[error("oh no")]
+    OhNo,
+}
+
+#[uniffi::export(with_foreign)]
+pub trait BoxedConstant: Send + Sync {
+    fn add(&self, b: u32) -> Result<u32, UniFfiCompatibleError>;
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum CryptoKitError {

--- a/mls-rs-crypto-cryptokit/src/lib.rs
+++ b/mls-rs-crypto-cryptokit/src/lib.rs
@@ -21,6 +21,8 @@ use mls_rs_core::{
 use mls_rs_crypto_traits::{AeadType, KdfType};
 use zeroize::Zeroizing;
 
+uniffi::setup_scaffolding!();
+
 #[derive(Debug)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum CryptoKitError {

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -33,6 +33,7 @@ by_ref_proposal = []
 psk = []
 x509 = ["mls-rs-core/x509", "dep:mls-rs-identity-x509"]
 rfc_compliant = ["state_update", "private_message", "custom_proposal", "out_of_order", "psk", "x509", "prior_epoch", "by_ref_proposal", "mls-rs-core/rfc_compliant"]
+replace_proposal = []
 
 std = ["mls-rs-core/std", "mls-rs-codec/std", "mls-rs-identity-x509?/std", "hex/std", "futures/std", "itertools/use_std", "safer-ffi-gen?/std", "zeroize/std", "dep:debug_tree", "dep:thiserror", "serde?/std"]
 

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -33,7 +33,7 @@ by_ref_proposal = []
 psk = []
 x509 = ["mls-rs-core/x509", "dep:mls-rs-identity-x509"]
 rfc_compliant = ["state_update", "private_message", "custom_proposal", "out_of_order", "psk", "x509", "prior_epoch", "by_ref_proposal", "mls-rs-core/rfc_compliant"]
-replace_proposal = []
+replace_proposal = ["mls-rs-core/replace_proposal"]
 
 std = ["mls-rs-core/std", "mls-rs-codec/std", "mls-rs-identity-x509?/std", "hex/std", "futures/std", "itertools/use_std", "safer-ffi-gen?/std", "zeroize/std", "dep:debug_tree", "dep:thiserror", "serde?/std"]
 

--- a/mls-rs/examples/basic_usage.rs
+++ b/mls-rs/examples/basic_usage.rs
@@ -63,6 +63,14 @@ fn main() -> Result<(), MlsError> {
     // Bob joins the group with the welcome message created as part of Alice's commit.
     let (mut bob_group, _) = bob.join_group(None, &alice_commit.welcome_messages[0])?;
 
+    #[cfg(feature = "private_message")]
+    encrypt_decrypt(alice_group, bob_group);
+
+    Ok(())
+}
+
+#[cfg(feature = "private_message")]
+fn encrypt_decrypt<C: MlsConfig>(alice_group: &Group<C>, bob_group: &Group<C>) {
     // Alice encrypts an application message to Bob.
     let msg = alice_group.encrypt_application_message(b"hello world", Default::default())?;
 
@@ -74,6 +82,4 @@ fn main() -> Result<(), MlsError> {
     // Alice and bob write the group state to their configured storage engine
     alice_group.write_to_storage()?;
     bob_group.write_to_storage()?;
-
-    Ok(())
 }

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -1045,13 +1045,16 @@ mod tests {
 
     #[test]
     fn builder_can_be_obtained_from_client_to_edit_properties_for_new_client() {
+        #[cfg(not(feature = "replace_proposal"))]
+        let expected_extensions = [33, 34].map(Into::into);
+
+        #[cfg(feature = "replace_proposal")]
+        let expected_extensions = [0xff01, 33, 34].map(Into::into);
+
         let alice = TestClientBuilder::new_for_test()
             .extension_type(33.into())
             .build();
         let bob = alice.to_builder().extension_type(34.into()).build();
-        assert_eq!(
-            bob.config.supported_extensions(),
-            [0xff01, 33, 34].map(Into::into)
-        );
+        assert_eq!(bob.config.supported_extensions(), expected_extensions);
     }
 }

--- a/mls-rs/src/client_builder.rs
+++ b/mls-rs/src/client_builder.rs
@@ -879,8 +879,14 @@ pub(crate) struct Settings {
 
 impl Default for Settings {
     fn default() -> Self {
+        #[cfg(not(feature = "replace_proposal"))]
+        let extension_types = Default::default();
+
+        #[cfg(feature = "replace_proposal")]
+        let extension_types = vec![ExtensionType::LEAF_NODE_EPOCH];
+
         Self {
-            extension_types: Default::default(),
+            extension_types: extension_types,
             protocol_versions: Default::default(),
             key_package_extensions: Default::default(),
             leaf_node_extensions: Default::default(),

--- a/mls-rs/src/extension/built_in.rs
+++ b/mls-rs/src/extension/built_in.rs
@@ -357,6 +357,7 @@ mod tests {
         assert_eq!(ext, restored)
     }
 
+    #[cfg(feature = "replace_proposal")]
     #[test]
     fn test_leaf_node_epoch() {
         let ext = LeafNodeEpochExt {

--- a/mls-rs/src/extension/built_in.rs
+++ b/mls-rs/src/extension/built_in.rs
@@ -235,6 +235,35 @@ impl MlsCodecExtension for ExternalSendersExt {
     }
 }
 
+/// Mark a LeafNode with the epoch in which it was created.  Note that a LeafNode with
+/// `leaf_node_source` set to `update` or `commit` is already bound to the `group_id` for the group
+/// by way of the `LeafNodeTBS` signed structure.
+#[cfg(feature = "replace_proposal")]
+#[cfg_attr(
+    all(feature = "ffi", not(test)),
+    safer_ffi_gen::ffi_type(clone, opaque)
+)]
+#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
+#[non_exhaustive]
+pub struct LeafNodeEpochExt {
+    pub epoch: u64,
+}
+
+#[cfg(feature = "replace_proposal")]
+#[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
+impl LeafNodeEpochExt {
+    pub fn new(epoch: u64) -> Self {
+        Self { epoch }
+    }
+}
+
+#[cfg(feature = "replace_proposal")]
+impl MlsCodecExtension for LeafNodeEpochExt {
+    fn extension_type() -> ExtensionType {
+        ExtensionType::LEAF_NODE_EPOCH
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -325,6 +354,19 @@ mod tests {
         assert_eq!(as_extension.extension_type, ExtensionType::EXTERNAL_PUB);
 
         let restored = ExternalPubExt::from_extension(&as_extension).unwrap();
+        assert_eq!(ext, restored)
+    }
+
+    #[test]
+    fn test_leaf_node_epoch() {
+        let ext = LeafNodeEpochExt {
+            epoch: 0x01234567890abcdef,
+        };
+
+        let as_extension = ext.clone().into_extension().unwrap();
+        assert_eq!(as_extension.extension_type, ExtensionType::LEAF_NODE_EPOCH);
+
+        let restored = LeafNodeEpochExt::from_extension(&as_extension).unwrap();
         assert_eq!(ext, restored)
     }
 }

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -230,8 +230,12 @@ where
 
     /// Insert a [`ReplaceProposal`](crate::group::proposal::ReplaceProposal) into
     /// the current commit that is being built.
-    pub fn replace_member(mut self, index: u32, leaf_node: LeafNode) -> Result<Self, MlsError> {
-        let proposal = self.group.replace_proposal(index, leaf_node)?;
+    pub fn replace_member(
+        mut self,
+        to_replace: u32,
+        leaf_node: LeafNode,
+    ) -> Result<Self, MlsError> {
+        let proposal = self.group.replace_proposal(to_replace, leaf_node)?;
         self.proposals.push(proposal);
         Ok(self)
     }
@@ -1059,7 +1063,11 @@ mod tests {
     #[cfg(feature = "replace_proposal")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn test_commit_builder_replace() {
-        let mut group = test_commit_builder_group().await;
+        let mut group = test_group_custom_config(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, |b| {
+            b.custom_proposal_type(ProposalType::REPLACE)
+        })
+        .await
+        .group;
 
         let (alice, alice_kp) =
             test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "a").await;

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -1033,6 +1033,7 @@ mod tests {
         assert_commit_builder_output(group, commit_output, vec![expected_remove], 0);
     }
 
+    #[cfg(feature = "replace_proposal")]
     fn replacement_leaf_node<C>(group: &mut Group<C>) -> Result<LeafNode, MlsError>
     where
         C: ClientConfig + Clone,

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -916,11 +916,11 @@ where
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn propose_replace(
         &mut self,
-        index: u32,
+        to_replace: u32,
         leaf_node: LeafNode,
         authenticated_data: Vec<u8>,
     ) -> Result<MlsMessage, MlsError> {
-        let proposal = self.replace_proposal(index, leaf_node).await?;
+        let proposal = self.replace_proposal(to_replace, leaf_node).await?;
         self.proposal_message(proposal, authenticated_data).await
     }
 
@@ -928,16 +928,16 @@ where
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn replace_proposal(
         &mut self,
-        _index: u32,
-        _leaf_node: LeafNode,
+        to_replace: u32,
+        leaf_node: LeafNode,
     ) -> Result<Proposal, MlsError> {
-        unimplemented!();
-        /*
+        // TODO(RLB) Verify that the new LeafNode is a plausible replacement for the current leaf
+        // node.
+
         Ok(Proposal::Replace(ReplaceProposal {
-            index: index,
-            leaf_node: new_leaf_node,
+            to_replace: LeafIndex(to_replace),
+            leaf_node,
         }))
-        */
     }
 
     /// Create a fresh LeafNode that can be used to update this member's leaf.

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -3049,7 +3049,6 @@ mod tests {
         assert_matches!(res, Err(MlsError::InvalidSuccessor));
     }
 
-    // TODO
     #[cfg(feature = "replace_proposal")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn sending_replace_for_different_identity_filters_it_out() {
@@ -3070,6 +3069,61 @@ mod tests {
 
         #[cfg(feature = "state_update")]
         assert_eq!(processed_proposals.1.unused_proposals, vec![replace_info]);
+    }
+
+    // TODO(RLB) Scenario
+    // * Alice creates the group
+    // * Bob joins
+    // * Bob creates a LeafNode
+    // * Bob commits
+    // * Alice sends Replace {1, bob_leaf_node}
+
+    #[cfg(feature = "replace_proposal")]
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn receiving_replace_for_old_epoch_fails() {
+        /*
+        let (alice, mut tree) = new_tree("alice").await;
+        let _bob = add_member(&mut tree, "bob").await;
+
+        let replace = Proposal::Replace(make_replace_proposal(1, "carol"));
+        let replace_ref = make_proposal_ref(&replace, alice).await;
+
+        let res = CommitReceiver::new(
+            &tree,
+            alice,
+            alice,
+            test_cipher_suite_provider(TEST_CIPHER_SUITE),
+        )
+        .cache(replace_ref.clone(), replace, alice)
+        .receive([replace_ref])
+        .await;
+
+        assert_matches!(res, Err(MlsError::InvalidSuccessor));
+        */
+    }
+
+    #[cfg(feature = "replace_proposal")]
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn sending_replace_for_old_epoch_filters_it_out() {
+        /*
+        let (alice, mut tree) = new_tree("alice").await;
+        let _bob = add_member(&mut tree, "bob").await;
+
+        let replace = Proposal::Replace(make_replace_proposal(1, "carol"));
+        let replace_info = make_proposal_info(&replace, alice).await;
+
+        let processed_proposals =
+            CommitSender::new(&tree, alice, test_cipher_suite_provider(TEST_CIPHER_SUITE))
+                .cache(replace_info.proposal_ref().unwrap().clone(), replace, alice)
+                .send()
+                .await
+                .unwrap();
+
+        assert_eq!(processed_proposals.0, Vec::new());
+
+        #[cfg(feature = "state_update")]
+        assert_eq!(processed_proposals.1.unused_proposals, vec![replace_info]);
+        */
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -306,6 +306,9 @@ impl ProposalBundle {
         #[cfg(feature = "by_ref_proposal")]
         let res = res.chain(self.updates.into_iter().map(|p| p.map(Proposal::Update)));
 
+        #[cfg(feature = "replace_proposal")]
+        let res = res.chain(self.replaces.into_iter().map(|p| p.map(Proposal::Replace)));
+
         res.chain(
             self.additions
                 .into_iter()

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -188,6 +188,11 @@ impl ProposalBundle {
             f(&proposal.as_ref().map(BorrowedProposal::from))
         })?;
 
+        #[cfg(feature = "replace_proposal")]
+        self.retain_by_type::<ReplaceProposal, _, _>(|proposal| {
+            f(&proposal.as_ref().map(BorrowedProposal::from))
+        })?;
+
         self.retain_by_type::<RemoveProposal, _, _>(|proposal| {
             f(&proposal.as_ref().map(BorrowedProposal::from))
         })?;
@@ -356,6 +361,12 @@ impl ProposalBundle {
     #[cfg(feature = "by_ref_proposal")]
     pub fn update_proposal_senders(&self) -> &[LeafIndex] {
         &self.update_senders
+    }
+
+    /// Replace proposals in the bundle.
+    #[cfg(feature = "replace_proposal")]
+    pub fn replace_proposals(&self) -> &[ProposalInfo<ReplaceProposal>] {
+        &self.replaces
     }
 
     /// Remove proposals in the bundle.

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -11,10 +11,13 @@ use itertools::Itertools;
 use crate::{
     group::{
         AddProposal, BorrowedProposal, Proposal, ProposalOrRef, ProposalType, ReInitProposal,
-        RemoveProposal, ReplaceProposal, Sender,
+        RemoveProposal, Sender,
     },
     ExtensionList,
 };
+
+#[cfg(feature = "replace_proposal")]
+use crate::group::ReplaceProposal;
 
 #[cfg(feature = "by_ref_proposal")]
 use crate::group::{proposal_cache::CachedProposal, LeafIndex, ProposalRef, UpdateProposal};

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use crate::{
     group::{
         AddProposal, BorrowedProposal, Proposal, ProposalOrRef, ProposalType, ReInitProposal,
-        RemoveProposal, Sender,
+        RemoveProposal, ReplaceProposal, Sender,
     },
     ExtensionList,
 };
@@ -38,6 +38,8 @@ pub struct ProposalBundle {
     pub(crate) updates: Vec<ProposalInfo<UpdateProposal>>,
     #[cfg(feature = "by_ref_proposal")]
     pub(crate) update_senders: Vec<LeafIndex>,
+    #[cfg(feature = "replace_proposal")]
+    pub(crate) replaces: Vec<ProposalInfo<ReplaceProposal>>,
     pub(crate) removals: Vec<ProposalInfo<RemoveProposal>>,
     #[cfg(feature = "psk")]
     pub(crate) psks: Vec<ProposalInfo<PreSharedKeyProposal>>,
@@ -58,6 +60,12 @@ impl ProposalBundle {
             }),
             #[cfg(feature = "by_ref_proposal")]
             Proposal::Update(proposal) => self.updates.push(ProposalInfo {
+                proposal,
+                sender,
+                source,
+            }),
+            #[cfg(feature = "replace_proposal")]
+            Proposal::Replace(proposal) => self.replaces.push(ProposalInfo {
                 proposal,
                 sender,
                 source,
@@ -621,6 +629,8 @@ macro_rules! impl_proposable {
 impl_proposable!(AddProposal, ADD, additions);
 #[cfg(feature = "by_ref_proposal")]
 impl_proposable!(UpdateProposal, UPDATE, updates);
+#[cfg(feature = "replace_proposal")]
+impl_proposable!(ReplaceProposal, REPLACE, replaces);
 impl_proposable!(RemoveProposal, REMOVE, removals);
 #[cfg(feature = "psk")]
 impl_proposable!(PreSharedKeyProposal, PSK, psks);

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -262,6 +262,13 @@ impl ProposalBundle {
                 .map(|p| p.as_ref().map(BorrowedProposal::Update)),
         );
 
+        #[cfg(feature = "replace_proposal")]
+        let res = res.chain(
+            self.replaces
+                .iter()
+                .map(|p| p.as_ref().map(BorrowedProposal::Replace)),
+        );
+
         #[cfg(feature = "psk")]
         let res = res.chain(
             self.psks

--- a/mls-rs/src/group/proposal_filter/filtering.rs
+++ b/mls-rs/src/group/proposal_filter/filtering.rs
@@ -25,6 +25,9 @@ use super::filtering_common::{filter_out_invalid_psks, ApplyProposalsOutput, Pro
 #[cfg(feature = "by_ref_proposal")]
 use crate::extension::ExternalSendersExt;
 
+#[cfg(feature = "replace_proposal")]
+use crate::group::ReplaceProposal;
+
 use alloc::vec::Vec;
 use mls_rs_core::{error::IntoAnyError, identity::IdentityProvider, psk::PreSharedKeyStorage};
 
@@ -60,9 +63,12 @@ where
         commit_time: Option<MlsTime>,
     ) -> Result<ApplyProposalsOutput, MlsError> {
         let proposals = filter_out_invalid_proposers(strategy, proposals)?;
+        let proposals = filter_out_update_for_committer(strategy, commit_sender, proposals)?;
+        let proposals = filter_out_replace_for_committer(strategy, commit_sender, proposals)?;
+        let proposals = filter_out_duplicate_updates(strategy, commit_sender, proposals)?;
+        let proposals = filter_out_duplicate_replaces(strategy, commit_sender, proposals)?;
 
-        let mut proposals: ProposalBundle =
-            filter_out_update_for_committer(strategy, commit_sender, proposals)?;
+        let mut proposals = proposals;
 
         // We ignore the strategy here because the check above ensures all updates are from members
         proposals.update_senders = proposals
@@ -175,6 +181,7 @@ where
             Some(group_extensions_in_use),
         );
 
+        // Check that Updates are valid
         let bad_indices: Vec<_> = wrap_iter(proposals.update_proposals())
             .zip(wrap_iter(proposals.update_proposal_senders()))
             .enumerate()
@@ -220,6 +227,52 @@ where
             proposals.update_senders.remove(i);
         });
 
+        // Check that Replaces are valid
+        let bad_indices: Vec<_> = wrap_iter(proposals.replace_proposals())
+            .enumerate()
+            .filter_map(|(i, p)| async move {
+                let res = {
+                    let to_replace = p.proposal.to_replace;
+                    let leaf = &p.proposal.leaf_node;
+
+                    let res = leaf_node_validator
+                        .check_if_valid(
+                            leaf,
+                            ValidationContext::Update((self.group_id, *to_replace, commit_time)),
+                        )
+                        .await;
+
+                    let old_leaf = match self.original_tree.get_leaf_node(to_replace) {
+                        Ok(leaf) => leaf,
+                        Err(e) => return Some(Err(e)),
+                    };
+
+                    let valid_successor = self
+                        .identity_provider
+                        .valid_successor(
+                            &old_leaf.signing_identity,
+                            &leaf.signing_identity,
+                            group_extensions_in_use,
+                        )
+                        .await
+                        .map_err(|e| MlsError::IdentityProviderError(e.into_any_error()))
+                        .and_then(|valid| valid.then_some(()).ok_or(MlsError::InvalidSuccessor));
+
+                    res.and(valid_successor)
+                };
+
+                apply_strategy(strategy, p.is_by_reference(), res)
+                    .map(|b| (!b).then_some(i))
+                    .transpose()
+            })
+            .try_collect()
+            .await?;
+
+        bad_indices.into_iter().rev().for_each(|i| {
+            proposals.remove::<ReplaceProposal>(i);
+        });
+
+        // Check that Adds are valid
         let bad_indices: Vec<_> = wrap_iter(proposals.add_proposals())
             .enumerate()
             .filter_map(|(i, p)| async move {
@@ -291,6 +344,24 @@ fn filter_out_update_for_committer(
     Ok(proposals)
 }
 
+#[cfg(feature = "replace_proposal")]
+fn filter_out_replace_for_committer(
+    strategy: FilterStrategy,
+    commit_sender: LeafIndex,
+    mut proposals: ProposalBundle,
+) -> Result<ProposalBundle, MlsError> {
+    proposals.retain_by_type::<ReplaceProposal, _, _>(|p| {
+        apply_strategy(
+            strategy,
+            p.is_by_reference(),
+            (p.proposal.to_replace != commit_sender)
+                .then_some(())
+                .ok_or(MlsError::InvalidCommitSelfUpdate),
+        )
+    })?;
+    Ok(proposals)
+}
+
 fn filter_out_removal_of_committer(
     strategy: FilterStrategy,
     commit_sender: LeafIndex,
@@ -303,6 +374,63 @@ fn filter_out_removal_of_committer(
             (p.proposal.to_remove != commit_sender)
                 .then_some(())
                 .ok_or(MlsError::CommitterSelfRemoval),
+        )
+    })?;
+    Ok(proposals)
+}
+
+fn filter_out_duplicate_updates(
+    strategy: FilterStrategy,
+    _commit_sender: LeafIndex,
+    mut proposals: ProposalBundle,
+) -> Result<ProposalBundle, MlsError> {
+    let mut seen = vec![];
+    proposals.retain_by_type::<UpdateProposal, _, _>(|p| {
+        let Sender::Member(index) = p.sender else {
+            unreachable!()
+        };
+
+        let fresh = !seen.contains(&index);
+        seen.push(index);
+
+        apply_strategy(
+            strategy,
+            p.is_by_reference(),
+            fresh
+                .then_some(())
+                .ok_or(MlsError::UpdatingNonExistingMember),
+        )
+    })?;
+    Ok(proposals)
+}
+
+#[cfg(feature = "replace_proposal")]
+fn filter_out_duplicate_replaces(
+    strategy: FilterStrategy,
+    _commit_sender: LeafIndex,
+    mut proposals: ProposalBundle,
+) -> Result<ProposalBundle, MlsError> {
+    let mut seen: Vec<_> = proposals
+        .by_type::<UpdateProposal>()
+        .map(|p| {
+            let Sender::Member(index) = p.sender else {
+                unreachable!()
+            };
+            index
+        })
+        .collect();
+
+    proposals.retain_by_type::<ReplaceProposal, _, _>(|p| {
+        let index = *p.proposal.to_replace;
+        let fresh = !seen.contains(&index);
+        seen.push(index);
+
+        apply_strategy(
+            strategy,
+            p.is_by_reference(),
+            fresh
+                .then_some(())
+                .ok_or(MlsError::UpdatingNonExistingMember),
         )
     })?;
     Ok(proposals)
@@ -432,6 +560,7 @@ pub(crate) fn proposer_can_propose(
     by_ref: bool,
 ) -> Result<(), MlsError> {
     let can_propose = match (proposer, by_ref) {
+        #[cfg(not(feature = "replace_proposal"))]
         (Sender::Member(_), false) => matches!(
             proposal_type,
             ProposalType::ADD
@@ -440,10 +569,32 @@ pub(crate) fn proposer_can_propose(
                 | ProposalType::RE_INIT
                 | ProposalType::GROUP_CONTEXT_EXTENSIONS
         ),
+        #[cfg(feature = "replace_proposal")]
+        (Sender::Member(_), false) => matches!(
+            proposal_type,
+            ProposalType::ADD
+                | ProposalType::REPLACE
+                | ProposalType::REMOVE
+                | ProposalType::PSK
+                | ProposalType::RE_INIT
+                | ProposalType::GROUP_CONTEXT_EXTENSIONS
+        ),
+        #[cfg(not(feature = "replace_proposal"))]
         (Sender::Member(_), true) => matches!(
             proposal_type,
             ProposalType::ADD
                 | ProposalType::UPDATE
+                | ProposalType::REMOVE
+                | ProposalType::PSK
+                | ProposalType::RE_INIT
+                | ProposalType::GROUP_CONTEXT_EXTENSIONS
+        ),
+        #[cfg(feature = "replace_proposal")]
+        (Sender::Member(_), true) => matches!(
+            proposal_type,
+            ProposalType::ADD
+                | ProposalType::UPDATE
+                | ProposalType::REPLACE
                 | ProposalType::REMOVE
                 | ProposalType::PSK
                 | ProposalType::RE_INIT
@@ -494,6 +645,16 @@ pub(crate) fn filter_out_invalid_proposers(
         if !apply_strategy(strategy, p.is_by_reference(), res)? {
             proposals.remove::<UpdateProposal>(i);
             proposals.update_senders.remove(i);
+        }
+    }
+
+    #[cfg(feature = "replace_proposal")]
+    for i in (0..proposals.replace_proposals().len()).rev() {
+        let p = &proposals.replace_proposals()[i];
+        let res = proposer_can_propose(p.sender, ProposalType::REPLACE, p.is_by_reference());
+
+        if !apply_strategy(strategy, p.is_by_reference(), res)? {
+            proposals.remove::<ReplaceProposal>(i);
         }
     }
 

--- a/mls-rs/src/group/snapshot.rs
+++ b/mls-rs/src/group/snapshot.rs
@@ -13,10 +13,7 @@ use crate::{
 };
 
 #[cfg(feature = "by_ref_proposal")]
-use crate::{
-    crypto::{HpkePublicKey, HpkeSecretKey},
-    group::ProposalRef,
-};
+use crate::{crypto::HpkePublicKey, group::ProposalRef};
 
 #[cfg(feature = "by_ref_proposal")]
 use super::proposal_cache::{CachedProposal, ProposalCache};
@@ -33,7 +30,9 @@ use std::collections::HashMap;
 #[cfg(all(feature = "by_ref_proposal", not(feature = "std")))]
 use alloc::vec::Vec;
 
-use super::{cipher_suite_provider, epoch::EpochSecrets, state_repo::GroupStateRepository};
+use super::{
+    cipher_suite_provider, epoch::EpochSecrets, state_repo::GroupStateRepository, PendingUpdate,
+};
 
 #[derive(Debug, PartialEq, Clone, MlsEncode, MlsDecode, MlsSize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -44,9 +43,9 @@ pub(crate) struct Snapshot {
     epoch_secrets: EpochSecrets,
     key_schedule: KeySchedule,
     #[cfg(all(feature = "std", feature = "by_ref_proposal"))]
-    pending_updates: HashMap<HpkePublicKey, (HpkeSecretKey, Option<SignatureSecretKey>)>,
+    pending_updates: HashMap<HpkePublicKey, PendingUpdate>,
     #[cfg(all(not(feature = "std"), feature = "by_ref_proposal"))]
-    pending_updates: Vec<(HpkePublicKey, (HpkeSecretKey, Option<SignatureSecretKey>))>,
+    pending_updates: Vec<(HpkePublicKey, PendingUpdate)>,
     pending_commit: Option<CommitGeneration>,
     signer: SignatureSecretKey,
 }

--- a/mls-rs/src/group/snapshot.rs
+++ b/mls-rs/src/group/snapshot.rs
@@ -8,10 +8,13 @@ use crate::{
     group::{
         cipher_suite_provider, epoch::EpochSecrets, key_schedule::KeySchedule,
         state_repo::GroupStateRepository, CommitGeneration, ConfirmationTag, Group, GroupContext,
-        GroupState, InterimTranscriptHash, PendingUpdate, ReInitProposal, TreeKemPublic,
+        GroupState, InterimTranscriptHash, ReInitProposal, TreeKemPublic,
     },
     tree_kem::TreeKemPrivate,
 };
+
+#[cfg(any(feature = "by_ref_proposal", feature = "replace_proposal"))]
+use crate::group::PendingUpdate;
 
 #[cfg(feature = "by_ref_proposal")]
 use crate::{

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -50,6 +50,19 @@ impl TestGroup {
         self.group.update_proposal(None, None).await.unwrap()
     }
 
+    #[cfg(feature = "replace_proposal")]
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub(crate) async fn replace_proposal(
+        &mut self,
+        to_replace: u32,
+        leaf_node: LeafNode,
+    ) -> Proposal {
+        self.group
+            .replace_proposal(to_replace, leaf_node)
+            .await
+            .unwrap()
+    }
+
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub(crate) async fn join_with_custom_config<F>(
         &mut self,

--- a/mls-rs/src/tree_kem/leaf_node.rs
+++ b/mls-rs/src/tree_kem/leaf_node.rs
@@ -267,10 +267,12 @@ pub(crate) mod test_utils {
     use crate::{
         cipher_suite::CipherSuite,
         crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider},
+        extension::ApplicationIdExt,
         identity::test_utils::{get_test_signing_identity, BasicWithCustomProvider},
     };
 
-    use crate::extension::{ApplicationIdExt, ExtensionType};
+    #[cfg(feature = "replace_proposal")]
+    use crate::extension::ExtensionType;
 
     use super::*;
 

--- a/mls-rs/src/tree_kem/leaf_node.rs
+++ b/mls-rs/src/tree_kem/leaf_node.rs
@@ -270,7 +270,7 @@ pub(crate) mod test_utils {
         identity::test_utils::{get_test_signing_identity, BasicWithCustomProvider},
     };
 
-    use crate::extension::ApplicationIdExt;
+    use crate::extension::{ApplicationIdExt, ExtensionType};
 
     use super::*;
 
@@ -385,6 +385,10 @@ pub(crate) mod test_utils {
                 CredentialType::from(BasicWithCustomProvider::CUSTOM_CREDENTIAL_TYPE),
             ],
             cipher_suites: TestCryptoProvider::all_supported_cipher_suites(),
+
+            #[cfg(feature = "replace_proposal")]
+            extensions: vec![ExtensionType::LEAF_NODE_EPOCH],
+
             ..Default::default()
         }
     }


### PR DESCRIPTION
### Issues:

Resolves #170 

### Description of changes:

This PR implements a Replace proposal long the lines discussed in #170 and [draft-barnes-mls-replace](https://datatracker.ietf.org/doc/draft-barnes-mls-replace/).  Changes are gated behind a feature flag `replace_proposal`, as discussed in #171.

### Call-outs:

There are a few questions around error codes highlighted with `XXX(RLB)` in the code.

The current code does not reflect support for the Replace proposal in Capabilities when this feature is enabled, and probably should to be specification-compliant.  Somewhat surprisingly, this does not cause tests to fail.  I suspect there's a general bug to fix in that there doesn't seem to be any check that a proposal is supported by the group before it is applied.

### Testing:

In general, the testing strategy is broadly parallel to testing of Update, since this new proposal type is closely related:

* Tests that the commit builder properly includes Replace proposals in `src/group/commit.rs`
* Tests of overall functionality in `src/group/mod.rs`
* Tests that proposal list rules are applied in `src/group/proposal_cache.rs`

As a small drive-by, I also added tests that duplicate Updates are correctly filtered / detected, and the corresponding code to implement this policy.

I think these tests are complete and in the right places, but my familiarity with this code base is pretty rudimentary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
