### PR TITLE
Add commit_required function on Group

### DIFF
--- a/mls-rs-codec/Cargo.toml
+++ b/mls-rs-codec/Cargo.toml
@@ -25,3 +25,6 @@ wasm-bindgen-test = { version = "0.3.26", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2.79" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -47,3 +47,6 @@ wasm-bindgen-test = { version = "0.3.26", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "^0.2.79" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)', 'cfg(coverage_nightly)'] }

--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -27,3 +27,6 @@ futures-test = "0.3.25"
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-crypto-cryptokit/Cargo.toml
+++ b/mls-rs-crypto-cryptokit/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/awslabs/mls-rs"
 keywords = ["mls", "mls-rs", "CryptoKit"]
 license = "Apache-2.0 OR MIT"
 
+[features]
+default = ["std"]
+std = ["dep:thiserror", "mls-rs-core/std", "mls-rs-crypto-traits/std"]
+
 [build-dependencies]
 # For parsing Swift outputs to build and link the bridge library
 serde = { version = "1.0", features = ["derive"] }
@@ -22,6 +26,7 @@ mls-rs-core = { path = "../mls-rs-core", version = "0.19.0", features = ["test_s
 maybe-async = "0.2.10"
 mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.19.0" }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.11.0" }
+thiserror = { version = "1.0.63", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 
 [target.'cfg(mls_build_async)'.dependencies]

--- a/mls-rs-crypto-cryptokit/Cargo.toml
+++ b/mls-rs-crypto-cryptokit/Cargo.toml
@@ -26,3 +26,6 @@ zeroize = { version = "1", default-features = false, features = ["alloc", "zeroi
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-crypto-hpke/Cargo.toml
+++ b/mls-rs-crypto-hpke/Cargo.toml
@@ -39,3 +39,6 @@ async-trait = "0.1.74"
 
 [target.'cfg(mls_build_async)'.dev-dependencies]
 futures-test = "0.3.25"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-crypto-openssl/Cargo.toml
+++ b/mls-rs-crypto-openssl/Cargo.toml
@@ -32,3 +32,6 @@ mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.10.0", featu
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -74,3 +74,6 @@ mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false,
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-crypto-traits/Cargo.toml
+++ b/mls-rs-crypto-traits/Cargo.toml
@@ -20,3 +20,6 @@ maybe-async = "0.2.10"
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-crypto-webcrypto/Cargo.toml
+++ b/mls-rs-crypto-webcrypto/Cargo.toml
@@ -32,3 +32,5 @@ futures-test = "0.3.25"
 serde_json = "^1.0"
 hex = { version = "^0.4.3", features = ["serde"] }
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-identity-x509/Cargo.toml
+++ b/mls-rs-identity-x509/Cargo.toml
@@ -33,3 +33,6 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "^0.2.79" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-identity-x509/src/lib.rs
+++ b/mls-rs-identity-x509/src/lib.rs
@@ -22,7 +22,6 @@ pub use traits::*;
 pub use mls_rs_core::identity::{CertificateChain, DerCertificate};
 
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// X.509 certificate request in DER format.
 pub struct DerCertificateRequest(Vec<u8>);
 
@@ -34,7 +33,6 @@ impl Debug for DerCertificateRequest {
     }
 }
 
-#[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen)]
 impl DerCertificateRequest {
     /// Create a DER certificate request from raw bytes.
     pub fn new(data: Vec<u8>) -> DerCertificateRequest {

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -31,3 +31,6 @@ sqlite = ["rusqlite/modern_sqlite"]
 sqlite-bundled = ["sqlite", "rusqlite/bundled"]
 sqlcipher = ["sqlite", "rusqlite/sqlcipher"]
 sqlcipher-bundled = ["sqlite", "rusqlite/bundled-sqlcipher"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-uniffi/Cargo.toml
+++ b/mls-rs-uniffi/Cargo.toml
@@ -29,3 +29,6 @@ tokio = { version = "1.36.0", features = ["sync"] }
 [dev-dependencies]
 uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs/", rev = "eeb785c", version = "0.27.0" }
 anyhow = "1"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -158,4 +158,4 @@ name = "client_tests"
 required-features = ["test_util"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)', 'cfg(coverage_nightly)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)', 'cfg(coverage_nightly)', 'cfg(awslc)', 'cfg(rustcrypto)'] }

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.41.0"
+version = "0.41.1"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -156,3 +156,6 @@ required-features = ["benchmark_util"]
 [[test]]
 name = "client_tests"
 required-features = ["test_util"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)', 'cfg(coverage_nightly)'] }

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -110,7 +110,7 @@ impl ProposalCache {
         self.own_proposals.clear();
     }
 
-    #[cfg(feature = "private_message")]
+    #[cfg(feature = "by_ref_proposal")]
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.proposals.is_empty()

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -14,7 +14,7 @@
 //! ## MLS Protocol Features
 //!
 //! - Multi-party E2EE [group evolution](https://www.rfc-editor.org/rfc/rfc9420.html#name-cryptographic-state-and-evo)
-//! via a propose-then-commit mechanism.
+//!   via a propose-then-commit mechanism.
 //! - Asynchronous by design with pre-computed [key packages](https://www.rfc-editor.org/rfc/rfc9420.html#name-key-packages),
 //!   allowing members to be added to a group while offline.
 //! - Customizable credential system with built in support for X.509 certificates.

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -966,7 +966,7 @@ mod tests {
         key_package::test_utils::test_key_package,
     };
 
-    #[cfg(any(feature = "by_ref_proposal", feature = "custo_proposal"))]
+    #[cfg(any(feature = "by_ref_proposal", feature = "custom_proposal"))]
     use crate::tree_kem::leaf_node::test_utils::get_basic_test_node;
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]


### PR DESCRIPTION
Resolves #156 

### Description of changes:

Sometimes it is nice to be able to determine if `Group::encrypt_application_message` will return `MlsError::CommitRequired` without actually trying to encrypt a message.

### Call-outs:

bumped version to 0.41.1

### Testing:

Added a test to cover this function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
