### PR TITLE
Cleanup unused imports for `--no-default-features`

### DIFF
--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -791,16 +791,17 @@ mod tests {
     };
     use assert_matches::assert_matches;
 
-    use crate::{
-        group::{
-            message_processor::ProposalMessageDescription,
-            proposal::Proposal,
-            test_utils::{test_group, test_group_custom_config},
-            ReceivedMessage,
-        },
-        psk::{ExternalPskId, PreSharedKey},
-    };
-
+    #[cfg(feature = "by_ref_proposal")]
+    use crate::group::message_processor::ProposalMessageDescription;
+    #[cfg(feature = "by_ref_proposal")]
+    use crate::group::proposal::Proposal;
+    use crate::group::test_utils::test_group;
+    #[cfg(feature = "psk")]
+    use crate::group::test_utils::test_group_custom_config;
+    #[cfg(feature = "by_ref_proposal")]
+    use crate::group::ReceivedMessage;
+    #[cfg(feature = "psk")]
+    use crate::psk::{ExternalPskId, PreSharedKey};
     use alloc::vec;
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -2,6 +2,7 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Debug;
@@ -614,7 +615,7 @@ where
             &self.cipher_suite_provider,
             self.context(),
             sender,
-            Content::Commit(alloc::boxed::Box::new(commit)),
+            Content::Commit(Box::new(commit)),
             old_signer,
             #[cfg(feature = "private_message")]
             self.encryption_options()?.control_wire_format(sender),
