### PR TITLE
Let `TestGroup` deref to `Group`

### DIFF
--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -855,7 +855,7 @@ mod tests {
 
         let proposal = bob
             .external_add_proposal(
-                &alice_group.group.group_info_message(true).await.unwrap(),
+                &alice_group.group_info_message(true).await.unwrap(),
                 None,
                 vec![],
             )
@@ -863,7 +863,6 @@ mod tests {
             .unwrap();
 
         let message = alice_group
-            .group
             .process_incoming_message(proposal)
             .await
             .unwrap();
@@ -875,12 +874,11 @@ mod tests {
             ) if p.key_package.leaf_node.signing_identity == bob_identity
         );
 
-        alice_group.group.commit(vec![]).await.unwrap();
-        alice_group.group.apply_pending_commit().await.unwrap();
+        alice_group.commit(vec![]).await.unwrap();
+        alice_group.apply_pending_commit().await.unwrap();
 
         // Check that the new member is in the group
         assert!(alice_group
-            .group
             .roster()
             .members_iter()
             .any(|member| member.signing_identity == bob_identity))
@@ -912,7 +910,6 @@ mod tests {
             .unwrap();
 
         let group_info_msg = alice_group
-            .group
             .group_info_message_allowing_ext_commit(true)
             .await
             .unwrap();
@@ -944,26 +941,24 @@ mod tests {
         assert_eq!(new_group.roster().members_iter().count(), num_members);
 
         let _ = alice_group
-            .group
             .process_incoming_message(external_commit.clone())
             .await
             .unwrap();
 
-        let bob_current_epoch = bob_group.group.current_epoch();
+        let bob_current_epoch = bob_group.current_epoch();
 
         let message = bob_group
-            .group
             .process_incoming_message(external_commit)
             .await
             .unwrap();
 
-        assert!(alice_group.group.roster().members_iter().count() == num_members);
+        assert!(alice_group.roster().members_iter().count() == num_members);
 
         if !do_remove {
-            assert!(bob_group.group.roster().members_iter().count() == num_members);
+            assert!(bob_group.roster().members_iter().count() == num_members);
         } else {
             // Bob was removed so his epoch must stay the same
-            assert_eq!(bob_group.group.current_epoch(), bob_current_epoch);
+            assert_eq!(bob_group.current_epoch(), bob_current_epoch);
 
             assert_matches!(
                 message,
@@ -979,7 +974,7 @@ mod tests {
 
         // Comparing epoch authenticators is sufficient to check that members are in sync.
         assert_eq!(
-            alice_group.group.epoch_authenticator().unwrap(),
+            alice_group.epoch_authenticator().unwrap(),
             new_group.epoch_authenticator().unwrap()
         );
 
@@ -1019,11 +1014,10 @@ mod tests {
         let mut alice_group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
         let mut bob_group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
 
-        bob_group.group.commit(vec![]).await.unwrap();
-        bob_group.group.apply_pending_commit().await.unwrap();
+        bob_group.commit(vec![]).await.unwrap();
+        bob_group.apply_pending_commit().await.unwrap();
 
         let group_info_msg = bob_group
-            .group
             .group_info_message_allowing_ext_commit(true)
             .await
             .unwrap();
@@ -1043,10 +1037,7 @@ mod tests {
             .unwrap();
 
         // If Carol tries to join Alice's group using the group info from Bob's group, that fails.
-        let res = alice_group
-            .group
-            .process_incoming_message(external_commit)
-            .await;
+        let res = alice_group.process_incoming_message(external_commit).await;
         assert_matches!(res, Err(_));
     }
 

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -787,7 +787,6 @@ pub(crate) mod test_utils {
             config,
             None,
             group
-                .group
                 .group_info_message_allowing_ext_commit(true)
                 .await
                 .unwrap(),
@@ -833,7 +832,7 @@ mod tests {
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     async fn test_group_with_one_commit(v: ProtocolVersion, cs: CipherSuite) -> TestGroup {
         let mut group = test_group(v, cs).await;
-        group.group.commit(Vec::new()).await.unwrap();
+        group.commit(Vec::new()).await.unwrap();
         group.process_pending_commit().await.unwrap();
         group
     }
@@ -848,11 +847,7 @@ mod tests {
 
         let bob_key_package = test_key_package_message(v, cs, "bob").await;
 
-        let mut commit_builder = group
-            .group
-            .commit_builder()
-            .add_member(bob_key_package)
-            .unwrap();
+        let mut commit_builder = group.commit_builder().add_member(bob_key_package).unwrap();
 
         #[cfg(feature = "by_ref_proposal")]
         if let Some(ext_signer) = ext_identity {
@@ -888,15 +883,15 @@ mod tests {
     async fn external_group_can_process_commit() {
         let mut alice = test_group_with_one_commit(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
         let mut server = make_external_group(&alice).await;
-        let commit_output = alice.group.commit(Vec::new()).await.unwrap();
-        alice.group.apply_pending_commit().await.unwrap();
+        let commit_output = alice.commit(Vec::new()).await.unwrap();
+        alice.apply_pending_commit().await.unwrap();
 
         server
             .process_incoming_message(commit_output.commit_message)
             .await
             .unwrap();
 
-        assert_eq!(alice.group.state, server.state);
+        assert_eq!(alice.state, server.state);
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
@@ -920,8 +915,8 @@ mod tests {
             ExternalReceivedMessage::Proposal(ProposalMessageDescription { ref proposal, ..}) if proposal == &add_proposal
         );
 
-        let commit_output = alice.group.commit(vec![]).await.unwrap();
-        alice.group.apply_pending_commit().await.unwrap();
+        let commit_output = alice.commit(vec![]).await.unwrap();
+        alice.apply_pending_commit().await.unwrap();
 
         let new_epoch = match server
             .process_incoming_message(commit_output.commit_message)
@@ -942,7 +937,7 @@ mod tests {
             .into_iter()
             .any(|p| p.proposal == add_proposal));
 
-        assert_eq!(alice.group.state, server.state);
+        assert_eq!(alice.state, server.state);
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
@@ -972,7 +967,7 @@ mod tests {
 
         assert_eq!(server.state.public_tree.get_leaf_nodes().len(), 2);
 
-        assert_eq!(alice.group.state, server.state);
+        assert_eq!(alice.state, server.state);
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
@@ -980,7 +975,7 @@ mod tests {
         let mut alice = test_group_with_one_commit(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
         let mut server = make_external_group(&alice).await;
 
-        let mut commit_output = alice.group.commit(vec![]).await.unwrap();
+        let mut commit_output = alice.commit(vec![]).await.unwrap();
 
         match commit_output.commit_message.payload {
             MlsMessagePayload::Plain(ref mut plain) => plain.content.epoch = 0,
@@ -1004,7 +999,7 @@ mod tests {
         )
         .await;
 
-        let mut commit_output = alice.group.commit(Vec::new()).await.unwrap();
+        let mut commit_output = alice.commit(Vec::new()).await.unwrap();
 
         match commit_output.commit_message.payload {
             MlsMessagePayload::Plain(ref mut plain) => plain.auth.signature = Vec::new().into(),
@@ -1044,7 +1039,6 @@ mod tests {
             config,
             None,
             alice
-                .group
                 .group_info_message_allowing_ext_commit(true)
                 .await
                 .unwrap(),
@@ -1066,7 +1060,6 @@ mod tests {
         let config = TestExternalClientBuilder::new_for_test().build_config();
 
         let mut group_info = alice
-            .group
             .group_info_message_allowing_ext_commit(true)
             .await
             .unwrap();
@@ -1119,7 +1112,7 @@ mod tests {
         alice.process_message(external_proposal).await.unwrap();
 
         // Alice commits the proposal
-        let commit_output = alice.group.commit(vec![]).await.unwrap();
+        let commit_output = alice.commit(vec![]).await.unwrap();
 
         let commit = match commit_output
             .commit_message
@@ -1145,7 +1138,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(alice.group.state, server.state);
+        assert_eq!(alice.state, server.state);
     }
 
     #[cfg(feature = "by_ref_proposal")]
@@ -1237,12 +1230,11 @@ mod tests {
         .await;
 
         let old_application_msg = alice
-            .group
             .encrypt_application_message(&[], vec![])
             .await
             .unwrap();
 
-        let commit_output = alice.group.commit(vec![]).await.unwrap();
+        let commit_output = alice.commit(vec![]).await.unwrap();
 
         server
             .process_incoming_message(commit_output.commit_message)
@@ -1266,9 +1258,9 @@ mod tests {
         )
         .await;
 
-        let proposal = alice.group.propose_update(vec![]).await.unwrap();
+        let proposal = alice.propose_update(vec![]).await.unwrap();
 
-        let commit_output = alice.group.commit(vec![]).await.unwrap();
+        let commit_output = alice.commit(vec![]).await.unwrap();
 
         server
             .process_incoming_message(proposal.clone())
@@ -1288,7 +1280,6 @@ mod tests {
         let mut alice = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
 
         let info = alice
-            .group
             .group_info_message_allowing_ext_commit(true)
             .await
             .unwrap();
@@ -1297,7 +1288,7 @@ mod tests {
         let mut server = ExternalGroup::join(config, None, info, None).await.unwrap();
 
         for _ in 0..2 {
-            let commit = alice.group.commit(vec![]).await.unwrap().commit_message;
+            let commit = alice.commit(vec![]).await.unwrap().commit_message;
             alice.process_pending_commit().await.unwrap();
             server.process_incoming_message(commit).await.unwrap();
         }
@@ -1325,7 +1316,6 @@ mod tests {
         let mut server = make_external_group(&alice).await;
 
         let info = alice
-            .group
             .group_info_message_allowing_ext_commit(false)
             .await
             .unwrap();
@@ -1355,7 +1345,6 @@ mod tests {
         let mut server = make_external_group(&alice).await;
 
         let [welcome] = alice
-            .group
             .commit_builder()
             .add_member(
                 test_key_package_message(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "john").await,

--- a/mls-rs/src/group/ciphertext_processor.rs
+++ b/mls-rs/src/group/ciphertext_processor.rs
@@ -305,10 +305,10 @@ mod test {
 
         let content = AuthenticatedContent::new_signed(
             &provider,
-            group.group.context(),
+            group.context(),
             Sender::Member(0),
             Content::Application(ApplicationData::from(b"test".to_vec())),
-            &group.group.signer,
+            &group.signer,
             WireFormat::PrivateMessage,
             vec![],
         )
@@ -331,7 +331,7 @@ mod test {
                 .await
                 .unwrap();
 
-            receiver_group.group.private_tree.self_index = LeafIndex::new(1);
+            receiver_group.private_tree.self_index = LeafIndex::new(1);
 
             let mut receiver_processor = test_processor(&mut receiver_group, cipher_suite);
 
@@ -401,7 +401,7 @@ mod test {
             .unwrap();
 
         ciphertext.ciphertext = random_bytes(ciphertext.ciphertext.len());
-        receiver_group.group.private_tree.self_index = LeafIndex::new(1);
+        receiver_group.private_tree.self_index = LeafIndex::new(1);
 
         let res = ciphertext_processor.open(&ciphertext).await;
 

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -1245,19 +1245,11 @@ mod tests {
         let (bob, bob_kp) =
             test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "b").await;
 
-        group
-            .group
-            .propose_add(alice_kp.clone(), vec![])
-            .await
-            .unwrap();
+        group.propose_add(alice_kp.clone(), vec![]).await.unwrap();
 
-        group
-            .group
-            .propose_add(bob_kp.clone(), vec![])
-            .await
-            .unwrap();
+        group.propose_add(bob_kp.clone(), vec![]).await.unwrap();
 
-        let output = group.group.commit(Vec::new()).await.unwrap();
+        let output = group.commit(Vec::new()).await.unwrap();
         let welcomes = output.welcome_messages;
 
         let cs = test_cipher_suite_provider(TEST_CIPHER_SUITE);
@@ -1283,7 +1275,6 @@ mod tests {
         let (identity, secret_key) = get_test_signing_identity(cs, b"member").await;
 
         let commit_output = groups[0]
-            .group
             .commit_builder()
             .set_new_signing_identity(secret_key, identity.clone())
             .build()
@@ -1292,7 +1283,7 @@ mod tests {
 
         // Check that the credential was updated by in the committer's state.
         groups[0].process_pending_commit().await.unwrap();
-        let new_member = groups[0].group.roster().member_with_index(0).unwrap();
+        let new_member = groups[0].roster().member_with_index(0).unwrap();
 
         assert_eq!(
             new_member.signing_identity.credential,
@@ -1310,7 +1301,7 @@ mod tests {
             .await
             .unwrap();
 
-        let new_member = groups[1].group.roster().member_with_index(0).unwrap();
+        let new_member = groups[1].roster().member_with_index(0).unwrap();
 
         assert_eq!(
             new_member.signing_identity.credential,
@@ -1332,8 +1323,7 @@ mod tests {
             None,
             Some(CommitOptions::new().with_ratchet_tree_extension(false)),
         )
-        .await
-        .group;
+        .await;
 
         let commit = group.commit(vec![]).await.unwrap();
 
@@ -1353,8 +1343,7 @@ mod tests {
             None,
             Some(CommitOptions::new().with_ratchet_tree_extension(true)),
         )
-        .await
-        .group;
+        .await;
 
         let commit = group.commit(vec![]).await.unwrap();
 
@@ -1374,8 +1363,7 @@ mod tests {
                     .with_ratchet_tree_extension(false),
             ),
         )
-        .await
-        .group;
+        .await;
 
         let commit = group.commit(vec![]).await.unwrap();
 
@@ -1402,8 +1390,7 @@ mod tests {
                     .with_ratchet_tree_extension(true),
             ),
         )
-        .await
-        .group;
+        .await;
 
         let commit = group.commit(vec![]).await.unwrap();
 
@@ -1426,8 +1413,7 @@ mod tests {
             None,
             Some(CommitOptions::new().with_allow_external_commit(false)),
         )
-        .await
-        .group;
+        .await;
 
         let commit = group.commit(vec![]).await.unwrap();
 
@@ -1627,9 +1613,7 @@ mod tests {
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn detached_commit() {
-        let mut group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE)
-            .await
-            .group;
+        let mut group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
 
         let (_commit, secrets) = group.commit_builder().build_detached().await.unwrap();
         assert!(group.pending_commit.is_none());

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1963,8 +1963,7 @@ mod tests {
                 .into_iter()
                 .map(move |cs| (p, cs))
         }) {
-            let test_group = test_group(protocol_version, cipher_suite).await;
-            let group = test_group.group;
+            let group = test_group(protocol_version, cipher_suite).await;
 
             assert_eq!(group.cipher_suite(), cipher_suite);
             assert_eq!(group.state.context.epoch, 0);
@@ -2001,33 +2000,26 @@ mod tests {
             test_member(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, b"bob").await;
 
         let proposal = test_group
-            .group
             .add_proposal(bob_key_package.key_package_message())
             .unwrap();
 
-        test_group
-            .group
-            .proposal_message(proposal, vec![])
-            .await
-            .unwrap();
+        test_group.proposal_message(proposal, vec![]).await.unwrap();
 
         // We should not be able to send application messages until a commit happens
         let res = test_group
-            .group
             .encrypt_application_message(b"test", vec![])
             .await;
 
         assert_matches!(res, Err(MlsError::CommitRequired));
 
         // We should be able to send application messages after a commit
-        test_group.group.commit(vec![]).await.unwrap();
+        test_group.commit(vec![]).await.unwrap();
 
-        assert!(test_group.group.has_pending_commit());
+        assert!(test_group.has_pending_commit());
 
-        test_group.group.apply_pending_commit().await.unwrap();
+        test_group.apply_pending_commit().await.unwrap();
 
         let res = test_group
-            .group
             .encrypt_application_message(b"test", vec![])
             .await;
 
@@ -2050,7 +2042,7 @@ mod tests {
         )
         .await;
 
-        let existing_leaf = test_group.group.current_user_leaf_node().unwrap().clone();
+        let existing_leaf = test_group.current_user_leaf_node().unwrap().clone();
 
         // Create an update proposal
         let proposal = test_group.update_proposal().await;
@@ -2084,7 +2076,7 @@ mod tests {
         let mut test_group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
 
         // Create an update proposal
-        let proposal_msg = test_group.group.propose_update(vec![]).await.unwrap();
+        let proposal_msg = test_group.propose_update(vec![]).await.unwrap();
 
         let proposal = match proposal_msg.into_plaintext().unwrap().content.content {
             Content::Proposal(p) => p,
@@ -2096,14 +2088,11 @@ mod tests {
             _ => panic!("found proposal message that isn't an update"),
         };
 
-        test_group.group.commit(vec![]).await.unwrap();
-        test_group.group.apply_pending_commit().await.unwrap();
+        test_group.commit(vec![]).await.unwrap();
+        test_group.apply_pending_commit().await.unwrap();
 
         // The leaf node should not be the one from the update, because the committer rejects it
-        assert_ne!(
-            &update_leaf,
-            test_group.group.current_user_leaf_node().unwrap()
-        );
+        assert_ne!(&update_leaf, test_group.current_user_leaf_node().unwrap());
     }
 
     #[cfg(feature = "by_ref_proposal")]
@@ -2121,7 +2110,6 @@ mod tests {
         }
 
         let proposal_message = alice_group
-            .group
             .proposal_message(proposal.clone(), vec![])
             .await
             .unwrap();
@@ -2132,20 +2120,19 @@ mod tests {
         };
 
         let proposal_ref = ProposalRef::from_content(
-            &bob_group.group.cipher_suite_provider,
+            &bob_group.cipher_suite_provider,
             &proposal_plaintext.clone().into(),
         )
         .await
         .unwrap();
 
         // Hack bob's receipt of the proposal
-        bob_group.group.state.proposals.insert(
-            proposal_ref,
-            proposal,
-            proposal_plaintext.content.sender,
-        );
+        bob_group
+            .state
+            .proposals
+            .insert(proposal_ref, proposal, proposal_plaintext.content.sender);
 
-        let commit_output = bob_group.group.commit(vec![]).await.unwrap();
+        let commit_output = bob_group.commit(vec![]).await.unwrap();
 
         assert_matches!(
             commit_output.commit_message,
@@ -2180,10 +2167,7 @@ mod tests {
 
         let (bob_test_group, _) = test_group.join("bob").await;
 
-        assert!(Group::equal_group_state(
-            &test_group.group,
-            &bob_test_group.group
-        ));
+        assert!(Group::equal_group_state(&test_group, &bob_test_group));
 
         (test_group, bob_test_group)
     }
@@ -2214,7 +2198,6 @@ mod tests {
 
         // Add bob to the group
         let commit_output = test_group
-            .group
             .commit_builder()
             .add_member(bob_key_package)
             .unwrap()
@@ -2248,9 +2231,7 @@ mod tests {
             })
             .unwrap();
 
-        let proposal = test_group
-            .group
-            .group_context_extensions_proposal(extension_list.clone());
+        let proposal = test_group.group_context_extensions_proposal(extension_list.clone());
 
         assert_matches!(proposal, Proposal::GroupContextExtensions(ext) if ext == extension_list);
     }
@@ -2266,7 +2247,6 @@ mod tests {
             test_group_custom(protocol_version, cipher_suite, vec![42.into()], None, None).await;
 
         let commit = test_group
-            .group
             .commit_builder()
             .set_group_context_ext(ext_list)
             .unwrap()
@@ -2294,12 +2274,12 @@ mod tests {
         let (mut test_group, _) =
             group_context_extension_proposal_test(extension_list.clone()).await;
 
-        let update = test_group.group.apply_pending_commit().await.unwrap();
+        let update = test_group.apply_pending_commit().await.unwrap();
 
         // FIXME: Test Reporting
         assert_matches!(update.effect, CommitEffect::NewEpoch(_));
 
-        assert_eq!(test_group.group.state.context.extensions, extension_list)
+        assert_eq!(test_group.state.context.extensions, extension_list)
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
@@ -2420,7 +2400,6 @@ mod tests {
         .await;
 
         let without_padding = test_group
-            .group
             .encrypt_application_message(&random_bytes(150), vec![])
             .await
             .unwrap();
@@ -2434,7 +2413,6 @@ mod tests {
             .await;
 
         let with_padding = test_group
-            .group
             .encrypt_application_message(&random_bytes(150), vec![])
             .await
             .unwrap();
@@ -2449,7 +2427,6 @@ mod tests {
         let group = test_group(protocol_version, cipher_suite).await;
 
         let info = group
-            .group
             .group_info_message(false)
             .await
             .unwrap()
@@ -2458,11 +2435,7 @@ mod tests {
 
         let info_msg = MlsMessage::new(protocol_version, MlsMessagePayload::GroupInfo(info));
 
-        let signing_identity = group
-            .group
-            .current_member_signing_identity()
-            .unwrap()
-            .clone();
+        let signing_identity = group.current_member_signing_identity().unwrap().clone();
 
         let res = external_commit::ExternalCommitBuilder::new(
             group.group.signer,
@@ -2489,7 +2462,7 @@ mod tests {
         )
         .await;
 
-        let commit_output = group.group.commit(vec![]).await.unwrap();
+        let commit_output = group.commit(vec![]).await.unwrap();
 
         let (test_client, _) =
             test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "bob").await;
@@ -2520,7 +2493,6 @@ mod tests {
             test_key_package_message(protocol_version, cipher_suite, "alice").await;
 
         test_group
-            .group
             .commit_builder()
             .add_member(test_key_package.clone())
             .unwrap()
@@ -2546,7 +2518,6 @@ mod tests {
         .await;
 
         test_group
-            .group
             .commit_builder()
             .add_member(test_key_package)
             .unwrap()
@@ -2577,7 +2548,7 @@ mod tests {
         )
         .await;
 
-        test_group.group.commit(vec![]).await.unwrap();
+        test_group.commit(vec![]).await.unwrap();
 
         assert!(!test_group
             .group
@@ -2601,7 +2572,7 @@ mod tests {
             .make_plaintext(Content::Application(b"hello".to_vec().into()))
             .await;
 
-        let res = bob.group.process_incoming_message(message).await;
+        let res = bob.process_incoming_message(message).await;
 
         assert_matches!(res, Err(MlsError::UnencryptedApplicationMessage));
     }
@@ -2621,7 +2592,6 @@ mod tests {
             .unwrap()
             .build(
                 alice_group
-                    .group
                     .group_info_message_allowing_ext_commit(true)
                     .await
                     .unwrap(),
@@ -2647,7 +2617,7 @@ mod tests {
 
         itertools::assert_equal(
             bob_group.roster().members_iter(),
-            alice_group.group.roster().members_iter(),
+            alice_group.roster().members_iter(),
         );
     }
 
@@ -2666,10 +2636,9 @@ mod tests {
         let (_, commit) = bob
             .external_commit_builder()
             .unwrap()
-            .with_tree_data(alice_group.group.export_tree().into_owned())
+            .with_tree_data(alice_group.export_tree().into_owned())
             .build(
                 alice_group
-                    .group
                     .group_info_message_allowing_ext_commit(false)
                     .await
                     .unwrap(),
@@ -2685,7 +2654,7 @@ mod tests {
         let (mut alice_group, mut bob_group) =
             test_two_member_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, true).await;
 
-        let mut commit_output = alice_group.group.commit(vec![]).await.unwrap();
+        let mut commit_output = alice_group.commit(vec![]).await.unwrap();
 
         let plaintext = match commit_output.commit_message.payload {
             MlsMessagePayload::Plain(ref mut plain) => plain,
@@ -2727,7 +2696,7 @@ mod tests {
     async fn group_with_path_required() -> TestGroup {
         let mut alice = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
 
-        alice.group.config.0.mls_rules.commit_options.path_required = true;
+        alice.config.0.mls_rules.commit_options.path_required = true;
 
         alice
     }
@@ -2739,7 +2708,6 @@ mod tests {
         alice.join("charlie").await;
 
         alice
-            .group
             .commit_builder()
             .remove_member(1)
             .unwrap()
@@ -2747,9 +2715,9 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(alice.group.private_tree.secret_keys[1].is_some());
+        assert!(alice.private_tree.secret_keys[1].is_some());
         alice.process_pending_commit().await.unwrap();
-        assert!(alice.group.private_tree.secret_keys[1].is_none());
+        assert!(alice.private_tree.secret_keys[1].is_none());
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
@@ -2759,7 +2727,6 @@ mod tests {
         let (mut charlie, _) = alice.join("charlie").await;
 
         let commit = charlie
-            .group
             .commit_builder()
             .remove_member(1)
             .unwrap()
@@ -2767,9 +2734,9 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(alice.group.private_tree.secret_keys[1].is_some());
+        assert!(alice.private_tree.secret_keys[1].is_some());
         alice.process_message(commit.commit_message).await.unwrap();
-        assert!(alice.group.private_tree.secret_keys[1].is_none());
+        assert!(alice.private_tree.secret_keys[1].is_none());
     }
 
     #[cfg(feature = "by_ref_proposal")]
@@ -2780,15 +2747,15 @@ mod tests {
         let (mut charlie, commit) = alice.join("charlie").await;
         bob.process_message(commit).await.unwrap();
 
-        let update = bob.group.propose_update(vec![]).await.unwrap();
+        let update = bob.propose_update(vec![]).await.unwrap();
         charlie.process_message(update.clone()).await.unwrap();
         alice.process_message(update).await.unwrap();
 
-        let commit = charlie.group.commit(vec![]).await.unwrap();
+        let commit = charlie.commit(vec![]).await.unwrap();
 
-        assert!(alice.group.private_tree.secret_keys[1].is_some());
+        assert!(alice.private_tree.secret_keys[1].is_some());
         alice.process_message(commit.commit_message).await.unwrap();
-        assert!(alice.group.private_tree.secret_keys[1].is_none());
+        assert!(alice.private_tree.secret_keys[1].is_none());
     }
 
     #[cfg(feature = "psk")]
@@ -2799,13 +2766,13 @@ mod tests {
         let (carol, commit) = alice.join("carol").await;
 
         // Apply the commit that adds carol
-        bob.group.process_incoming_message(commit).await.unwrap();
+        bob.process_incoming_message(commit).await.unwrap();
 
-        let bob_identity = bob.group.current_member_signing_identity().unwrap().clone();
-        let signer = bob.group.signer.clone();
+        let bob_identity = bob.current_member_signing_identity().unwrap().clone();
+        let signer = bob.signer.clone();
 
         let new_key_pkg = Client::new(
-            bob.group.config.clone(),
+            bob.config.clone(),
             Some(signer),
             Some((bob_identity, TEST_CIPHER_SUITE)),
             TEST_PROTOCOL_VERSION,
@@ -2815,17 +2782,16 @@ mod tests {
         .unwrap();
 
         let (mut alice_sub_group, welcome) = alice
-            .group
             .branch(b"subgroup".to_vec(), vec![new_key_pkg])
             .await
             .unwrap();
 
         let welcome = &welcome[0];
 
-        let (mut bob_sub_group, _) = bob.group.join_subgroup(welcome, None).await.unwrap();
+        let (mut bob_sub_group, _) = bob.join_subgroup(welcome, None).await.unwrap();
 
         // Carol can't join
-        let res = carol.group.join_subgroup(welcome, None).await.map(|_| ());
+        let res = carol.join_subgroup(welcome, None).await.map(|_| ());
         assert_matches!(res, Err(_));
 
         // Alice and Bob can still talk
@@ -2892,21 +2858,16 @@ mod tests {
         let bob_msg = b"I'm Bob";
 
         let msg = bob_group
-            .group
             .encrypt_application_message(bob_msg, vec![])
             .await
             .unwrap();
 
-        let received_by_alice = alice_group
-            .group
-            .process_incoming_message(msg)
-            .await
-            .unwrap();
+        let received_by_alice = alice_group.process_incoming_message(msg).await.unwrap();
 
         assert_matches!(
             received_by_alice,
             ReceivedMessage::ApplicationMessage(ApplicationMessageDescription { sender_index, .. })
-                if sender_index == bob_group.group.current_member_index()
+                if sender_index == bob_group.current_member_index()
         );
     }
 
@@ -2916,8 +2877,8 @@ mod tests {
         let (bob_group, _) = alice_group.join("bob").await;
 
         assert_eq!(
-            alice_group.group.epoch_authenticator().unwrap(),
-            bob_group.group.epoch_authenticator().unwrap()
+            alice_group.epoch_authenticator().unwrap(),
+            bob_group.epoch_authenticator().unwrap()
         );
     }
 
@@ -2928,13 +2889,11 @@ mod tests {
         let (mut bob_group, _) = alice_group.join("bob").await;
 
         let message = alice_group
-            .group
             .encrypt_application_message(b"foobar", Vec::new())
             .await
             .unwrap();
 
         let received_message = bob_group
-            .group
             .process_incoming_message(message.clone())
             .await
             .unwrap();
@@ -2944,7 +2903,7 @@ mod tests {
             ReceivedMessage::ApplicationMessage(m) if m.data() == b"foobar"
         );
 
-        let res = bob_group.group.process_incoming_message(message).await;
+        let res = bob_group.process_incoming_message(message).await;
 
         assert_matches!(res, Err(MlsError::KeyMissing(0)));
     }
@@ -2961,7 +2920,6 @@ mod tests {
         .await;
 
         alice_group
-            .group
             .commit_builder()
             .set_group_context_ext(
                 vec![RequiredCapabilitiesExt {
@@ -2989,7 +2947,6 @@ mod tests {
         );
 
         alice_group
-            .group
             .commit_builder()
             .add_member(test_key_package.clone())
             .unwrap()
@@ -3013,7 +2970,7 @@ mod tests {
                 if add.key_package == test_key_package.into_key_package().unwrap()
         );
 
-        assert_eq!(alice_group.group.roster().members_iter().count(), 2);
+        assert_eq!(alice_group.roster().members_iter().count(), 2);
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
@@ -3021,12 +2978,12 @@ mod tests {
         // RFC, 13.4.2. "The leaf_node_source field MUST be set to commit."
         let mut groups = test_n_member_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, 3).await;
 
-        groups[0].group.commit_modifiers.modify_leaf = |leaf, sk| {
+        groups[0].commit_modifiers.modify_leaf = |leaf, sk| {
             leaf.leaf_node_source = LeafNodeSource::Update;
             Some(sk.clone())
         };
 
-        let commit_output = groups[0].group.commit(vec![]).await.unwrap();
+        let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[2]
             .process_message(commit_output.commit_message)
@@ -3042,12 +2999,12 @@ mod tests {
         let mut groups = test_n_member_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, 3).await;
 
         // Group 0 starts using fixed key
-        groups[0].group.commit_modifiers.modify_leaf = |leaf, sk| {
+        groups[0].commit_modifiers.modify_leaf = |leaf, sk| {
             leaf.public_key = get_test_25519_key(1u8);
             Some(sk.clone())
         };
 
-        let commit_output = groups[0].group.commit(vec![]).await.unwrap();
+        let commit_output = groups[0].commit(vec![]).await.unwrap();
         groups[0].process_pending_commit().await.unwrap();
         groups[2]
             .process_message(commit_output.commit_message)
@@ -3055,7 +3012,7 @@ mod tests {
             .unwrap();
 
         // Group 0 tries to use the fixed key againd
-        let commit_output = groups[0].group.commit(vec![]).await.unwrap();
+        let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[2]
             .process_message(commit_output.commit_message)
@@ -3077,28 +3034,22 @@ mod tests {
         let mut groups = test_n_member_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, 10).await;
 
         // Group 1 uses the fixed key
-        groups[1].group.commit_modifiers.modify_leaf = |leaf, sk| {
+        groups[1].commit_modifiers.modify_leaf = |leaf, sk| {
             leaf.public_key = get_test_25519_key(1u8);
             Some(sk.clone())
         };
 
-        let commit_output = groups
-            .get_mut(1)
-            .unwrap()
-            .group
-            .commit(vec![])
-            .await
-            .unwrap();
+        let commit_output = groups.get_mut(1).unwrap().commit(vec![]).await.unwrap();
 
         process_commit(&mut groups, commit_output.commit_message, 1).await;
 
         // Group 0 tries to use the fixed key too
-        groups[0].group.commit_modifiers.modify_leaf = |leaf, sk| {
+        groups[0].commit_modifiers.modify_leaf = |leaf, sk| {
             leaf.public_key = get_test_25519_key(1u8);
             Some(sk.clone())
         };
 
-        let commit_output = groups[0].group.commit(vec![]).await.unwrap();
+        let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[7]
             .process_message(commit_output.commit_message)
@@ -3120,7 +3071,7 @@ mod tests {
         let mut groups = test_n_member_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, 10).await;
 
         // Group 1 uses the fixed key
-        groups[1].group.commit_modifiers.modify_leaf = |leaf, _| {
+        groups[1].commit_modifiers.modify_leaf = |leaf, _| {
             let sk = hex!(
                 "3468b4c890255c983e3d5cbf5cb64c1ef7f6433a518f2f3151d6672f839a06ebcad4fc381fe61822af45135c82921a348e6f46643d66ddefc70483565433714b"
             )
@@ -3132,18 +3083,12 @@ mod tests {
             Some(sk)
         };
 
-        let commit_output = groups
-            .get_mut(1)
-            .unwrap()
-            .group
-            .commit(vec![])
-            .await
-            .unwrap();
+        let commit_output = groups.get_mut(1).unwrap().commit(vec![]).await.unwrap();
 
         process_commit(&mut groups, commit_output.commit_message, 1).await;
 
         // Group 0 tries to use the fixed key too
-        groups[0].group.commit_modifiers.modify_leaf = |leaf, _| {
+        groups[0].commit_modifiers.modify_leaf = |leaf, _| {
             let sk = hex!(
                 "3468b4c890255c983e3d5cbf5cb64c1ef7f6433a518f2f3151d6672f839a06ebcad4fc381fe61822af45135c82921a348e6f46643d66ddefc70483565433714b"
             )
@@ -3155,7 +3100,7 @@ mod tests {
             Some(sk)
         };
 
-        let commit_output = groups[0].group.commit(vec![]).await.unwrap();
+        let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[7]
             .process_message(commit_output.commit_message)
@@ -3168,12 +3113,12 @@ mod tests {
     async fn commit_leaf_incorrect_signature() {
         let mut groups = test_n_member_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, 3).await;
 
-        groups[0].group.commit_modifiers.modify_leaf = |leaf, _| {
+        groups[0].commit_modifiers.modify_leaf = |leaf, _| {
             leaf.signature[0] ^= 1;
             None
         };
 
-        let commit_output = groups[0].group.commit(vec![]).await.unwrap();
+        let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[2]
             .process_message(commit_output.commit_message)
@@ -3463,17 +3408,17 @@ mod tests {
     async fn committing_degenerate_path_succeeds() {
         let mut groups = test_n_member_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, 10).await;
 
-        groups[0].group.commit_modifiers.modify_tree = |tree: &mut TreeKemPublic| {
+        groups[0].commit_modifiers.modify_tree = |tree: &mut TreeKemPublic| {
             tree.update_node(get_test_25519_key(1u8), 1).unwrap();
             tree.update_node(get_test_25519_key(1u8), 3).unwrap();
         };
 
-        groups[0].group.commit_modifiers.modify_leaf = |leaf, sk| {
+        groups[0].commit_modifiers.modify_leaf = |leaf, sk| {
             leaf.public_key = get_test_25519_key(1u8);
             Some(sk.clone())
         };
 
-        let commit_output = groups[0].group.commit(vec![]).await.unwrap();
+        let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[7]
             .process_message(commit_output.commit_message)
@@ -3487,7 +3432,6 @@ mod tests {
         let mut groups = test_n_member_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, 10).await;
 
         let commit_output = groups[0]
-            .group
             .commit_builder()
             .remove_member(1)
             .unwrap()
@@ -3504,11 +3448,11 @@ mod tests {
                 .unwrap();
         }
 
-        groups[0].group.commit_modifiers.modify_tree = |tree: &mut TreeKemPublic| {
+        groups[0].commit_modifiers.modify_tree = |tree: &mut TreeKemPublic| {
             tree.update_node(get_test_25519_key(1u8), 1).unwrap();
         };
 
-        groups[0].group.commit_modifiers.modify_path = |path: Vec<UpdatePathNode>| {
+        groups[0].commit_modifiers.modify_path = |path: Vec<UpdatePathNode>| {
             let mut path = path;
             let mut node = path[0].clone();
             node.public_key = get_test_25519_key(1u8);
@@ -3516,7 +3460,7 @@ mod tests {
             path
         };
 
-        let commit_output = groups[0].group.commit(vec![]).await.unwrap();
+        let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[7]
             .process_message(commit_output.commit_message)
@@ -3531,7 +3475,6 @@ mod tests {
         let mut groups = test_n_member_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, 10).await;
 
         let commit_output = groups[0]
-            .group
             .commit_builder()
             .remove_member(1)
             .unwrap()
@@ -3548,13 +3491,13 @@ mod tests {
                 .unwrap();
         }
 
-        groups[0].group.commit_modifiers.modify_path = |path: Vec<UpdatePathNode>| {
+        groups[0].commit_modifiers.modify_path = |path: Vec<UpdatePathNode>| {
             let mut path = path;
             path.pop();
             path
         };
 
-        let commit_output = groups[0].group.commit(vec![]).await.unwrap();
+        let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[7]
             .process_message(commit_output.commit_message)
@@ -3570,17 +3513,16 @@ mod tests {
         let (identity, secret_key) = get_test_signing_identity(TEST_CIPHER_SUITE, b"member").await;
 
         let update = groups[0]
-            .group
             .propose_update_with_identity(secret_key, identity.clone(), vec![])
             .await
             .unwrap();
 
         groups[1].process_message(update).await.unwrap();
-        let commit_output = groups[1].group.commit(vec![]).await.unwrap();
+        let commit_output = groups[1].commit(vec![]).await.unwrap();
 
         // Check that the credential was updated by in the committer's state.
         groups[1].process_pending_commit().await.unwrap();
-        let new_member = groups[1].group.roster().member_with_index(0).unwrap();
+        let new_member = groups[1].roster().member_with_index(0).unwrap();
 
         assert_eq!(
             new_member.signing_identity.credential,
@@ -3597,7 +3539,7 @@ mod tests {
             .process_message(commit_output.commit_message)
             .await
             .unwrap();
-        let new_member = groups[0].group.roster().member_with_index(0).unwrap();
+        let new_member = groups[0].roster().member_with_index(0).unwrap();
 
         assert_eq!(
             new_member.signing_identity.credential,
@@ -3618,13 +3560,9 @@ mod tests {
         let key_package =
             test_key_package_message(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "foobar").await;
 
-        let proposal = groups[0]
-            .group
-            .propose_add(key_package, vec![])
-            .await
-            .unwrap();
+        let proposal = groups[0].propose_add(key_package, vec![]).await.unwrap();
 
-        let commit = groups[0].group.commit(vec![]).await.unwrap().commit_message;
+        let commit = groups[0].commit(vec![]).await.unwrap().commit_message;
 
         // 10 years from now
         let future_time = MlsTime::now().seconds_since_epoch() + 10 * 365 * 24 * 3600;
@@ -3632,13 +3570,8 @@ mod tests {
         let future_time =
             MlsTime::from_duration_since_epoch(core::time::Duration::from_secs(future_time));
 
-        groups[1]
-            .group
-            .process_incoming_message(proposal)
-            .await
-            .unwrap();
+        groups[1].process_incoming_message(proposal).await.unwrap();
         let res = groups[1]
-            .group
             .process_incoming_message_with_time(commit, future_time)
             .await;
 
@@ -3673,7 +3606,6 @@ mod tests {
         let custom_proposal = CustomProposal::new(TEST_CUSTOM_PROPOSAL_TYPE, vec![0, 1, 2]);
 
         let commit = alice
-            .group
             .commit_builder()
             .custom_proposal(custom_proposal.clone())
             .build()
@@ -3684,7 +3616,7 @@ mod tests {
         let ReceivedMessage::Commit(CommitMessageDescription {
             effect: CommitEffect::NewEpoch(new_epoch),
             ..
-        }) = bob.group.process_incoming_message(commit).await.unwrap()
+        }) = bob.process_incoming_message(commit).await.unwrap()
         else {
             panic!("unexpected commit effect");
         };
@@ -3705,22 +3637,21 @@ mod tests {
         let custom_proposal = CustomProposal::new(TEST_CUSTOM_PROPOSAL_TYPE, vec![0, 1, 2]);
 
         let proposal = alice
-            .group
             .propose_custom(custom_proposal.clone(), vec![])
             .await
             .unwrap();
 
-        let recv_prop = bob.group.process_incoming_message(proposal).await.unwrap();
+        let recv_prop = bob.process_incoming_message(proposal).await.unwrap();
 
         assert_matches!(recv_prop, ReceivedMessage::Proposal(ProposalMessageDescription { proposal: Proposal::Custom(c), ..})
             if c == custom_proposal);
 
-        let commit = bob.group.commit(vec![]).await.unwrap().commit_message;
+        let commit = bob.commit(vec![]).await.unwrap().commit_message;
 
         let ReceivedMessage::Commit(CommitMessageDescription {
             effect: CommitEffect::NewEpoch(new_epoch),
             ..
-        }) = bob.group.process_incoming_message(commit).await.unwrap()
+        }) = bob.process_incoming_message(commit).await.unwrap()
         else {
             panic!("unexpected commit effect");
         };
@@ -3736,9 +3667,7 @@ mod tests {
     #[cfg(feature = "psk")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn can_join_with_psk() {
-        let mut alice = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE)
-            .await
-            .group;
+        let mut alice = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
 
         let (bob, key_pkg) =
             test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "bob").await;
@@ -4123,9 +4052,7 @@ mod tests {
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn group_can_receive_commit_from_self() {
-        let mut group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE)
-            .await
-            .group;
+        let mut group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
 
         let commit = group.commit(vec![]).await.unwrap();
 
@@ -4145,16 +4072,12 @@ mod tests {
     async fn can_process_commit_when_pending_commit() {
         let mut groups = test_n_member_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, 2).await;
 
-        let commit = groups[0].group.commit(vec![]).await.unwrap().commit_message;
-        groups[1].group.commit(vec![]).await.unwrap();
+        let commit = groups[0].commit(vec![]).await.unwrap().commit_message;
+        groups[1].commit(vec![]).await.unwrap();
 
-        groups[1]
-            .group
-            .process_incoming_message(commit)
-            .await
-            .unwrap();
+        groups[1].process_incoming_message(commit).await.unwrap();
 
-        let res = groups[1].group.apply_pending_commit().await;
+        let res = groups[1].apply_pending_commit().await;
         assert_matches!(res, Err(MlsError::PendingCommitNotFound));
     }
 
@@ -4185,8 +4108,8 @@ mod tests {
             group: alice.create_group(Default::default()).await.unwrap(),
         };
 
-        let mut bob = alice.join("bob").await.0.group;
-        let mut alice = alice.group;
+        let mut bob = alice.join("bob").await.0;
+        let mut alice = alice;
 
         let upd = alice.propose_update(vec![]).await.unwrap();
         alice.process_incoming_message(upd.clone()).await.unwrap();
@@ -4212,24 +4135,22 @@ mod tests {
     async fn commit_clears_proposals() {
         let mut groups = test_n_member_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, 2).await;
 
-        groups[0].group.propose_update(vec![]).await.unwrap();
+        groups[0].propose_update(vec![]).await.unwrap();
 
-        assert_eq!(groups[0].group.state.proposals.proposals.len(), 1);
-        assert_eq!(groups[0].group.state.proposals.own_proposals.len(), 1);
+        assert_eq!(groups[0].state.proposals.proposals.len(), 1);
+        assert_eq!(groups[0].state.proposals.own_proposals.len(), 1);
 
-        let commit = groups[1].group.commit(vec![]).await.unwrap().commit_message;
+        let commit = groups[1].commit(vec![]).await.unwrap().commit_message;
         groups[0].process_message(commit).await.unwrap();
 
-        assert!(groups[0].group.state.proposals.proposals.is_empty());
-        assert!(groups[0].group.state.proposals.own_proposals.is_empty());
+        assert!(groups[0].state.proposals.proposals.is_empty());
+        assert!(groups[0].state.proposals.own_proposals.is_empty());
     }
 
     #[cfg(feature = "by_ref_proposal")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn commit_required_is_true_when_proposals_pending() {
-        let mut group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE)
-            .await
-            .group;
+        let mut group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
 
         assert!(!group.commit_required());
 

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -1374,7 +1374,7 @@ mod tests {
 
         let kem_output = vec![0; cipher_suite_provider.kdf_extract_size()];
         let group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
-        let public_tree = &group.group.state.public_tree;
+        let public_tree = &group.state.public_tree;
 
         let res = cache
             .resolve_for_commit_default(
@@ -1383,7 +1383,7 @@ mod tests {
                     ExternalInit { kem_output },
                 )))],
                 None,
-                &group.group.context().extensions,
+                &group.context().extensions,
                 &BasicIdentityProvider,
                 &cipher_suite_provider,
                 public_tree,
@@ -1414,14 +1414,14 @@ mod tests {
         );
 
         let group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
-        let public_tree = &group.group.state.public_tree;
+        let public_tree = &group.state.public_tree;
 
         let res = cache
             .resolve_for_commit_default(
                 Sender::NewMemberCommit,
                 vec![ProposalOrRef::Reference(proposal_ref)],
                 Some(&test_node().await),
-                &group.group.context().extensions,
+                &group.context().extensions,
                 &BasicIdentityProvider,
                 &cipher_suite_provider,
                 public_tree,
@@ -1439,7 +1439,7 @@ mod tests {
         let cipher_suite_provider = test_cipher_suite_provider(TEST_CIPHER_SUITE);
         let kem_output = vec![0; cipher_suite_provider.kdf_extract_size()];
         let group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
-        let public_tree = &group.group.state.public_tree;
+        let public_tree = &group.state.public_tree;
 
         let res = cache
             .resolve_for_commit_default(
@@ -1454,7 +1454,7 @@ mod tests {
                 .map(|p| ProposalOrRef::Proposal(Box::new(p)))
                 .collect(),
                 Some(&test_node().await),
-                &group.group.context().extensions,
+                &group.context().extensions,
                 &BasicIdentityProvider,
                 &cipher_suite_provider,
                 public_tree,
@@ -1475,7 +1475,7 @@ mod tests {
         let cipher_suite_provider = test_cipher_suite_provider(TEST_CIPHER_SUITE);
         let kem_output = vec![0; cipher_suite_provider.kdf_extract_size()];
         let group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
-        let public_tree = &group.group.state.public_tree;
+        let public_tree = &group.state.public_tree;
 
         cache
             .resolve_for_commit_default(
@@ -1488,7 +1488,7 @@ mod tests {
                 .map(|p| ProposalOrRef::Proposal(Box::new(p)))
                 .collect(),
                 Some(&test_node().await),
-                &group.group.context().extensions,
+                &group.context().extensions,
                 &BasicIdentityProvider,
                 &cipher_suite_provider,
                 public_tree,
@@ -1519,7 +1519,7 @@ mod tests {
         let cipher_suite_provider = test_cipher_suite_provider(TEST_CIPHER_SUITE);
         let kem_output = vec![0; cipher_suite_provider.kdf_extract_size()];
         let group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
-        let group_extensions = group.group.context().extensions.clone();
+        let group_extensions = group.context().extensions.clone();
         let mut public_tree = group.group.state.public_tree;
 
         let foo = get_basic_test_node(TEST_CIPHER_SUITE, "foo").await;
@@ -1573,7 +1573,7 @@ mod tests {
         let cipher_suite_provider = test_cipher_suite_provider(TEST_CIPHER_SUITE);
         let kem_output = vec![0; cipher_suite_provider.kdf_extract_size()];
         let group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
-        let group_extensions = group.group.context().extensions.clone();
+        let group_extensions = group.context().extensions.clone();
         let mut public_tree = group.group.state.public_tree;
 
         let node = get_basic_test_node(TEST_CIPHER_SUITE, "bar").await;
@@ -1622,7 +1622,7 @@ mod tests {
         let cipher_suite_provider = test_cipher_suite_provider(TEST_CIPHER_SUITE);
         let kem_output = vec![0; cipher_suite_provider.kdf_extract_size()];
         let group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
-        let group_extensions = group.group.context().extensions.clone();
+        let group_extensions = group.context().extensions.clone();
         let mut public_tree = group.group.state.public_tree;
 
         let node = get_basic_test_node(TEST_CIPHER_SUITE, "foo").await;
@@ -1717,14 +1717,14 @@ mod tests {
         let cache = make_proposal_cache();
         let cipher_suite_provider = test_cipher_suite_provider(TEST_CIPHER_SUITE);
         let group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
-        let public_tree = &group.group.state.public_tree;
+        let public_tree = &group.state.public_tree;
 
         let res = cache
             .resolve_for_commit_default(
                 Sender::NewMemberCommit,
                 Vec::new(),
                 Some(&test_node().await),
-                &group.group.context().extensions,
+                &group.context().extensions,
                 &BasicIdentityProvider,
                 &cipher_suite_provider,
                 public_tree,

--- a/mls-rs/src/group/snapshot.rs
+++ b/mls-rs/src/group/snapshot.rs
@@ -268,25 +268,25 @@ mod tests {
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     async fn snapshot_restore(group: TestGroup) {
-        let snapshot = group.group.snapshot();
+        let snapshot = group.snapshot();
 
-        let group_restored = Group::from_snapshot(group.group.config.clone(), snapshot)
+        let group_restored = Group::from_snapshot(group.config.clone(), snapshot)
             .await
             .unwrap();
 
-        assert!(Group::equal_group_state(&group.group, &group_restored));
+        assert!(Group::equal_group_state(&group, &group_restored));
 
         #[cfg(feature = "tree_index")]
         assert!(group_restored
             .state
             .public_tree
-            .equal_internals(&group.group.state.public_tree))
+            .equal_internals(&group.state.public_tree))
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn snapshot_with_pending_commit_can_be_serialized_to_json() {
         let mut group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
-        group.group.commit(vec![]).await.unwrap();
+        group.commit(vec![]).await.unwrap();
 
         snapshot_restore(group).await
     }
@@ -300,7 +300,7 @@ mod tests {
         let update_proposal = group.update_proposal().await;
 
         // This will insert the proposal into the internal proposal cache
-        let _ = group.group.proposal_message(update_proposal, vec![]).await;
+        let _ = group.proposal_message(update_proposal, vec![]).await;
 
         snapshot_restore(group).await
     }


### PR DESCRIPTION
### Description of changes:

This lets us treat a `TestGroup` as a `Group` in most places and thus turn a lot of `alice_group.group` lines into just `alice_group`.

### Call-outs:

This makes the code less explicit, but on balance I like the new way since it reduces stutter.

### Testing:

Unit tests pass before/after.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