@@ -879,8 +880,6 @@ pub(crate) mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use alloc::boxed::Box;
-
     use mls_rs_core::{
         error::IntoAnyError,
         extension::ExtensionType,
@@ -888,19 +887,7 @@ mod tests {
         time::MlsTime,
     };
 
-    use crate::{
-        crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider},
-        group::{
-            mls_rules::DefaultMlsRules,
-            test_utils::{test_group, test_group_custom},
-        },
-        mls_rules::CommitOptions,
-        Client,
-    };
-
-    #[cfg(feature = "by_ref_proposal")]
-    use crate::extension::ExternalSendersExt;
-
+    use crate::extension::RequiredCapabilitiesExt;
     use crate::{
         client::test_utils::{test_client_with_key_pkg, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
         client_builder::{
@@ -908,7 +895,9 @@ mod tests {
             WithIdentityProvider,
         },
         client_config::ClientConfig,
+        crypto::test_utils::TestCryptoProvider,
         extension::test_utils::{TestExtension, TEST_EXTENSION_TYPE},
+        group::test_utils::{test_group, test_group_custom},
         group::{
             proposal::ProposalType,
             test_utils::{test_group_custom_config, test_n_member_group},
@@ -916,9 +905,16 @@ mod tests {
         identity::test_utils::get_test_signing_identity,
         identity::{basic::BasicIdentityProvider, test_utils::get_test_basic_credential},
         key_package::test_utils::test_key_package_message,
+        mls_rules::CommitOptions,
+        Client,
     };
 
-    use crate::extension::RequiredCapabilitiesExt;
+    #[cfg(feature = "by_ref_proposal")]
+    use crate::crypto::test_utils::test_cipher_suite_provider;
+    #[cfg(feature = "by_ref_proposal")]
+    use crate::extension::ExternalSendersExt;
+    #[cfg(feature = "by_ref_proposal")]
+    use crate::group::mls_rules::DefaultMlsRules;
 
     #[cfg(feature = "psk")]
     use crate::{

--- a/mls-rs/src/group/message_verifier.rs
+++ b/mls-rs/src/group/message_verifier.rs
@@ -213,6 +213,7 @@ fn signing_identity_for_new_member_proposal(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{
         client::{
             test_utils::{test_client_with_key_pkg, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
@@ -226,7 +227,6 @@ mod tests {
             test_utils::{test_group_custom, TestGroup},
             Group, PublicMessage,
         },
-        tree_kem::node::LeafIndex,
     };
     use alloc::vec;
     use assert_matches::assert_matches;
@@ -250,6 +250,7 @@ mod tests {
     #[cfg(feature = "by_ref_proposal")]
     use alloc::boxed::Box;
 
+    #[cfg(feature = "by_ref_proposal")]
     use crate::group::{
         test_utils::{test_group, test_member},
         Sender,
@@ -257,8 +258,6 @@ mod tests {
 
     #[cfg(feature = "by_ref_proposal")]
     use crate::identity::test_utils::get_test_signing_identity;
-
-    use super::{verify_auth_content_signature, verify_plaintext_authentication};
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     async fn make_signed_plaintext(group: &mut Group<TestClientConfig>) -> PublicMessage {

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1887,25 +1887,30 @@ pub(crate) mod test_utils;
 mod tests {
     use crate::{
         client::test_utils::{
-            test_client_with_key_pkg, test_client_with_key_pkg_custom, TestClientBuilder,
-            TEST_CIPHER_SUITE, TEST_CUSTOM_PROPOSAL_TYPE, TEST_PROTOCOL_VERSION,
+            test_client_with_key_pkg, TestClientBuilder, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION,
         },
-        client_builder::{test_utils::TestClientConfig, ClientBuilder, MlsConfig},
+        client_builder::test_utils::TestClientConfig,
         crypto::test_utils::TestCryptoProvider,
-        group::{
-            mls_rules::{CommitDirection, CommitSource},
-            proposal_filter::{ProposalBundle, ProposalInfo},
-        },
-        identity::{
-            basic::BasicIdentityProvider,
-            test_utils::{get_test_signing_identity, BasicWithCustomProvider},
-        },
+        group::proposal_filter::ProposalInfo,
+        identity::test_utils::get_test_signing_identity,
         key_package::test_utils::test_key_package_message,
         mls_rules::CommitOptions,
         tree_kem::{
             leaf_node::{test_utils::get_test_capabilities, LeafNodeSource},
             UpdatePathNode,
         },
+    };
+
+    #[cfg(feature = "by_ref_proposal")]
+    use crate::{
+        client::test_utils::{test_client_with_key_pkg_custom, TEST_CUSTOM_PROPOSAL_TYPE},
+        client_builder::{ClientBuilder, MlsConfig},
+        group::{
+            mls_rules::{CommitDirection, CommitSource},
+            proposal_filter::ProposalBundle,
+        },
+        identity::basic::BasicIdentityProvider,
+        identity::test_utils::BasicWithCustomProvider,
     };
 
     #[cfg(any(feature = "private_message", feature = "custom_proposal"))]

--- a/mls-rs/src/identity.rs
+++ b/mls-rs/src/identity.rs
@@ -17,6 +17,7 @@ pub use mls_rs_core::identity::{
 
 #[cfg(test)]
 pub(crate) mod test_utils {
+    #[cfg(feature = "std")]
     use alloc::boxed::Box;
     use alloc::vec;
     use alloc::vec::Vec;

--- a/mls-rs/src/tree_kem/interop_test_vectors.rs
+++ b/mls-rs/src/tree_kem/interop_test_vectors.rs
@@ -2,20 +2,27 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+#[cfg(feature = "rfc_compliant")]
 use alloc::vec;
 use alloc::vec::Vec;
-use mls_rs_codec::{MlsDecode, MlsEncode};
-use mls_rs_core::crypto::{CipherSuite, CipherSuiteProvider};
+#[cfg(feature = "rfc_compliant")]
+use mls_rs_codec::MlsDecode;
+use mls_rs_codec::MlsEncode;
+#[cfg(feature = "rfc_compliant")]
+use mls_rs_core::crypto::CipherSuite;
+use mls_rs_core::crypto::CipherSuiteProvider;
 
+#[cfg(feature = "rfc_compliant")]
 use itertools::Itertools;
 
+#[cfg(feature = "rfc_compliant")]
 use crate::{
     crypto::test_utils::try_test_cipher_suite_provider, identity::basic::BasicIdentityProvider,
 };
 
-use super::{
-    node::NodeVec, test_utils::TreeWithSigners, tree_validator::TreeValidator, TreeKemPublic,
-};
+use super::TreeKemPublic;
+#[cfg(feature = "rfc_compliant")]
+use super::{node::NodeVec, test_utils::TreeWithSigners, tree_validator::TreeValidator};
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
 struct ValidationTestCase {

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -625,8 +625,10 @@ mod tests {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
+    #[cfg(feature = "std")]
+    use alloc::boxed::Box;
     use alloc::vec;
-    use alloc::{boxed::Box, vec::Vec};
+    use alloc::vec::Vec;
     use mls_rs_codec::MlsEncode;
     use mls_rs_core::{
         error::IntoAnyError,


### PR DESCRIPTION
### Description of changes:

I noticed that I got a lot of warnings when I tried running

    cargo test --no-default-features

This fixes the warnings related to imports. There are some other warnings related to fields never being read (tested), but they can be fixed in other PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
