### PR TITLE
Format with `imports_granularity = "Module"`

### DIFF
--- a/mls-rs-codec-derive/src/lib.rs
+++ b/mls-rs-codec-derive/src/lib.rs
@@ -4,10 +4,8 @@
 
 use std::str::FromStr;
 
-use darling::{
-    ast::{self, Fields},
-    FromDeriveInput, FromField, FromVariant,
-};
+use darling::ast::{self, Fields};
+use darling::{FromDeriveInput, FromField, FromVariant};
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 use syn::{

--- a/mls-rs-codec/src/byte_vec.rs
+++ b/mls-rs-codec/src/byte_vec.rs
@@ -2,7 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{iter::mls_decode_split_on_collection, Error, MlsEncode, MlsSize, VarInt};
+use crate::iter::mls_decode_split_on_collection;
+use crate::{Error, MlsEncode, MlsSize, VarInt};
 
 use alloc::vec::Vec;
 

--- a/mls-rs-codec/src/cow.rs
+++ b/mls-rs-codec/src/cow.rs
@@ -1,7 +1,5 @@
-use alloc::{
-    borrow::{Cow, ToOwned},
-    vec::Vec,
-};
+use alloc::borrow::{Cow, ToOwned};
+use alloc::vec::Vec;
 
 use crate::{Error, MlsDecode, MlsEncode, MlsSize};
 

--- a/mls-rs-codec/src/map.rs
+++ b/mls-rs-codec/src/map.rs
@@ -2,7 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 
 #[cfg(feature = "std")]
 use std::{collections::HashMap, hash::Hash};

--- a/mls-rs-codec/src/string.rs
+++ b/mls-rs-codec/src/string.rs
@@ -1,5 +1,6 @@
 use crate::{MlsDecode, MlsEncode, MlsSize};
-use alloc::{string::String, vec::Vec};
+use alloc::string::String;
+use alloc::vec::Vec;
 
 impl MlsSize for str {
     fn mls_encoded_len(&self) -> usize {

--- a/mls-rs-codec/src/vec.rs
+++ b/mls-rs-codec/src/vec.rs
@@ -64,7 +64,8 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{Error, MlsDecode, MlsEncode};
-    use alloc::{vec, vec::Vec};
+    use alloc::vec;
+    use alloc::vec::Vec;
     use assert_matches::assert_matches;
 
     #[cfg(target_arch = "wasm32")]

--- a/mls-rs-core/src/crypto.rs
+++ b/mls-rs-core/src/crypto.rs
@@ -5,10 +5,8 @@
 use crate::error::IntoAnyError;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use zeroize::{ZeroizeOnDrop, Zeroizing};
 

--- a/mls-rs-core/src/extension.rs
+++ b/mls-rs-core/src/extension.rs
@@ -2,10 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 
 use crate::error::{AnyError, IntoAnyError};
 use alloc::vec::Vec;

--- a/mls-rs-core/src/extension/list.rs
+++ b/mls-rs-core/src/extension/list.rs
@@ -173,9 +173,8 @@ mod tests {
     use assert_matches::assert_matches;
     use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
-    use crate::extension::{
-        list::ExtensionList, Extension, ExtensionType, MlsCodecExtension, MlsExtension,
-    };
+    use crate::extension::list::ExtensionList;
+    use crate::extension::{Extension, ExtensionType, MlsCodecExtension, MlsExtension};
 
     #[derive(Debug, Clone, MlsSize, MlsEncode, MlsDecode, PartialEq, Eq)]
     struct TestExtensionA(u32);

--- a/mls-rs-core/src/group/roster.rs
+++ b/mls-rs-core/src/group/roster.rs
@@ -6,12 +6,10 @@ use alloc::vec;
 use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
-use crate::{
-    crypto::CipherSuite,
-    extension::{ExtensionList, ExtensionType},
-    identity::{CredentialType, SigningIdentity},
-    protocol_version::ProtocolVersion,
-};
+use crate::crypto::CipherSuite;
+use crate::extension::{ExtensionList, ExtensionType};
+use crate::identity::{CredentialType, SigningIdentity};
+use crate::protocol_version::ProtocolVersion;
 
 use super::ProposalType;
 

--- a/mls-rs-core/src/identity/basic.rs
+++ b/mls-rs-core/src/identity/basic.rs
@@ -2,10 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use core::{
-    convert::Infallible,
-    fmt::{self, Debug},
-};
+use core::convert::Infallible;
+use core::fmt::{self, Debug};
 
 use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};

--- a/mls-rs-core/src/identity/credential.rs
+++ b/mls-rs-core/src/identity/credential.rs
@@ -2,10 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 
 use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};

--- a/mls-rs-core/src/identity/provider.rs
+++ b/mls-rs-core/src/identity/provider.rs
@@ -2,7 +2,9 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{error::IntoAnyError, extension::ExtensionList, time::MlsTime};
+use crate::error::IntoAnyError;
+use crate::extension::ExtensionList;
+use crate::time::MlsTime;
 #[cfg(mls_build_async)]
 use alloc::boxed::Box;
 use alloc::vec::Vec;

--- a/mls-rs-core/src/identity/x509.rs
+++ b/mls-rs-core/src/identity/x509.rs
@@ -2,11 +2,9 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use core::{
-    convert::Infallible,
-    fmt::{self, Debug},
-    ops::{Deref, DerefMut},
-};
+use core::convert::Infallible;
+use core::fmt::{self, Debug};
+use core::ops::{Deref, DerefMut};
 
 use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};

--- a/mls-rs-core/src/key_package.rs
+++ b/mls-rs-core/src/key_package.rs
@@ -8,7 +8,8 @@ use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
-use crate::{crypto::HpkeSecretKey, error::IntoAnyError};
+use crate::crypto::HpkeSecretKey;
+use crate::error::IntoAnyError;
 
 #[derive(Clone, PartialEq, Eq, MlsEncode, MlsDecode, MlsSize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/mls-rs-core/src/psk.rs
+++ b/mls-rs-core/src/psk.rs
@@ -6,10 +6,8 @@ use crate::error::IntoAnyError;
 #[cfg(mls_build_async)]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use zeroize::Zeroizing;
 

--- a/mls-rs-core/src/secret.rs
+++ b/mls-rs-core/src/secret.rs
@@ -3,10 +3,8 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::{Deref, DerefMut},
-};
+use core::fmt::{self, Debug};
+use core::ops::{Deref, DerefMut};
 use zeroize::Zeroizing;
 
 #[cfg_attr(

--- a/mls-rs-crypto-awslc/src/ec.rs
+++ b/mls-rs-crypto-awslc/src/ec.rs
@@ -2,7 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use std::{os::raw::c_void, ptr::null_mut};
+use std::os::raw::c_void;
+use std::ptr::null_mut;
 
 use aws_lc_rs::error::Unspecified;
 use aws_lc_sys::{

--- a/mls-rs-crypto-awslc/src/ecdsa.rs
+++ b/mls-rs-crypto-awslc/src/ecdsa.rs
@@ -2,13 +2,14 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use std::{ffi::c_void, mem::MaybeUninit, ops::Deref, ptr::null_mut};
+use std::ffi::c_void;
+use std::mem::MaybeUninit;
+use std::ops::Deref;
+use std::ptr::null_mut;
 
-use aws_lc_rs::{
-    digest,
-    error::Unspecified,
-    signature::{self, UnparsedPublicKey, ED25519_PUBLIC_KEY_LEN},
-};
+use aws_lc_rs::digest;
+use aws_lc_rs::error::Unspecified;
+use aws_lc_rs::signature::{self, UnparsedPublicKey, ED25519_PUBLIC_KEY_LEN};
 
 use aws_lc_sys::{
     ECDSA_SIG_free, ECDSA_SIG_to_bytes, ECDSA_do_sign, ED25519_keypair, ED25519_sign,
@@ -18,11 +19,10 @@ use aws_lc_sys::{
 use mls_rs_core::crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey};
 use mls_rs_crypto_traits::Curve;
 
-use crate::{
-    check_non_null,
-    ec::{ec_generate, ec_public_key, EcPrivateKey, EcPublicKey, EvpPkey, SUPPORTED_NIST_CURVES},
-    AwsLcCryptoError,
+use crate::ec::{
+    ec_generate, ec_public_key, EcPrivateKey, EcPublicKey, EvpPkey, SUPPORTED_NIST_CURVES,
 };
+use crate::{check_non_null, AwsLcCryptoError};
 
 #[derive(Clone)]
 pub struct AwsLcEcdsa(Curve);

--- a/mls-rs-crypto-awslc/src/lib.rs
+++ b/mls-rs-crypto-awslc/src/lib.rs
@@ -9,28 +9,26 @@ mod kdf;
 
 pub mod x509;
 
-use std::{ffi::c_int, mem::MaybeUninit};
+use std::ffi::c_int;
+use std::mem::MaybeUninit;
 
 use aead::AwsLcAead;
-use aws_lc_rs::{digest, error::Unspecified, hmac};
+use aws_lc_rs::error::Unspecified;
+use aws_lc_rs::{digest, hmac};
 
 use aws_lc_sys::SHA256;
-use mls_rs_core::{
-    crypto::{
-        CipherSuite, CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkePublicKey,
-        HpkeSecretKey, SignaturePublicKey, SignatureSecretKey,
-    },
-    error::IntoAnyError,
+use mls_rs_core::crypto::{
+    CipherSuite, CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkePublicKey, HpkeSecretKey,
+    SignaturePublicKey, SignatureSecretKey,
 };
+use mls_rs_core::error::IntoAnyError;
 
 use ec::Ecdh;
 use ecdsa::AwsLcEcdsa;
 use kdf::AwsLcHkdf;
-use mls_rs_crypto_hpke::{
-    context::{ContextR, ContextS},
-    dhkem::DhKem,
-    hpke::{Hpke, HpkeError},
-};
+use mls_rs_crypto_hpke::context::{ContextR, ContextS};
+use mls_rs_crypto_hpke::dhkem::DhKem;
+use mls_rs_crypto_hpke::hpke::{Hpke, HpkeError};
 use mls_rs_crypto_traits::{AeadType, KdfType, KemId};
 use thiserror::Error;
 use zeroize::Zeroizing;

--- a/mls-rs-crypto-awslc/src/x509/certificate.rs
+++ b/mls-rs-crypto-awslc/src/x509/certificate.rs
@@ -2,12 +2,10 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use std::{
-    ffi::{c_long, c_void},
-    mem,
-    ptr::null_mut,
-    time::Duration,
-};
+use std::ffi::{c_long, c_void};
+use std::mem;
+use std::ptr::null_mut;
+use std::time::Duration;
 
 use aws_lc_sys::{
     d2i_X509, i2d_X509, i2d_X509_NAME, ASN1_INTEGER_free, ASN1_INTEGER_to_BN, ASN1_TIME_free,
@@ -20,24 +18,18 @@ use aws_lc_sys::{
     X509_set_issuer_name, X509_set_notAfter, X509_set_notBefore, X509_set_pubkey,
     X509_set_serialNumber, X509_set_subject_name, X509_set_version, X509_sign, ASN1_TIME, X509,
 };
-use mls_rs_core::{
-    crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey},
-    time::MlsTime,
-};
+use mls_rs_core::crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey};
+use mls_rs_core::time::MlsTime;
 use mls_rs_identity_x509::{DerCertificate, SubjectAltName, SubjectComponent};
 
-use crate::{
-    check_int_return, check_non_null, check_non_null_const, check_res, ecdsa::AwsLcEcdsa,
-    AwsLcCryptoError,
-};
+use crate::ecdsa::AwsLcEcdsa;
+use crate::{check_int_return, check_non_null, check_non_null_const, check_res, AwsLcCryptoError};
 
-use super::{
-    component::{
-        components_from_name, GeneralName, Stack, StackItem, X509Extension, X509ExtensionContext,
-        X509Name,
-    },
-    request::digest_for_curve,
+use super::component::{
+    components_from_name, GeneralName, Stack, StackItem, X509Extension, X509ExtensionContext,
+    X509Name,
 };
+use super::request::digest_for_curve;
 
 pub struct Certificate(*mut X509);
 
@@ -346,19 +338,16 @@ unsafe fn posix_to_asn1_time(time: MlsTime) -> Result<*mut ASN1_TIME, AwsLcCrypt
 
 #[cfg(test)]
 mod tests {
-    use mls_rs_core::{crypto::CipherSuite, time::MlsTime};
+    use mls_rs_core::crypto::CipherSuite;
+    use mls_rs_core::time::MlsTime;
     use mls_rs_identity_x509::{
         CertificateChain, SubjectAltName, SubjectComponent, X509CredentialValidator,
     };
 
-    use crate::{
-        ecdsa::AwsLcEcdsa,
-        x509::{
-            component::{KeyUsage, X509Extension},
-            test_utils::{test_root_ca, test_root_ca_key},
-            CertificateValidator,
-        },
-    };
+    use crate::ecdsa::AwsLcEcdsa;
+    use crate::x509::component::{KeyUsage, X509Extension};
+    use crate::x509::test_utils::{test_root_ca, test_root_ca_key};
+    use crate::x509::CertificateValidator;
 
     use super::Certificate;
 

--- a/mls-rs-crypto-awslc/src/x509/component.rs
+++ b/mls-rs-crypto-awslc/src/x509/component.rs
@@ -3,12 +3,10 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use core::slice;
-use std::{
-    ffi::{c_int, c_void, CString},
-    marker::PhantomData,
-    net::IpAddr,
-    ptr::null_mut,
-};
+use std::ffi::{c_int, c_void, CString};
+use std::marker::PhantomData;
+use std::net::IpAddr;
+use std::ptr::null_mut;
 
 use aws_lc_sys::{
     stack_st, ASN1_STRING_data, ASN1_STRING_free, ASN1_STRING_get0_data, ASN1_STRING_length,

--- a/mls-rs-crypto-awslc/src/x509/parser.rs
+++ b/mls-rs-crypto-awslc/src/x509/parser.rs
@@ -59,12 +59,10 @@ mod tests {
     use mls_rs_core::crypto::CipherSuite;
     use mls_rs_identity_x509::{SubjectAltName, SubjectComponent, X509CertificateReader};
 
-    use crate::{
-        ecdsa::AwsLcEcdsa,
-        x509::{
-            component::X509Name,
-            test_utils::{load_github_leaf, load_ip_cert, load_test_ca, test_leaf, test_leaf_key},
-        },
+    use crate::ecdsa::AwsLcEcdsa;
+    use crate::x509::component::X509Name;
+    use crate::x509::test_utils::{
+        load_github_leaf, load_ip_cert, load_test_ca, test_leaf, test_leaf_key,
     };
 
     use super::CertificateParser;

--- a/mls-rs-crypto-awslc/src/x509/request.rs
+++ b/mls-rs-crypto-awslc/src/x509/request.rs
@@ -2,10 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use std::{
-    ffi::c_long,
-    ptr::{null, null_mut},
-};
+use std::ffi::c_long;
+use std::ptr::{null, null_mut};
 
 use aws_lc_sys::{
     i2d_X509_REQ, EVP_sha256, EVP_sha384, EVP_sha512, X509_REQ_add_extensions, X509_REQ_free,
@@ -15,9 +13,9 @@ use aws_lc_sys::{
 use mls_rs_core::crypto::SignatureSecretKey;
 use mls_rs_crypto_traits::Curve;
 
-use crate::{
-    check_int_return, check_non_null, check_res, ec::EvpPkey, ecdsa::AwsLcEcdsa, AwsLcCryptoError,
-};
+use crate::ec::EvpPkey;
+use crate::ecdsa::AwsLcEcdsa;
+use crate::{check_int_return, check_non_null, check_res, AwsLcCryptoError};
 
 use super::component::{Stack, X509Extension, X509Name};
 

--- a/mls-rs-crypto-awslc/src/x509/validator.rs
+++ b/mls-rs-crypto-awslc/src/x509/validator.rs
@@ -11,12 +11,14 @@ use aws_lc_sys::{
     X509_VERIFY_PARAM_set_time, X509_verify_cert, X509_verify_cert_error_string, X509_VERIFY_PARAM,
     X509_V_FLAG_NO_CHECK_TIME, X509_V_OK,
 };
-use mls_rs_core::{crypto::SignaturePublicKey, time::MlsTime};
+use mls_rs_core::crypto::SignaturePublicKey;
+use mls_rs_core::time::MlsTime;
 use mls_rs_identity_x509::{CertificateChain, DerCertificate, X509CredentialValidator};
 
 use crate::{check_non_null, check_res, AwsLcCryptoError};
 
-use super::{certificate::Certificate, component::Stack};
+use super::certificate::Certificate;
+use super::component::Stack;
 
 pub struct CertificateValidator {
     ca_certs: Stack<Certificate>,
@@ -136,16 +138,11 @@ mod tests {
     use mls_rs_core::time::MlsTime;
     use mls_rs_identity_x509::{CertificateChain, DerCertificate, X509CredentialValidator};
 
-    use crate::{
-        x509::{
-            test_utils::{
-                load_test_ca, load_test_cert_chain, load_test_invalid_ca_chain,
-                load_test_invalid_chain,
-            },
-            CertificateValidator,
-        },
-        AwsLcCryptoError,
+    use crate::x509::test_utils::{
+        load_test_ca, load_test_cert_chain, load_test_invalid_ca_chain, load_test_invalid_chain,
     };
+    use crate::x509::CertificateValidator;
+    use crate::AwsLcCryptoError;
 
     pub fn load_another_ca() -> DerCertificate {
         DerCertificate::from(include_bytes!("../../test_data/x509/another_ca.der").to_vec())

--- a/mls-rs-crypto-awslc/src/x509/writer.rs
+++ b/mls-rs-crypto-awslc/src/x509/writer.rs
@@ -7,12 +7,11 @@ use mls_rs_identity_x509::{
     CertificateRequestParameters, DerCertificateRequest, X509RequestWriter,
 };
 
-use crate::{ecdsa::AwsLcEcdsa, AwsLcCryptoError};
+use crate::ecdsa::AwsLcEcdsa;
+use crate::AwsLcCryptoError;
 
-use super::{
-    component::{KeyUsage, Stack, X509Extension, X509Name},
-    request::{self, X509Request},
-};
+use super::component::{KeyUsage, Stack, X509Extension, X509Name};
+use super::request::{self, X509Request};
 
 pub struct CertificateRequestWriter {
     signer: AwsLcEcdsa,
@@ -77,13 +76,9 @@ mod tests {
         X509RequestWriter,
     };
 
-    use crate::{
-        x509::{
-            test_utils::{csr_pem_to_der, ec_key_from_pem},
-            CertificateRequestWriter,
-        },
-        AwsLcCryptoProvider,
-    };
+    use crate::x509::test_utils::{csr_pem_to_der, ec_key_from_pem};
+    use crate::x509::CertificateRequestWriter;
+    use crate::AwsLcCryptoProvider;
 
     fn test_writing_csr(ca: bool) {
         let subject_seckey = if ca {

--- a/mls-rs-crypto-cryptokit/build.rs
+++ b/mls-rs-crypto-cryptokit/build.rs
@@ -12,7 +12,8 @@ fn main() {
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod swift {
     use serde::Deserialize;
-    use std::{env, process::Command};
+    use std::env;
+    use std::process::Command;
 
     #[derive(Debug, Deserialize)]
     struct SwiftTargetInfo {

--- a/mls-rs-crypto-cryptokit/src/aead.rs
+++ b/mls-rs-crypto-cryptokit/src/aead.rs
@@ -7,7 +7,8 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 
-use mls_rs_core::{crypto::CipherSuite, error::IntoAnyError};
+use mls_rs_core::crypto::CipherSuite;
+use mls_rs_core::error::IntoAnyError;
 use mls_rs_crypto_traits::{AeadId, AeadType, AES_TAG_LEN};
 
 #[derive(Debug)]

--- a/mls-rs-crypto-cryptokit/src/kdf.rs
+++ b/mls-rs-crypto-cryptokit/src/kdf.rs
@@ -2,7 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs_core::{crypto::CipherSuite, error::IntoAnyError};
+use mls_rs_core::crypto::CipherSuite;
+use mls_rs_core::error::IntoAnyError;
 use mls_rs_crypto_traits::{KdfId, KdfType};
 
 #[derive(Debug)]

--- a/mls-rs-crypto-cryptokit/src/kem.rs
+++ b/mls-rs-crypto-cryptokit/src/kem.rs
@@ -8,10 +8,8 @@ use core::ops::Deref;
 
 use alloc::vec::Vec;
 
-use mls_rs_core::{
-    crypto::{self, CipherSuite, HpkePublicKey, HpkeSecretKey},
-    error::IntoAnyError,
-};
+use mls_rs_core::crypto::{self, CipherSuite, HpkePublicKey, HpkeSecretKey};
+use mls_rs_core::error::IntoAnyError;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]

--- a/mls-rs-crypto-cryptokit/src/lib.rs
+++ b/mls-rs-crypto-cryptokit/src/lib.rs
@@ -11,13 +11,11 @@ use kdf::{Kdf, KdfError};
 use kem::{Kem, KemError};
 use sig::{Signature, SignatureError};
 
-use mls_rs_core::{
-    crypto::{
-        CipherSuite, CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkeContextR,
-        HpkeContextS, HpkePublicKey, HpkeSecretKey, SignaturePublicKey, SignatureSecretKey,
-    },
-    error::IntoAnyError,
+use mls_rs_core::crypto::{
+    CipherSuite, CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkeContextR, HpkeContextS,
+    HpkePublicKey, HpkeSecretKey, SignaturePublicKey, SignatureSecretKey,
 };
+use mls_rs_core::error::IntoAnyError;
 use mls_rs_crypto_traits::{AeadType, KdfType};
 use zeroize::Zeroizing;
 

--- a/mls-rs-crypto-hpke/src/context.rs
+++ b/mls-rs-crypto-hpke/src/context.rs
@@ -2,13 +2,12 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs_core::{
-    crypto::{HpkeContextR, HpkeContextS},
-    error::IntoAnyError,
-};
+use mls_rs_core::crypto::{HpkeContextR, HpkeContextS};
+use mls_rs_core::error::IntoAnyError;
 use mls_rs_crypto_traits::{AeadType, KdfType};
 
-use crate::{hpke::HpkeError, kdf::HpkeKdf};
+use crate::hpke::HpkeError;
+use crate::kdf::HpkeKdf;
 
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};

--- a/mls-rs-crypto-hpke/src/dhkem.rs
+++ b/mls-rs-crypto-hpke/src/dhkem.rs
@@ -4,10 +4,8 @@
 
 use mls_rs_crypto_traits::{DhType, KdfType, KemResult, KemType};
 
-use mls_rs_core::{
-    crypto::{HpkePublicKey, HpkeSecretKey},
-    error::{AnyError, IntoAnyError},
-};
+use mls_rs_core::crypto::{HpkePublicKey, HpkeSecretKey};
+use mls_rs_core::error::{AnyError, IntoAnyError};
 use zeroize::Zeroizing;
 
 use crate::kdf::HpkeKdf;

--- a/mls-rs-crypto-hpke/src/hpke.rs
+++ b/mls-rs-crypto-hpke/src/hpke.rs
@@ -6,21 +6,17 @@ use core::fmt::Debug;
 
 use crate::alloc::borrow::ToOwned;
 
-use mls_rs_core::{
-    crypto::{
-        HpkeCiphertext, HpkeContextR, HpkeContextS, HpkeModeId, HpkePublicKey, HpkeSecretKey,
-    },
-    error::{AnyError, IntoAnyError},
+use mls_rs_core::crypto::{
+    HpkeCiphertext, HpkeContextR, HpkeContextS, HpkeModeId, HpkePublicKey, HpkeSecretKey,
 };
+use mls_rs_core::error::{AnyError, IntoAnyError};
 
 use mls_rs_crypto_traits::{AeadType, KdfType, KemType, AEAD_ID_EXPORT_ONLY};
 
 use zeroize::Zeroizing;
 
-use crate::{
-    context::{Context, ContextR, ContextS, EncryptionContext},
-    kdf::HpkeKdf,
-};
+use crate::context::{Context, ContextR, ContextS, EncryptionContext};
+use crate::kdf::HpkeKdf;
 
 use alloc::vec::Vec;
 

--- a/mls-rs-crypto-hpke/src/test_utils.rs
+++ b/mls-rs-crypto-hpke/src/test_utils.rs
@@ -6,11 +6,9 @@
 
 use alloc::vec::Vec;
 
-use crate::{
-    context::{Context, ContextR, ContextS, EncryptionContext},
-    dhkem::DhKem,
-    hpke::Hpke,
-};
+use crate::context::{Context, ContextR, ContextS, EncryptionContext};
+use crate::dhkem::DhKem;
+use crate::hpke::Hpke;
 
 use mls_rs_core::crypto::test_suite::{EncapOutput, TestHpke};
 use mls_rs_crypto_traits::{AeadType, DhType, KdfType, KemResult, KemType};

--- a/mls-rs-crypto-openssl/src/aead.rs
+++ b/mls-rs-crypto-openssl/src/aead.rs
@@ -2,9 +2,11 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use std::{fmt::Debug, ops::Deref};
+use std::fmt::Debug;
+use std::ops::Deref;
 
-use mls_rs_core::{crypto::CipherSuite, error::IntoAnyError};
+use mls_rs_core::crypto::CipherSuite;
+use mls_rs_core::error::IntoAnyError;
 use mls_rs_crypto_traits::{AeadId, AeadType, AES_TAG_LEN};
 use openssl::symm::{decrypt_aead, encrypt_aead, Cipher};
 use thiserror::Error;

--- a/mls-rs-crypto-openssl/src/ec.rs
+++ b/mls-rs-crypto-openssl/src/ec.rs
@@ -6,14 +6,12 @@ use core::fmt::{self, Debug};
 use mls_rs_crypto_traits::Curve;
 use thiserror::Error;
 
-use openssl::{
-    bn::{BigNum, BigNumContext},
-    derive::Deriver,
-    ec::{EcGroup, EcKey, EcPoint, PointConversionForm},
-    error::ErrorStack,
-    nid::Nid,
-    pkey::{HasParams, Id, PKey, Private, Public},
-};
+use openssl::bn::{BigNum, BigNumContext};
+use openssl::derive::Deriver;
+use openssl::ec::{EcGroup, EcKey, EcPoint, PointConversionForm};
+use openssl::error::ErrorStack;
+use openssl::nid::Nid;
+use openssl::pkey::{HasParams, Id, PKey, Private, Public};
 
 pub type EcPublicKey = PKey<Public>;
 pub type EcPrivateKey = PKey<Private>;
@@ -357,12 +355,11 @@ pub(crate) mod test_utils {
 mod tests {
     use assert_matches::assert_matches;
 
+    use super::test_utils::{byte_equal, get_test_public_keys, get_test_secret_keys};
     use super::{
         generate_keypair, generate_private_key, private_key_bytes_to_public,
         private_key_from_bytes, private_key_to_bytes, pub_key_from_uncompressed,
-        pub_key_to_uncompressed,
-        test_utils::{byte_equal, get_test_public_keys, get_test_secret_keys},
-        Curve, EcError,
+        pub_key_to_uncompressed, Curve, EcError,
     };
 
     const SUPPORTED_CURVES: [Curve; 7] = [

--- a/mls-rs-crypto-openssl/src/ec_signer.rs
+++ b/mls-rs-crypto-openssl/src/ec_signer.rs
@@ -149,13 +149,11 @@ impl EcSigner {
 mod test {
     use mls_rs_crypto_traits::Curve;
 
-    use crate::{
-        ec::test_utils::{
-            get_test_public_keys, get_test_public_keys_der, get_test_secret_keys,
-            get_test_secret_keys_der, TestKeys,
-        },
-        ec_signer::EcSigner,
+    use crate::ec::test_utils::{
+        get_test_public_keys, get_test_public_keys_der, get_test_secret_keys,
+        get_test_secret_keys_der, TestKeys,
     };
+    use crate::ec_signer::EcSigner;
 
     #[test]
     fn import_der_public() {

--- a/mls-rs-crypto-openssl/src/ecdh.rs
+++ b/mls-rs-crypto-openssl/src/ecdh.rs
@@ -7,10 +7,8 @@ use std::ops::Deref;
 use mls_rs_crypto_traits::{Curve, DhType};
 use thiserror::Error;
 
-use mls_rs_core::{
-    crypto::{CipherSuite, HpkePublicKey, HpkeSecretKey},
-    error::IntoAnyError,
-};
+use mls_rs_core::crypto::{CipherSuite, HpkePublicKey, HpkeSecretKey};
+use mls_rs_core::error::IntoAnyError;
 
 use crate::ec::{
     generate_keypair, private_key_bytes_to_public, private_key_ecdh, private_key_from_bytes,

--- a/mls-rs-crypto-openssl/src/kdf.rs
+++ b/mls-rs-crypto-openssl/src/kdf.rs
@@ -2,15 +2,15 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use std::{fmt::Debug, ops::Deref};
+use std::fmt::Debug;
+use std::ops::Deref;
 
-use mls_rs_core::{crypto::CipherSuite, error::IntoAnyError};
+use mls_rs_core::crypto::CipherSuite;
+use mls_rs_core::error::IntoAnyError;
 use mls_rs_crypto_traits::{KdfId, KdfType};
-use openssl::{
-    md::{Md, MdRef},
-    pkey::Id,
-    pkey_ctx::{HkdfMode, PkeyCtx},
-};
+use openssl::md::{Md, MdRef};
+use openssl::pkey::Id;
+use openssl::pkey_ctx::{HkdfMode, PkeyCtx};
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/mls-rs-crypto-openssl/src/lib.rs
+++ b/mls-rs-crypto-openssl/src/lib.rs
@@ -13,11 +13,9 @@ pub mod mac;
 pub mod x509;
 
 use aead::Aead;
-use mls_rs_crypto_hpke::{
-    context::{ContextR, ContextS},
-    dhkem::DhKem,
-    hpke::{Hpke, HpkeError},
-};
+use mls_rs_crypto_hpke::context::{ContextR, ContextS};
+use mls_rs_crypto_hpke::dhkem::DhKem;
+use mls_rs_crypto_hpke::hpke::{Hpke, HpkeError};
 use mls_rs_crypto_traits::{AeadType, KdfType, KemId, KemType};
 
 use ec::EcError;
@@ -28,13 +26,11 @@ use mac::{Hash, HashError};
 use openssl::error::ErrorStack;
 use thiserror::Error;
 
-use mls_rs_core::{
-    crypto::{
-        CipherSuite, CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkePublicKey,
-        HpkeSecretKey, SignaturePublicKey, SignatureSecretKey,
-    },
-    error::{AnyError, IntoAnyError},
+use mls_rs_core::crypto::{
+    CipherSuite, CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkePublicKey, HpkeSecretKey,
+    SignaturePublicKey, SignatureSecretKey,
 };
+use mls_rs_core::error::{AnyError, IntoAnyError};
 
 pub use openssl;
 use zeroize::Zeroizing;

--- a/mls-rs-crypto-openssl/src/mac.rs
+++ b/mls-rs-crypto-openssl/src/mac.rs
@@ -5,11 +5,9 @@
 use std::ops::Deref;
 
 use mls_rs_core::crypto::CipherSuite;
-use openssl::{
-    hash::{hash, MessageDigest},
-    pkey::PKey,
-    sign::Signer,
-};
+use openssl::hash::{hash, MessageDigest};
+use openssl::pkey::PKey;
+use openssl::sign::Signer;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/mls-rs-crypto-openssl/src/x509.rs
+++ b/mls-rs-crypto-openssl/src/x509.rs
@@ -2,33 +2,30 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use std::{net::IpAddr, ops::Deref};
+use std::net::IpAddr;
+use std::ops::Deref;
 
-use mls_rs_core::{
-    crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey},
-    error::IntoAnyError,
-    identity::{CertificateChain, SigningIdentity},
-};
+use mls_rs_core::crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::identity::{CertificateChain, SigningIdentity};
 use mls_rs_identity_x509::{
     CertificateRequestParameters, DerCertificate, DerCertificateRequest, SubjectAltName,
     SubjectComponent, SubjectIdentityExtractor, X509CredentialValidator, X509IdentityProvider,
     X509RequestWriter,
 };
-use openssl::{
-    bn::BigNumContext,
-    ec::PointConversionForm,
-    error::ErrorStack,
-    hash::MessageDigest,
-    nid::Nid,
-    pkey::{PKey, PKeyRef, Private, Public},
-    stack::Stack,
-    x509::{
-        extension::{BasicConstraints, KeyUsage, SubjectAlternativeName},
-        store::{X509Store, X509StoreBuilder},
-        verify::{X509VerifyFlags, X509VerifyParam},
-        X509Builder, X509Extension, X509Name, X509NameBuilder, X509ReqBuilder, X509StoreContext,
-        X509VerifyResult, X509v3Context, X509,
-    },
+use openssl::bn::BigNumContext;
+use openssl::ec::PointConversionForm;
+use openssl::error::ErrorStack;
+use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
+use openssl::pkey::{PKey, PKeyRef, Private, Public};
+use openssl::stack::Stack;
+use openssl::x509::extension::{BasicConstraints, KeyUsage, SubjectAlternativeName};
+use openssl::x509::store::{X509Store, X509StoreBuilder};
+use openssl::x509::verify::{X509VerifyFlags, X509VerifyParam};
+use openssl::x509::{
+    X509Builder, X509Extension, X509Name, X509NameBuilder, X509ReqBuilder, X509StoreContext,
+    X509VerifyResult, X509v3Context, X509,
 };
 use thiserror::Error;
 
@@ -571,35 +568,26 @@ mod tests {
     use std::time::Duration;
 
     use assert_matches::assert_matches;
-    use mls_rs_core::{
-        crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey},
-        time::MlsTime,
-    };
+    use mls_rs_core::crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey};
+    use mls_rs_core::time::MlsTime;
     use mls_rs_identity_x509::{
         CertificateChain, CertificateRequestParameters, DerCertificateRequest, SubjectAltName,
         SubjectComponent, X509CertificateReader, X509RequestWriter,
     };
-    use openssl::{
-        pkey::PKey,
-        x509::{X509Name, X509Req, X509},
-    };
+    use openssl::pkey::PKey;
+    use openssl::x509::{X509Name, X509Req, X509};
 
-    use crate::{
-        ec::private_key_to_bytes,
-        x509::{
-            test_utils::{load_another_ca, load_test_invalid_ca_chain, load_test_invalid_chain},
-            CertificateRequestWriter,
-        },
+    use crate::ec::private_key_to_bytes;
+    use crate::x509::test_utils::{
+        load_another_ca, load_test_invalid_ca_chain, load_test_invalid_chain,
     };
+    use crate::x509::CertificateRequestWriter;
 
-    use super::{
-        pub_key_to_uncompressed,
-        test_utils::{
-            load_github_leaf, load_ip_cert, load_test_ca, load_test_cert_chain,
-            load_test_system_cert_chain,
-        },
-        X509Error, X509Reader, X509Validator,
+    use super::test_utils::{
+        load_github_leaf, load_ip_cert, load_test_ca, load_test_cert_chain,
+        load_test_system_cert_chain,
     };
+    use super::{pub_key_to_uncompressed, X509Error, X509Reader, X509Validator};
 
     #[test]
     fn can_detect_invalid_ca_certificates() {

--- a/mls-rs-crypto-rustcrypto/src/aead.rs
+++ b/mls-rs-crypto-rustcrypto/src/aead.rs
@@ -8,9 +8,11 @@ use core::fmt::Debug;
 
 use aes_gcm::{Aes128Gcm, Aes256Gcm, KeyInit};
 use chacha20poly1305::ChaCha20Poly1305;
-use mls_rs_core::{crypto::CipherSuite, error::IntoAnyError};
+use mls_rs_core::crypto::CipherSuite;
+use mls_rs_core::error::IntoAnyError;
 use mls_rs_crypto_traits::{AeadId, AeadType, AES_TAG_LEN};
-use rc_aead::{generic_array::GenericArray, Payload};
+use rc_aead::generic_array::GenericArray;
+use rc_aead::Payload;
 
 use alloc::vec::Vec;
 

--- a/mls-rs-crypto-rustcrypto/src/ec.rs
+++ b/mls-rs-crypto-rustcrypto/src/ec.rs
@@ -345,12 +345,11 @@ pub(crate) mod test_utils {
 mod tests {
     use assert_matches::assert_matches;
 
+    use super::test_utils::{byte_equal, get_test_public_keys, get_test_secret_keys};
     use super::{
         generate_keypair, generate_private_key, private_key_bytes_to_public,
         private_key_from_bytes, private_key_to_bytes, pub_key_from_uncompressed,
-        pub_key_to_uncompressed,
-        test_utils::{byte_equal, get_test_public_keys, get_test_secret_keys},
-        Curve, EcError,
+        pub_key_to_uncompressed, Curve, EcError,
     };
 
     use alloc::vec;

--- a/mls-rs-crypto-rustcrypto/src/ec_for_x509.rs
+++ b/mls-rs-crypto-rustcrypto/src/ec_for_x509.rs
@@ -6,19 +6,15 @@ use std::fmt::Debug;
 
 use mls_rs_crypto_traits::Curve;
 use p256::pkcs8::EncodePublicKey;
+use spki::der::asn1::{BitString, BitStringRef};
+use spki::der::{Any, AnyRef};
 use spki::{
-    der::{
-        asn1::{BitString, BitStringRef},
-        Any, AnyRef,
-    },
     AlgorithmIdentifier, AlgorithmIdentifierRef, ObjectIdentifier, SubjectPublicKeyInfo,
     SubjectPublicKeyInfoRef,
 };
 
-use crate::{
-    ec::{pub_key_from_uncompressed, EcError, EcPublicKey},
-    ec_signer::EcSigner,
-};
+use crate::ec::{pub_key_from_uncompressed, EcError, EcPublicKey};
+use crate::ec_signer::EcSigner;
 pub const X25519_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.110");
 pub const ED25519_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
 pub const P256_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.3.1.7");

--- a/mls-rs-crypto-rustcrypto/src/ecdh.rs
+++ b/mls-rs-crypto-rustcrypto/src/ecdh.rs
@@ -8,10 +8,8 @@ use alloc::vec::Vec;
 
 use mls_rs_crypto_traits::{Curve, DhType};
 
-use mls_rs_core::{
-    crypto::{CipherSuite, HpkePublicKey, HpkeSecretKey},
-    error::IntoAnyError,
-};
+use mls_rs_core::crypto::{CipherSuite, HpkePublicKey, HpkeSecretKey};
+use mls_rs_core::error::IntoAnyError;
 
 use crate::ec::{
     generate_keypair, private_key_bytes_to_public, private_key_ecdh, private_key_from_bytes,

--- a/mls-rs-crypto-rustcrypto/src/kdf.rs
+++ b/mls-rs-crypto-rustcrypto/src/kdf.rs
@@ -5,7 +5,8 @@
 use core::fmt::Debug;
 
 use hkdf::SimpleHkdf;
-use mls_rs_core::{crypto::CipherSuite, error::IntoAnyError};
+use mls_rs_core::crypto::CipherSuite;
+use mls_rs_core::error::IntoAnyError;
 use mls_rs_crypto_traits::{KdfId, KdfType};
 use sha2::{Sha256, Sha384, Sha512};
 

--- a/mls-rs-crypto-rustcrypto/src/lib.rs
+++ b/mls-rs-crypto-rustcrypto/src/lib.rs
@@ -23,21 +23,17 @@ use ec_signer::{EcSigner, EcSignerError};
 use ecdh::Ecdh;
 use kdf::Kdf;
 use mac::{Hash, HashError};
-use mls_rs_crypto_hpke::{
-    context::{ContextR, ContextS},
-    dhkem::DhKem,
-    hpke::{Hpke, HpkeError},
-};
+use mls_rs_crypto_hpke::context::{ContextR, ContextS};
+use mls_rs_crypto_hpke::dhkem::DhKem;
+use mls_rs_crypto_hpke::hpke::{Hpke, HpkeError};
 use mls_rs_crypto_traits::{AeadType, KdfType, KemId, KemType};
 use rand_core::{OsRng, RngCore};
 
-use mls_rs_core::{
-    crypto::{
-        CipherSuite, CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkePublicKey,
-        HpkeSecretKey, SignaturePublicKey, SignatureSecretKey,
-    },
-    error::{AnyError, IntoAnyError},
+use mls_rs_core::crypto::{
+    CipherSuite, CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkePublicKey, HpkeSecretKey,
+    SignaturePublicKey, SignatureSecretKey,
 };
+use mls_rs_core::error::{AnyError, IntoAnyError};
 use zeroize::Zeroizing;
 
 use alloc::vec;

--- a/mls-rs-crypto-rustcrypto/src/mac.rs
+++ b/mls-rs-crypto-rustcrypto/src/mac.rs
@@ -2,10 +2,9 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use hmac::{
-    digest::{crypto_common::BlockSizeUser, FixedOutputReset},
-    Mac, SimpleHmac,
-};
+use hmac::digest::crypto_common::BlockSizeUser;
+use hmac::digest::FixedOutputReset;
+use hmac::{Mac, SimpleHmac};
 use mls_rs_core::crypto::CipherSuite;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 

--- a/mls-rs-crypto-rustcrypto/src/x509.rs
+++ b/mls-rs-crypto-rustcrypto/src/x509.rs
@@ -4,11 +4,15 @@
 
 use std::net::AddrParseError;
 
-use mls_rs_core::{crypto::CipherSuite, error::IntoAnyError};
+use mls_rs_core::crypto::CipherSuite;
+use mls_rs_core::error::IntoAnyError;
 use mls_rs_identity_x509::SubjectAltName;
-use spki::{der::Tag, ObjectIdentifier};
+use spki::der::Tag;
+use spki::ObjectIdentifier;
 
-use crate::{ec::EcError, ec_for_x509::EcX509Error, ec_signer::EcSignerError};
+use crate::ec::EcError;
+use crate::ec_for_x509::EcX509Error;
+use crate::ec_signer::EcSignerError;
 
 mod reader;
 mod util;

--- a/mls-rs-crypto-rustcrypto/src/x509/reader.rs
+++ b/mls-rs-crypto-rustcrypto/src/x509/reader.rs
@@ -5,18 +5,17 @@
 use mls_rs_identity_x509::{
     DerCertificate, SubjectAltName as MlsSubjectAltName, SubjectComponent, X509CertificateReader,
 };
-use spki::der::{oid::AssociatedOid, Decode, Encode};
-use x509_cert::{
-    ext::pkix::{name::GeneralNames, SubjectAltName},
-    Certificate,
-};
+use spki::der::oid::AssociatedOid;
+use spki::der::{Decode, Encode};
+use x509_cert::ext::pkix::name::GeneralNames;
+use x509_cert::ext::pkix::SubjectAltName;
+use x509_cert::Certificate;
 
-use crate::{ec::pub_key_to_uncompressed, ec_for_x509::pub_key_from_spki};
+use crate::ec::pub_key_to_uncompressed;
+use crate::ec_for_x509::pub_key_from_spki;
 
-use super::{
-    util::{general_names_to_alt_names, parse_x509_name},
-    X509Error,
-};
+use super::util::{general_names_to_alt_names, parse_x509_name};
+use super::X509Error;
 
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
@@ -84,17 +83,14 @@ impl X509CertificateReader for X509Reader {
 #[cfg(test)]
 mod tests {
     use mls_rs_identity_x509::{SubjectAltName, SubjectComponent, X509CertificateReader};
-    use spki::der::{
-        asn1::{SetOfVec, Utf8StringRef},
-        oid::db::rfc4519,
-        Any, Encode,
-    };
-    use x509_cert::{attr::AttributeTypeAndValue, name::RelativeDistinguishedName};
+    use spki::der::asn1::{SetOfVec, Utf8StringRef};
+    use spki::der::oid::db::rfc4519;
+    use spki::der::{Any, Encode};
+    use x509_cert::attr::AttributeTypeAndValue;
+    use x509_cert::name::RelativeDistinguishedName;
 
-    use crate::x509::{
-        util::test_utils::{load_github_leaf, load_ip_cert, load_test_ca},
-        X509Reader,
-    };
+    use crate::x509::util::test_utils::{load_github_leaf, load_ip_cert, load_test_ca};
+    use crate::x509::X509Reader;
 
     #[test]
     fn subject_parser_bytes() {

--- a/mls-rs-crypto-rustcrypto/src/x509/util.rs
+++ b/mls-rs-crypto-rustcrypto/src/x509/util.rs
@@ -6,38 +6,26 @@ use mls_rs_core::crypto::CipherSuite;
 use mls_rs_identity_x509::{
     CertificateRequestParameters, SubjectAltName as MlsSubjectAltName, SubjectComponent,
 };
-use std::{net::IpAddr, str::FromStr};
+use std::net::IpAddr;
+use std::str::FromStr;
 
-use spki::{
-    der::{
-        asn1::{Ia5String, OctetString, PrintableString, PrintableStringRef},
-        oid::db::{rfc3280, rfc4519, rfc5912::ECDSA_WITH_SHA_256},
-        Tag, Tagged,
-    },
-    ObjectIdentifier,
-};
+use spki::der::asn1::{Ia5String, OctetString, PrintableString, PrintableStringRef};
+use spki::der::oid::db::rfc5912::ECDSA_WITH_SHA_256;
+use spki::der::oid::db::{rfc3280, rfc4519};
+use spki::der::{Tag, Tagged};
+use spki::ObjectIdentifier;
 
-use x509_cert::{
-    attr::{Attribute, AttributeTypeAndValue},
-    ext::{
-        pkix::{
-            name::{GeneralName, GeneralNames},
-            BasicConstraints, KeyUsage, KeyUsages,
-        },
-        Extension,
-    },
-    name::{RdnSequence, RelativeDistinguishedName},
-    request::ExtensionReq,
-};
+use x509_cert::attr::{Attribute, AttributeTypeAndValue};
+use x509_cert::ext::pkix::name::{GeneralName, GeneralNames};
+use x509_cert::ext::pkix::{BasicConstraints, KeyUsage, KeyUsages};
+use x509_cert::ext::Extension;
+use x509_cert::name::{RdnSequence, RelativeDistinguishedName};
+use x509_cert::request::ExtensionReq;
 
-use x509_cert::{
-    der::{
-        asn1::{Any, Ia5StringRef, SetOfVec, Utf8StringRef},
-        oid::AssociatedOid,
-        Decode, Encode,
-    },
-    ext::pkix::SubjectAltName,
-};
+use x509_cert::der::asn1::{Any, Ia5StringRef, SetOfVec, Utf8StringRef};
+use x509_cert::der::oid::AssociatedOid;
+use x509_cert::der::{Decode, Encode};
+use x509_cert::ext::pkix::SubjectAltName;
 
 use crate::ec_for_x509::ED25519_OID;
 

--- a/mls-rs-crypto-rustcrypto/src/x509/validator.rs
+++ b/mls-rs-crypto-rustcrypto/src/x509/validator.rs
@@ -2,19 +2,16 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs_core::{crypto::SignaturePublicKey, time::MlsTime};
+use mls_rs_core::crypto::SignaturePublicKey;
+use mls_rs_core::time::MlsTime;
 use mls_rs_identity_x509::{CertificateChain, DerCertificate, X509CredentialValidator};
 use spki::der::{Decode, Encode};
-use std::{
-    collections::HashMap,
-    fmt::{self, Debug},
-};
+use std::collections::HashMap;
+use std::fmt::{self, Debug};
 use x509_cert::Certificate;
 
-use crate::{
-    ec::pub_key_to_uncompressed,
-    ec_for_x509::{pub_key_from_spki, signer_from_algorithm},
-};
+use crate::ec::pub_key_to_uncompressed;
+use crate::ec_for_x509::{pub_key_from_spki, signer_from_algorithm};
 
 use super::X509Error;
 
@@ -222,16 +219,12 @@ mod tests {
     use spki::der::Decode;
     use x509_cert::Certificate;
 
-    use crate::{
-        ec_signer::EcSignerError,
-        x509::{
-            util::test_utils::{
-                load_another_ca, load_test_ca, load_test_cert_chain, load_test_invalid_ca_chain,
-                load_test_invalid_chain,
-            },
-            X509Error,
-        },
+    use crate::ec_signer::EcSignerError;
+    use crate::x509::util::test_utils::{
+        load_another_ca, load_test_ca, load_test_cert_chain, load_test_invalid_ca_chain,
+        load_test_invalid_chain,
     };
+    use crate::x509::X509Error;
 
     use super::X509Validator;
 

--- a/mls-rs-crypto-rustcrypto/src/x509/writer.rs
+++ b/mls-rs-crypto-rustcrypto/src/x509/writer.rs
@@ -8,21 +8,21 @@ use mls_rs_identity_x509::{
     CertificateRequestParameters, DerCertificateRequest, X509RequestWriter,
 };
 
-use spki::{
-    der::{asn1::BitString, Decode},
-    AlgorithmIdentifier, SubjectPublicKeyInfo,
-};
+use spki::der::asn1::BitString;
+use spki::der::Decode;
+use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 
-use x509_cert::{attr::Attributes, der::Encode};
+use x509_cert::attr::Attributes;
+use x509_cert::der::Encode;
 
 use x509_cert::request::{CertReq, CertReqInfo};
 
-use crate::{ec::pub_key_from_uncompressed, ec_for_x509::pub_key_to_spki, ec_signer::EcSigner};
+use crate::ec::pub_key_from_uncompressed;
+use crate::ec_for_x509::pub_key_to_spki;
+use crate::ec_signer::EcSigner;
 
-use super::{
-    util::{build_x509_name, extension_req, object_id_for_ciphersuite, request_extensions},
-    X509Error,
-};
+use super::util::{build_x509_name, extension_req, object_id_for_ciphersuite, request_extensions};
+use super::X509Error;
 
 #[derive(Debug, Clone)]
 pub struct CertificateRequestWriter {
@@ -119,7 +119,8 @@ mod tests {
         CertificateRequestParameters, SubjectAltName, SubjectComponent, X509RequestWriter,
     };
 
-    use crate::{ec::test_utils::ed25519_seed_to_private_key, x509::CertificateRequestWriter};
+    use crate::ec::test_utils::ed25519_seed_to_private_key;
+    use crate::x509::CertificateRequestWriter;
 
     #[test]
     fn writing_ca_csr() {

--- a/mls-rs-crypto-traits/src/aead.rs
+++ b/mls-rs-crypto-traits/src/aead.rs
@@ -6,7 +6,8 @@
 use mockall::automock;
 
 use alloc::vec::Vec;
-use mls_rs_core::{crypto::CipherSuite, error::IntoAnyError};
+use mls_rs_core::crypto::CipherSuite;
+use mls_rs_core::error::IntoAnyError;
 
 pub const AEAD_ID_EXPORT_ONLY: u16 = 0xFFFF;
 pub const AES_TAG_LEN: usize = 16;

--- a/mls-rs-crypto-traits/src/dh.rs
+++ b/mls-rs-crypto-traits/src/dh.rs
@@ -2,10 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs_core::{
-    crypto::{HpkePublicKey, HpkeSecretKey},
-    error::IntoAnyError,
-};
+use mls_rs_core::crypto::{HpkePublicKey, HpkeSecretKey};
+use mls_rs_core::error::IntoAnyError;
 
 use alloc::vec::Vec;
 

--- a/mls-rs-crypto-traits/src/kdf.rs
+++ b/mls-rs-crypto-traits/src/kdf.rs
@@ -6,7 +6,8 @@
 use mockall::automock;
 
 use alloc::vec::Vec;
-use mls_rs_core::{crypto::CipherSuite, error::IntoAnyError};
+use mls_rs_core::crypto::CipherSuite;
+use mls_rs_core::error::IntoAnyError;
 
 /// A trait that provides the required KDF functions
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]

--- a/mls-rs-crypto-traits/src/kem.rs
+++ b/mls-rs-crypto-traits/src/kem.rs
@@ -2,10 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs_core::{
-    crypto::{CipherSuite, HpkePublicKey, HpkeSecretKey},
-    error::IntoAnyError,
-};
+use mls_rs_core::crypto::{CipherSuite, HpkePublicKey, HpkeSecretKey};
+use mls_rs_core::error::IntoAnyError;
 
 use alloc::vec::Vec;
 

--- a/mls-rs-crypto-traits/src/mock.rs
+++ b/mls-rs-crypto-traits/src/mock.rs
@@ -2,7 +2,10 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-pub use crate::{aead::MockAeadType, dh::MockDhType, kdf::MockKdfType, kem::MockKemType};
+pub use crate::aead::MockAeadType;
+pub use crate::dh::MockDhType;
+pub use crate::kdf::MockKdfType;
+pub use crate::kem::MockKemType;
 
 #[derive(Debug)]
 pub struct TestError {}

--- a/mls-rs-crypto-webcrypto/src/aead.rs
+++ b/mls-rs-crypto-webcrypto/src/aead.rs
@@ -8,7 +8,8 @@ use mls_rs_crypto_traits::{AeadId, AeadType};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::AesGcmParams;
 
-use crate::{get_crypto, key_type::KeyType, CryptoError};
+use crate::key_type::KeyType;
+use crate::{get_crypto, CryptoError};
 
 #[derive(Clone)]
 pub struct Aead {

--- a/mls-rs-crypto-webcrypto/src/ec/der_private_key.rs
+++ b/mls-rs-crypto-webcrypto/src/ec/der_private_key.rs
@@ -2,16 +2,15 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use der::{
-    asn1::{BitString, ContextSpecific, OctetString, Uint},
-    oid::ObjectIdentifier,
-    Any, Decode, Encode, Sequence,
-};
+use der::asn1::{BitString, ContextSpecific, OctetString, Uint};
+use der::oid::ObjectIdentifier;
+use der::{Any, Decode, Encode, Sequence};
 use js_sys::Array;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{CryptoKeyPair, EcKeyGenParams};
 
-use crate::{get_crypto, key_type::KeyType, CryptoError};
+use crate::key_type::KeyType;
+use crate::{get_crypto, CryptoError};
 
 /// Generate private / public key pair.
 pub(crate) async fn generate(curve: &'static str) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {

--- a/mls-rs-crypto-webcrypto/src/ec/ecdh.rs
+++ b/mls-rs-crypto-webcrypto/src/ec/ecdh.rs
@@ -11,7 +11,8 @@ use wasm_bindgen_futures::JsFuture;
 use web_sys::{CryptoKey, EcdhKeyDeriveParams, SubtleCrypto};
 
 use super::der_private_key::{generate, DerPrivateKey};
-use crate::{get_crypto, key_type::KeyType, CryptoError};
+use crate::key_type::KeyType;
+use crate::{get_crypto, CryptoError};
 
 use const_oid::db::rfc5912::{SECP_256_R_1, SECP_384_R_1, SECP_521_R_1};
 

--- a/mls-rs-crypto-webcrypto/src/ec/ecdsa.rs
+++ b/mls-rs-crypto-webcrypto/src/ec/ecdsa.rs
@@ -1,11 +1,13 @@
-use der::{asn1::Uint, Decode, Encode, Sequence};
+use der::asn1::Uint;
+use der::{Decode, Encode, Sequence};
 use js_sys::{Boolean, Uint8Array};
 use mls_rs_core::crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::EcdsaParams;
 
 use super::der_private_key::{generate, DerPrivateKey};
-use crate::{get_crypto, key_type::KeyType, CryptoError};
+use crate::key_type::KeyType;
+use crate::{get_crypto, CryptoError};
 
 #[derive(Sequence)]
 struct DerSignature {

--- a/mls-rs-crypto-webcrypto/src/hkdf.rs
+++ b/mls-rs-crypto-webcrypto/src/hkdf.rs
@@ -9,7 +9,8 @@ use js_sys::Uint8Array;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::SubtleCrypto;
 
-use crate::{get_crypto, key_type::KeyType, CryptoError};
+use crate::key_type::KeyType;
+use crate::{get_crypto, CryptoError};
 
 #[derive(Clone)]
 pub struct Hkdf {

--- a/mls-rs-crypto-webcrypto/src/lib.rs
+++ b/mls-rs-crypto-webcrypto/src/lib.rs
@@ -9,19 +9,15 @@ mod ec;
 mod hkdf;
 mod key_type;
 
-use mls_rs_core::{
-    crypto::{
-        CipherSuite, CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkePublicKey,
-        HpkeSecretKey, SignaturePublicKey, SignatureSecretKey,
-    },
-    error::{AnyError, IntoAnyError},
+use mls_rs_core::crypto::{
+    CipherSuite, CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkePublicKey, HpkeSecretKey,
+    SignaturePublicKey, SignatureSecretKey,
 };
+use mls_rs_core::error::{AnyError, IntoAnyError};
 
-use mls_rs_crypto_hpke::{
-    context::{ContextR, ContextS},
-    dhkem::DhKem,
-    hpke::Hpke,
-};
+use mls_rs_crypto_hpke::context::{ContextR, ContextS};
+use mls_rs_crypto_hpke::dhkem::DhKem;
+use mls_rs_crypto_hpke::hpke::Hpke;
 
 use mls_rs_crypto_traits::{AeadType, KdfType, KemId};
 
@@ -29,11 +25,9 @@ use wasm_bindgen::JsValue;
 use web_sys::SubtleCrypto;
 use zeroize::Zeroizing;
 
-use crate::{
-    aead::Aead,
-    ec::{EcSigner, Ecdh},
-    hkdf::Hkdf,
-};
+use crate::aead::Aead;
+use crate::ec::{EcSigner, Ecdh};
+use crate::hkdf::Hkdf;
 
 #[derive(Debug, thiserror::Error)]
 pub enum CryptoError {

--- a/mls-rs-ffi/src/lib.rs
+++ b/mls-rs-ffi/src/lib.rs
@@ -5,10 +5,8 @@
 #[cfg(all(feature = "openssl", feature = "sqlite", feature = "x509"))]
 mod openssl_sqlite {
     use mls_rs::client_builder::{BaseConfig, WithCryptoProvider, WithIdentityProvider};
-    use mls_rs_crypto_openssl::{
-        x509::{X509Reader, X509Validator},
-        OpensslCryptoProvider,
-    };
+    use mls_rs_crypto_openssl::x509::{X509Reader, X509Validator};
+    use mls_rs_crypto_openssl::OpensslCryptoProvider;
     use mls_rs_identity_x509::{SubjectIdentityExtractor, X509IdentityProvider};
 
     pub type OpensslSqlMlsConfig = WithIdentityProvider<

--- a/mls-rs-identity-x509/src/error.rs
+++ b/mls-rs-identity-x509/src/error.rs
@@ -2,7 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs_core::{error::AnyError, identity::CredentialType};
+use mls_rs_core::error::AnyError;
+use mls_rs_core::identity::CredentialType;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]

--- a/mls-rs-identity-x509/src/identity_extractor.rs
+++ b/mls-rs-identity-x509/src/identity_extractor.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
-use mls_rs_core::{error::IntoAnyError, identity::CertificateChain};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::identity::CertificateChain;
 
 use crate::{
     DerCertificate, SubjectComponent, X509CertificateReader, X509IdentityError,
@@ -126,9 +127,9 @@ fn get_certificate(
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
+    use crate::test_utils::test_certificate_chain;
     use crate::{
-        test_utils::test_certificate_chain, MockX509CertificateReader, SubjectComponent,
-        SubjectIdentityExtractor, X509IdentityError,
+        MockX509CertificateReader, SubjectComponent, SubjectIdentityExtractor, X509IdentityError,
     };
 
     use alloc::vec;

--- a/mls-rs-identity-x509/src/lib.rs
+++ b/mls-rs-identity-x509/src/lib.rs
@@ -61,7 +61,9 @@ impl AsRef<[u8]> for DerCertificateRequest {
 pub(crate) mod test_utils {
 
     use alloc::vec;
-    use mls_rs_core::{crypto::SignaturePublicKey, error::IntoAnyError, identity::SigningIdentity};
+    use mls_rs_core::crypto::SignaturePublicKey;
+    use mls_rs_core::error::IntoAnyError;
+    use mls_rs_core::identity::SigningIdentity;
     use rand::{thread_rng, Rng};
 
     use crate::{CertificateChain, DerCertificate};

--- a/mls-rs-identity-x509/src/provider.rs
+++ b/mls-rs-identity-x509/src/provider.rs
@@ -2,16 +2,15 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{util::credential_to_chain, CertificateChain, X509IdentityError};
+use crate::util::credential_to_chain;
+use crate::{CertificateChain, X509IdentityError};
 use alloc::vec;
 use alloc::vec::Vec;
-use mls_rs_core::{
-    crypto::SignaturePublicKey,
-    error::IntoAnyError,
-    extension::ExtensionList,
-    identity::{CredentialType, IdentityProvider},
-    time::MlsTime,
-};
+use mls_rs_core::crypto::SignaturePublicKey;
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::extension::ExtensionList;
+use mls_rs_core::identity::{CredentialType, IdentityProvider};
+use mls_rs_core::time::MlsTime;
 
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
@@ -185,13 +184,14 @@ where
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use mls_rs_core::{crypto::SignaturePublicKey, identity::CredentialType, time::MlsTime};
+    use mls_rs_core::crypto::SignaturePublicKey;
+    use mls_rs_core::identity::CredentialType;
+    use mls_rs_core::time::MlsTime;
 
+    use crate::test_utils::{
+        test_certificate_chain, test_signing_identity, test_signing_identity_with_chain, TestError,
+    };
     use crate::{
-        test_utils::{
-            test_certificate_chain, test_signing_identity, test_signing_identity_with_chain,
-            TestError,
-        },
         MockX509CredentialValidator, MockX509IdentityExtractor, X509IdentityError,
         X509IdentityProvider,
     };

--- a/mls-rs-identity-x509/src/traits.rs
+++ b/mls-rs-identity-x509/src/traits.rs
@@ -5,7 +5,8 @@
 use crate::{DerCertificate, DerCertificateRequest};
 
 use alloc::vec::Vec;
-use mls_rs_core::{crypto::SignaturePublicKey, error::IntoAnyError};
+use mls_rs_core::crypto::SignaturePublicKey;
+use mls_rs_core::error::IntoAnyError;
 
 #[cfg(all(test, feature = "std"))]
 use mockall::automock;

--- a/mls-rs-provider-sqlite/src/application.rs
+++ b/mls-rs-provider-sqlite/src/application.rs
@@ -2,10 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use std::{
-    fmt::{self, Debug},
-    sync::{Arc, Mutex},
-};
+use std::fmt::{self, Debug};
+use std::sync::{Arc, Mutex};
 
 use rusqlite::{params, Connection, OptionalExtension};
 
@@ -153,10 +151,10 @@ impl Item {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        application::Item, connection_strategy::MemoryStrategy, test_utils::gen_rand_bytes,
-        SqLiteDataStorageEngine,
-    };
+    use crate::application::Item;
+    use crate::connection_strategy::MemoryStrategy;
+    use crate::test_utils::gen_rand_bytes;
+    use crate::SqLiteDataStorageEngine;
 
     use super::SqLiteApplicationStorage;
 

--- a/mls-rs-provider-sqlite/src/cipher.rs
+++ b/mls-rs-provider-sqlite/src/cipher.rs
@@ -126,9 +126,9 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use crate::cipher::SqlCipherConfig;
-    use crate::connection_strategy::{ConnectionStrategy, MemoryStrategy};
+    use crate::connection_strategy::{ConnectionStrategy, FileConnectionStrategy, MemoryStrategy};
     use crate::test_utils::gen_rand_bytes;
-    use crate::{connection_strategy::FileConnectionStrategy, SqLiteDataStorageError};
+    use crate::SqLiteDataStorageError;
 
     use super::{CipheredConnectionStrategy, SqlCipherKey};
 

--- a/mls-rs-provider-sqlite/src/group_state.rs
+++ b/mls-rs-provider-sqlite/src/group_state.rs
@@ -4,10 +4,8 @@
 
 use mls_rs_core::group::{EpochRecord, GroupState, GroupStateStorage};
 use rusqlite::{params, Connection, OptionalExtension};
-use std::{
-    fmt::Debug,
-    sync::{Arc, Mutex},
-};
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
 
 use crate::SqLiteDataStorageError;
 
@@ -214,10 +212,9 @@ impl GroupStateStorage for SqLiteGroupStateStorage {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        SqLiteDataStorageEngine,
-        {connection_strategy::MemoryStrategy, test_utils::gen_rand_bytes},
-    };
+    use crate::connection_strategy::MemoryStrategy;
+    use crate::test_utils::gen_rand_bytes;
+    use crate::SqLiteDataStorageEngine;
 
     use super::*;
 

--- a/mls-rs-provider-sqlite/src/key_package.rs
+++ b/mls-rs-provider-sqlite/src/key_package.rs
@@ -2,11 +2,9 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs_core::{
-    key_package::{KeyPackageData, KeyPackageStorage},
-    mls_rs_codec::{MlsDecode, MlsEncode},
-    time::MlsTime,
-};
+use mls_rs_core::key_package::{KeyPackageData, KeyPackageStorage};
+use mls_rs_core::mls_rs_codec::{MlsDecode, MlsEncode};
+use mls_rs_core::time::MlsTime;
 use rusqlite::{params, Connection, OptionalExtension};
 use std::sync::{Arc, Mutex};
 
@@ -123,12 +121,12 @@ impl KeyPackageStorage for SqLiteKeyPackageStorage {
 #[cfg(test)]
 mod tests {
     use super::SqLiteKeyPackageStorage;
-    use crate::{
-        SqLiteDataStorageEngine, SqLiteDataStorageError,
-        {connection_strategy::MemoryStrategy, test_utils::gen_rand_bytes},
-    };
+    use crate::connection_strategy::MemoryStrategy;
+    use crate::test_utils::gen_rand_bytes;
+    use crate::{SqLiteDataStorageEngine, SqLiteDataStorageError};
     use assert_matches::assert_matches;
-    use mls_rs_core::{crypto::HpkeSecretKey, key_package::KeyPackageData};
+    use mls_rs_core::crypto::HpkeSecretKey;
+    use mls_rs_core::key_package::KeyPackageData;
 
     fn test_storage() -> SqLiteKeyPackageStorage {
         SqLiteDataStorageEngine::new(MemoryStrategy)

--- a/mls-rs-provider-sqlite/src/lib.rs
+++ b/mls-rs-provider-sqlite/src/lib.rs
@@ -25,12 +25,10 @@ pub mod connection_strategy;
 
 /// SQLite storage components.
 pub mod storage {
-    pub use {
-        crate::application::{Item, SqLiteApplicationStorage},
-        crate::group_state::SqLiteGroupStateStorage,
-        crate::key_package::SqLiteKeyPackageStorage,
-        crate::psk::SqLitePreSharedKeyStorage,
-    };
+    pub use crate::application::{Item, SqLiteApplicationStorage};
+    pub use crate::group_state::SqLiteGroupStateStorage;
+    pub use crate::key_package::SqLiteKeyPackageStorage;
+    pub use crate::psk::SqLitePreSharedKeyStorage;
 }
 
 #[derive(Debug, Error)]
@@ -152,7 +150,8 @@ fn create_tables_v1(connection: &Connection) -> Result<(), SqLiteDataStorageErro
 
 #[cfg(test)]
 mod tests {
-    use crate::{connection_strategy::MemoryStrategy, SqLiteDataStorageEngine};
+    use crate::connection_strategy::MemoryStrategy;
+    use crate::SqLiteDataStorageEngine;
 
     #[test]
     pub fn user_version_test() {

--- a/mls-rs-provider-sqlite/src/psk.rs
+++ b/mls-rs-provider-sqlite/src/psk.rs
@@ -5,10 +5,8 @@
 use crate::SqLiteDataStorageError;
 use mls_rs_core::psk::{ExternalPskId, PreSharedKey, PreSharedKeyStorage};
 use rusqlite::{params, Connection, OptionalExtension};
-use std::{
-    ops::Deref,
-    sync::{Arc, Mutex},
-};
+use std::ops::Deref;
+use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone)]
 /// SQLite storage for MLS pre-shared keys.
@@ -77,10 +75,9 @@ impl PreSharedKeyStorage for SqLitePreSharedKeyStorage {
 mod tests {
     use mls_rs_core::psk::PreSharedKey;
 
-    use crate::{
-        SqLiteDataStorageEngine,
-        {connection_strategy::MemoryStrategy, test_utils::gen_rand_bytes},
-    };
+    use crate::connection_strategy::MemoryStrategy;
+    use crate::test_utils::gen_rand_bytes;
+    use crate::SqLiteDataStorageEngine;
 
     use super::SqLitePreSharedKeyStorage;
 

--- a/mls-rs-uniffi/src/config.rs
+++ b/mls-rs-uniffi/src/config.rs
@@ -1,11 +1,9 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use mls_rs::{
-    client_builder::{self, WithGroupStateStorage},
-    identity::basic,
-    storage_provider::in_memory::InMemoryGroupStateStorage,
-};
+use mls_rs::client_builder::{self, WithGroupStateStorage};
+use mls_rs::identity::basic;
+use mls_rs::storage_provider::in_memory::InMemoryGroupStateStorage;
 use mls_rs_crypto_openssl::OpensslCryptoProvider;
 
 use self::group_state::{GroupStateStorage, GroupStateStorageAdapter};

--- a/mls-rs-uniffi/src/lib.rs
+++ b/mls-rs-uniffi/src/lib.rs
@@ -30,10 +30,8 @@ use std::sync::Mutex;
 use tokio::sync::Mutex;
 
 use mls_rs::error::{IntoAnyError, MlsError};
-use mls_rs::group;
 use mls_rs::identity::basic;
-use mls_rs::mls_rules;
-use mls_rs::{CipherSuiteProvider, CryptoProvider};
+use mls_rs::{group, mls_rules, CipherSuiteProvider, CryptoProvider};
 use mls_rs_core::identity;
 use mls_rs_core::identity::{BasicCredential, IdentityProvider};
 use mls_rs_crypto_openssl::OpensslCryptoProvider;

--- a/mls-rs/benches/group_add.rs
+++ b/mls-rs/benches/group_add.rs
@@ -3,15 +3,11 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use criterion::{BatchSize, BenchmarkId, Criterion};
-use mls_rs::{
-    client_builder::MlsConfig,
-    identity::{
-        basic::{BasicCredential, BasicIdentityProvider},
-        SigningIdentity,
-    },
-    mls_rules::{CommitOptions, DefaultMlsRules},
-    CipherSuite, CipherSuiteProvider, Client, CryptoProvider,
-};
+use mls_rs::client_builder::MlsConfig;
+use mls_rs::identity::basic::{BasicCredential, BasicIdentityProvider};
+use mls_rs::identity::SigningIdentity;
+use mls_rs::mls_rules::{CommitOptions, DefaultMlsRules};
+use mls_rs::{CipherSuite, CipherSuiteProvider, Client, CryptoProvider};
 use mls_rs_crypto_openssl::OpensslCryptoProvider;
 
 fn bench(c: &mut Criterion) {

--- a/mls-rs/benches/group_commit.rs
+++ b/mls-rs/benches/group_commit.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use criterion::{BatchSize, BenchmarkId, Criterion};
-use mls_rs::{test_utils::benchmarks::load_group_states, CipherSuite};
+use mls_rs::test_utils::benchmarks::load_group_states;
+use mls_rs::CipherSuite;
 
 fn bench(c: &mut Criterion) {
     let cipher_suite = CipherSuite::CURVE25519_AES128;

--- a/mls-rs/benches/group_receive_commit.rs
+++ b/mls-rs/benches/group_receive_commit.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use criterion::{BatchSize, BenchmarkId, Criterion};
-use mls_rs::{test_utils::benchmarks::load_group_states, CipherSuite};
+use mls_rs::test_utils::benchmarks::load_group_states;
+use mls_rs::CipherSuite;
 
 fn bench(c: &mut Criterion) {
     let cipher_suite = CipherSuite::CURVE25519_AES128;

--- a/mls-rs/benches/group_serialize.rs
+++ b/mls-rs/benches/group_serialize.rs
@@ -2,7 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs::{test_utils::benchmarks::load_group_states, CipherSuite};
+use mls_rs::test_utils::benchmarks::load_group_states;
+use mls_rs::CipherSuite;
 
 use criterion::{BenchmarkId, Criterion};
 

--- a/mls-rs/examples/basic_server_usage.rs
+++ b/mls-rs/examples/basic_server_usage.rs
@@ -2,20 +2,14 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs::{
-    client_builder::MlsConfig,
-    error::MlsError,
-    external_client::{
-        builder::MlsConfig as ExternalMlsConfig, ExternalClient, ExternalReceivedMessage,
-        ExternalSnapshot,
-    },
-    group::{CachedProposal, ReceivedMessage},
-    identity::{
-        basic::{BasicCredential, BasicIdentityProvider},
-        SigningIdentity,
-    },
-    CipherSuite, CipherSuiteProvider, Client, CryptoProvider, ExtensionList, MlsMessage,
-};
+use mls_rs::client_builder::MlsConfig;
+use mls_rs::error::MlsError;
+use mls_rs::external_client::builder::MlsConfig as ExternalMlsConfig;
+use mls_rs::external_client::{ExternalClient, ExternalReceivedMessage, ExternalSnapshot};
+use mls_rs::group::{CachedProposal, ReceivedMessage};
+use mls_rs::identity::basic::{BasicCredential, BasicIdentityProvider};
+use mls_rs::identity::SigningIdentity;
+use mls_rs::{CipherSuite, CipherSuiteProvider, Client, CryptoProvider, ExtensionList, MlsMessage};
 use mls_rs_core::crypto::SignatureSecretKey;
 
 const CIPHERSUITE: CipherSuite = CipherSuite::CURVE25519_AES128;

--- a/mls-rs/examples/basic_usage.rs
+++ b/mls-rs/examples/basic_usage.rs
@@ -2,15 +2,11 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs::{
-    client_builder::MlsConfig,
-    error::MlsError,
-    identity::{
-        basic::{BasicCredential, BasicIdentityProvider},
-        SigningIdentity,
-    },
-    CipherSuite, CipherSuiteProvider, Client, CryptoProvider, ExtensionList,
-};
+use mls_rs::client_builder::MlsConfig;
+use mls_rs::error::MlsError;
+use mls_rs::identity::basic::{BasicCredential, BasicIdentityProvider};
+use mls_rs::identity::SigningIdentity;
+use mls_rs::{CipherSuite, CipherSuiteProvider, Client, CryptoProvider, ExtensionList};
 
 const CIPHERSUITE: CipherSuite = CipherSuite::CURVE25519_AES128;
 

--- a/mls-rs/examples/custom.rs
+++ b/mls-rs/examples/custom.rs
@@ -24,29 +24,26 @@
 /// * Proposal validation rules that enforce 1. above.
 ///
 use assert_matches::assert_matches;
+use mls_rs::client_builder::{MlsConfig, PaddingMode};
+use mls_rs::error::MlsError;
+use mls_rs::group::proposal::{MlsCustomProposal, Proposal};
+use mls_rs::group::{Roster, Sender};
+use mls_rs::mls_rules::{
+    CommitDirection, CommitOptions, CommitSource, EncryptionOptions, ProposalBundle, ProposalSource,
+};
 use mls_rs::{
-    client_builder::{MlsConfig, PaddingMode},
-    error::MlsError,
-    group::{
-        proposal::{MlsCustomProposal, Proposal},
-        Roster, Sender,
-    },
-    mls_rules::{
-        CommitDirection, CommitOptions, CommitSource, EncryptionOptions, ProposalBundle,
-        ProposalSource,
-    },
     CipherSuite, CipherSuiteProvider, Client, CryptoProvider, ExtensionList, IdentityProvider,
     MlsRules,
 };
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
-use mls_rs_core::{
-    crypto::{SignaturePublicKey, SignatureSecretKey},
-    error::IntoAnyError,
-    extension::{ExtensionError, ExtensionType, MlsCodecExtension},
-    group::ProposalType,
-    identity::{Credential, CredentialType, CustomCredential, MlsCredential, SigningIdentity},
-    time::MlsTime,
+use mls_rs_core::crypto::{SignaturePublicKey, SignatureSecretKey};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::extension::{ExtensionError, ExtensionType, MlsCodecExtension};
+use mls_rs_core::group::ProposalType;
+use mls_rs_core::identity::{
+    Credential, CredentialType, CustomCredential, MlsCredential, SigningIdentity,
 };
+use mls_rs_core::time::MlsTime;
 
 use std::fmt::Display;
 

--- a/mls-rs/examples/large_group.rs
+++ b/mls-rs/examples/large_group.rs
@@ -2,16 +2,12 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs::{
-    client_builder::MlsConfig,
-    error::MlsError,
-    identity::{
-        basic::{BasicCredential, BasicIdentityProvider},
-        SigningIdentity,
-    },
-    mls_rules::{CommitOptions, DefaultMlsRules},
-    CipherSuite, CipherSuiteProvider, Client, CryptoProvider, Group,
-};
+use mls_rs::client_builder::MlsConfig;
+use mls_rs::error::MlsError;
+use mls_rs::identity::basic::{BasicCredential, BasicIdentityProvider};
+use mls_rs::identity::SigningIdentity;
+use mls_rs::mls_rules::{CommitOptions, DefaultMlsRules};
+use mls_rs::{CipherSuite, CipherSuiteProvider, Client, CryptoProvider, Group};
 
 const CIPHERSUITE: CipherSuite = CipherSuite::CURVE25519_AES128;
 const GROUP_SIZES: [usize; 8] = [2, 3, 5, 9, 17, 33, 65, 129];

--- a/mls-rs/fuzz/fuzz_targets/deserialize.rs
+++ b/mls-rs/fuzz/fuzz_targets/deserialize.rs
@@ -6,7 +6,8 @@
 
 mod deserialize {
     use libfuzzer_sys::fuzz_target;
-    use mls_rs::{mls_rs_codec::MlsDecode, MlsMessage};
+    use mls_rs::mls_rs_codec::MlsDecode;
+    use mls_rs::MlsMessage;
 
     fuzz_target!(|data: &[u8]| {
         let _ = MlsMessage::mls_decode(&mut &*data);

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -7,13 +7,14 @@ use crate::client_builder::{recreate_config, BaseConfig, ClientBuilder, MakeConf
 use crate::client_config::ClientConfig;
 use crate::group::framing::MlsMessage;
 
+use crate::group::snapshot::Snapshot;
 #[cfg(feature = "by_ref_proposal")]
 use crate::group::{
     framing::{Content, MlsMessagePayload, PublicMessage, Sender, WireFormat},
     message_signature::AuthenticatedContent,
     proposal::{AddProposal, Proposal},
 };
-use crate::group::{snapshot::Snapshot, ExportedTree, Group, NewMemberInfo};
+use crate::group::{ExportedTree, Group, NewMemberInfo};
 use crate::identity::SigningIdentity;
 use crate::key_package::{KeyPackageGeneration, KeyPackageGenerator};
 use crate::protocol_version::ProtocolVersion;
@@ -784,22 +785,16 @@ mod tests {
     use super::test_utils::*;
 
     use super::*;
-    use crate::{
-        crypto::test_utils::TestCryptoProvider,
-        identity::test_utils::{get_test_basic_credential, get_test_signing_identity},
-        tree_kem::leaf_node::LeafNodeSource,
-    };
+    use crate::crypto::test_utils::TestCryptoProvider;
+    use crate::identity::test_utils::{get_test_basic_credential, get_test_signing_identity};
+    use crate::tree_kem::leaf_node::LeafNodeSource;
     use assert_matches::assert_matches;
 
-    use crate::{
-        group::{
-            message_processor::ProposalMessageDescription,
-            proposal::Proposal,
-            test_utils::{test_group, test_group_custom_config},
-            ReceivedMessage,
-        },
-        psk::{ExternalPskId, PreSharedKey},
-    };
+    use crate::group::message_processor::ProposalMessageDescription;
+    use crate::group::proposal::Proposal;
+    use crate::group::test_utils::{test_group, test_group_custom_config};
+    use crate::group::ReceivedMessage;
+    use crate::psk::{ExternalPskId, PreSharedKey};
 
     use alloc::vec;
 
@@ -893,7 +888,8 @@ mod tests {
         // interim_transcript_hash to be computed from the confirmed_transcript_hash and
         // confirmation_tag, which is not the case for the initial interim_transcript_hash.
 
-        use crate::group::{message_processor::CommitEffect, CommitMessageDescription};
+        use crate::group::message_processor::CommitEffect;
+        use crate::group::CommitMessageDescription;
 
         let psk = PreSharedKey::from(b"psk".to_vec());
         let psk_id = ExternalPskId::new(b"psk id".to_vec());

--- a/mls-rs/src/client_builder.rs
+++ b/mls-rs/src/client_builder.rs
@@ -6,25 +6,20 @@
 //!
 //! See [`ClientBuilder`].
 
-use crate::{
-    cipher_suite::CipherSuite,
-    client::Client,
-    client_config::ClientConfig,
-    extension::{ExtensionType, MlsExtension},
-    group::{
-        mls_rules::{DefaultMlsRules, MlsRules},
-        proposal::ProposalType,
-    },
-    identity::CredentialType,
-    identity::SigningIdentity,
-    protocol_version::ProtocolVersion,
-    psk::{ExternalPskId, PreSharedKey},
-    storage_provider::in_memory::{
-        InMemoryGroupStateStorage, InMemoryKeyPackageStorage, InMemoryPreSharedKeyStorage,
-    },
-    tree_kem::{Capabilities, Lifetime},
-    Sealed,
+use crate::cipher_suite::CipherSuite;
+use crate::client::Client;
+use crate::client_config::ClientConfig;
+use crate::extension::{ExtensionType, MlsExtension};
+use crate::group::mls_rules::{DefaultMlsRules, MlsRules};
+use crate::group::proposal::ProposalType;
+use crate::identity::{CredentialType, SigningIdentity};
+use crate::protocol_version::ProtocolVersion;
+use crate::psk::{ExternalPskId, PreSharedKey};
+use crate::storage_provider::in_memory::{
+    InMemoryGroupStateStorage, InMemoryKeyPackageStorage, InMemoryPreSharedKeyStorage,
 };
+use crate::tree_kem::{Capabilities, Lifetime};
+use crate::Sealed;
 
 #[cfg(feature = "std")]
 use crate::time::MlsTime;
@@ -927,11 +922,9 @@ pub(crate) fn recreate_config<T: ClientConfig>(
 /// Definitions meant to be private that are inaccessible outside this crate. They need to be marked
 /// `pub` because they appear in public definitions.
 mod private {
-    use mls_rs_core::{
-        crypto::{CipherSuite, SignatureSecretKey},
-        identity::SigningIdentity,
-        protocol_version::ProtocolVersion,
-    };
+    use mls_rs_core::crypto::{CipherSuite, SignatureSecretKey};
+    use mls_rs_core::identity::SigningIdentity;
+    use mls_rs_core::protocol_version::ProtocolVersion;
 
     use crate::client_builder::{IntoConfigOutput, Settings};
 
@@ -977,27 +970,21 @@ mod private {
     }
 }
 
-use mls_rs_core::{
-    crypto::{CryptoProvider, SignatureSecretKey},
-    extension::{ExtensionError, ExtensionList},
-    group::GroupStateStorage,
-    identity::IdentityProvider,
-    key_package::KeyPackageStorage,
-    psk::PreSharedKeyStorage,
-};
+use mls_rs_core::crypto::{CryptoProvider, SignatureSecretKey};
+use mls_rs_core::extension::{ExtensionError, ExtensionList};
+use mls_rs_core::group::GroupStateStorage;
+use mls_rs_core::identity::IdentityProvider;
+use mls_rs_core::key_package::KeyPackageStorage;
+use mls_rs_core::psk::PreSharedKeyStorage;
 use private::{Config, ConfigInner, IntoConfig};
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use crate::{
-        client_builder::{BaseConfig, ClientBuilder, WithIdentityProvider},
-        crypto::test_utils::TestCryptoProvider,
-        identity::{
-            basic::BasicIdentityProvider,
-            test_utils::{get_test_signing_identity, BasicWithCustomProvider},
-        },
-        CipherSuite,
-    };
+    use crate::client_builder::{BaseConfig, ClientBuilder, WithIdentityProvider};
+    use crate::crypto::test_utils::TestCryptoProvider;
+    use crate::identity::basic::BasicIdentityProvider;
+    use crate::identity::test_utils::{get_test_signing_identity, BasicWithCustomProvider};
+    use crate::CipherSuite;
 
     use super::WithCryptoProvider;
 

--- a/mls-rs/src/client_config.rs
+++ b/mls-rs/src/client_config.rs
@@ -2,19 +2,20 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{
-    extension::ExtensionType,
-    group::{mls_rules::MlsRules, proposal::ProposalType},
-    identity::CredentialType,
-    protocol_version::ProtocolVersion,
-    tree_kem::{leaf_node::ConfigProperties, Capabilities, Lifetime},
-    ExtensionList,
-};
+use crate::extension::ExtensionType;
+use crate::group::mls_rules::MlsRules;
+use crate::group::proposal::ProposalType;
+use crate::identity::CredentialType;
+use crate::protocol_version::ProtocolVersion;
+use crate::tree_kem::leaf_node::ConfigProperties;
+use crate::tree_kem::{Capabilities, Lifetime};
+use crate::ExtensionList;
 use alloc::vec::Vec;
-use mls_rs_core::{
-    crypto::CryptoProvider, group::GroupStateStorage, identity::IdentityProvider,
-    key_package::KeyPackageStorage, psk::PreSharedKeyStorage,
-};
+use mls_rs_core::crypto::CryptoProvider;
+use mls_rs_core::group::GroupStateStorage;
+use mls_rs_core::identity::IdentityProvider;
+use mls_rs_core::key_package::KeyPackageStorage;
+use mls_rs_core::psk::PreSharedKeyStorage;
 
 pub trait ClientConfig: Send + Sync + Clone {
     type KeyPackageRepository: KeyPackageStorage + Clone;

--- a/mls-rs/src/extension/built_in.rs
+++ b/mls-rs/src/extension/built_in.rs
@@ -7,7 +7,8 @@ use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::extension::{ExtensionType, MlsCodecExtension};
 
-use mls_rs_core::{group::ProposalType, identity::CredentialType};
+use mls_rs_core::group::ProposalType;
+use mls_rs_core::identity::CredentialType;
 
 #[cfg(feature = "by_ref_proposal")]
 use mls_rs_core::{

--- a/mls-rs/src/external_client.rs
+++ b/mls-rs/src/external_client.rs
@@ -2,21 +2,19 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{
-    client::MlsError,
-    group::{framing::MlsMessage, message_processor::validate_key_package, ExportedTree},
-    KeyPackage,
-};
+use crate::client::MlsError;
+use crate::group::framing::MlsMessage;
+use crate::group::message_processor::validate_key_package;
+use crate::group::ExportedTree;
+use crate::KeyPackage;
 
 pub mod builder;
 mod config;
 mod group;
 
 pub(crate) use config::ExternalClientConfig;
-use mls_rs_core::{
-    crypto::{CryptoProvider, SignatureSecretKey},
-    identity::SigningIdentity,
-};
+use mls_rs_core::crypto::{CryptoProvider, SignatureSecretKey};
+use mls_rs_core::identity::SigningIdentity;
 
 use builder::{ExternalBaseConfig, ExternalClientBuilder};
 
@@ -129,10 +127,8 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests_utils {
-    use crate::{
-        client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
-        key_package::test_utils::test_key_package_message,
-    };
+    use crate::client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION};
+    use crate::key_package::test_utils::test_key_package_message;
 
     pub use super::builder::test_utils::*;
 

--- a/mls-rs/src/external_client/builder.rs
+++ b/mls-rs/src/external_client/builder.rs
@@ -6,23 +6,17 @@
 //!
 //! See [`ExternalClientBuilder`].
 
-use crate::{
-    crypto::SignaturePublicKey,
-    extension::ExtensionType,
-    external_client::{ExternalClient, ExternalClientConfig},
-    group::{
-        mls_rules::{DefaultMlsRules, MlsRules},
-        proposal::ProposalType,
-    },
-    identity::CredentialType,
-    protocol_version::ProtocolVersion,
-    tree_kem::Capabilities,
-    CryptoProvider, Sealed,
-};
-use std::{
-    collections::HashMap,
-    fmt::{self, Debug},
-};
+use crate::crypto::SignaturePublicKey;
+use crate::extension::ExtensionType;
+use crate::external_client::{ExternalClient, ExternalClientConfig};
+use crate::group::mls_rules::{DefaultMlsRules, MlsRules};
+use crate::group::proposal::ProposalType;
+use crate::identity::CredentialType;
+use crate::protocol_version::ProtocolVersion;
+use crate::tree_kem::Capabilities;
+use crate::{CryptoProvider, Sealed};
+use std::collections::HashMap;
+use std::fmt::{self, Debug};
 
 /// Base client configuration type when instantiating `ExternalClientBuilder`
 pub type ExternalBaseConfig = Config<Missing, DefaultMlsRules, Missing>;
@@ -520,7 +514,8 @@ impl Default for Settings {
 /// Definitions meant to be private that are inaccessible outside this crate. They need to be marked
 /// `pub` because they appear in public definitions.
 mod private {
-    use mls_rs_core::{crypto::SignatureSecretKey, identity::SigningIdentity};
+    use mls_rs_core::crypto::SignatureSecretKey;
+    use mls_rs_core::identity::SigningIdentity;
 
     use super::{IntoConfigOutput, Settings};
 
@@ -555,18 +550,15 @@ mod private {
     }
 }
 
-use mls_rs_core::{
-    crypto::SignatureSecretKey,
-    identity::{IdentityProvider, SigningIdentity},
-};
+use mls_rs_core::crypto::SignatureSecretKey;
+use mls_rs_core::identity::{IdentityProvider, SigningIdentity};
 use private::{Config, ConfigInner, IntoConfig};
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use crate::{
-        cipher_suite::CipherSuite, crypto::test_utils::TestCryptoProvider,
-        identity::basic::BasicIdentityProvider,
-    };
+    use crate::cipher_suite::CipherSuite;
+    use crate::crypto::test_utils::TestCryptoProvider;
+    use crate::identity::basic::BasicIdentityProvider;
 
     use super::{
         ExternalBaseConfig, ExternalClientBuilder, WithCryptoProvider, WithIdentityProvider,

--- a/mls-rs/src/external_client/config.rs
+++ b/mls-rs/src/external_client/config.rs
@@ -4,15 +4,14 @@
 
 use mls_rs_core::identity::IdentityProvider;
 
-use crate::{
-    crypto::SignaturePublicKey,
-    extension::ExtensionType,
-    group::{mls_rules::MlsRules, proposal::ProposalType},
-    identity::CredentialType,
-    protocol_version::ProtocolVersion,
-    tree_kem::Capabilities,
-    CryptoProvider,
-};
+use crate::crypto::SignaturePublicKey;
+use crate::extension::ExtensionType;
+use crate::group::mls_rules::MlsRules;
+use crate::group::proposal::ProposalType;
+use crate::identity::CredentialType;
+use crate::protocol_version::ProtocolVersion;
+use crate::tree_kem::Capabilities;
+use crate::CryptoProvider;
 
 pub trait ExternalClientConfig: Send + Sync + Clone {
     type IdentityProvider: IdentityProvider + Clone;

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -3,38 +3,37 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
-use mls_rs_core::{
-    crypto::SignatureSecretKey, error::IntoAnyError, extension::ExtensionList, group::Member,
-    identity::IdentityProvider,
-};
+use mls_rs_core::crypto::SignatureSecretKey;
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::extension::ExtensionList;
+use mls_rs_core::group::Member;
+use mls_rs_core::identity::IdentityProvider;
 
-use crate::{
-    cipher_suite::CipherSuite,
-    client::MlsError,
-    external_client::ExternalClientConfig,
-    group::{
-        cipher_suite_provider,
-        confirmation_tag::ConfirmationTag,
-        framing::PublicMessage,
-        member_from_leaf_node,
-        message_processor::{
-            ApplicationMessageDescription, CommitMessageDescription, EventOrContent,
-            MessageProcessor, ProposalMessageDescription, ProvisionalState,
-        },
-        proposal::RemoveProposal,
-        proposal_filter::ProposalInfo,
-        snapshot::RawGroupState,
-        state::GroupState,
-        transcript_hash::InterimTranscriptHash,
-        validate_group_info_joiner, ContentType, ExportedTree, GroupContext, GroupInfo, Roster,
-        Welcome,
-    },
-    identity::SigningIdentity,
-    protocol_version::ProtocolVersion,
-    psk::AlwaysFoundPskStorage,
-    tree_kem::{node::LeafIndex, path_secret::PathSecret, TreeKemPrivate},
-    CryptoProvider, KeyPackage, MlsMessage,
+use crate::cipher_suite::CipherSuite;
+use crate::client::MlsError;
+use crate::external_client::ExternalClientConfig;
+use crate::group::confirmation_tag::ConfirmationTag;
+use crate::group::framing::PublicMessage;
+use crate::group::message_processor::{
+    ApplicationMessageDescription, CommitMessageDescription, EventOrContent, MessageProcessor,
+    ProposalMessageDescription, ProvisionalState,
 };
+use crate::group::proposal::RemoveProposal;
+use crate::group::proposal_filter::ProposalInfo;
+use crate::group::snapshot::RawGroupState;
+use crate::group::state::GroupState;
+use crate::group::transcript_hash::InterimTranscriptHash;
+use crate::group::{
+    cipher_suite_provider, member_from_leaf_node, validate_group_info_joiner, ContentType,
+    ExportedTree, GroupContext, GroupInfo, Roster, Welcome,
+};
+use crate::identity::SigningIdentity;
+use crate::protocol_version::ProtocolVersion;
+use crate::psk::AlwaysFoundPskStorage;
+use crate::tree_kem::node::LeafIndex;
+use crate::tree_kem::path_secret::PathSecret;
+use crate::tree_kem::TreeKemPrivate;
+use crate::{CryptoProvider, KeyPackage, MlsMessage};
 
 #[cfg(feature = "by_ref_proposal")]
 use crate::{
@@ -760,10 +759,10 @@ impl From<KeyPackage> for ExternalReceivedMessage {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use crate::{
-        external_client::tests_utils::{TestExternalClientBuilder, TestExternalClientConfig},
-        group::test_utils::TestGroup,
+    use crate::external_client::tests_utils::{
+        TestExternalClientBuilder, TestExternalClientConfig,
     };
+    use crate::group::test_utils::TestGroup;
 
     use super::ExternalGroup;
 
@@ -801,32 +800,28 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod tests {
     use super::test_utils::make_external_group;
-    use crate::{
-        cipher_suite::CipherSuite,
-        client::{
-            test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
-            MlsError,
-        },
-        crypto::{test_utils::TestCryptoProvider, SignatureSecretKey},
-        extension::ExternalSendersExt,
-        external_client::{
-            group::test_utils::make_external_group_with_config,
-            tests_utils::{TestExternalClientBuilder, TestExternalClientConfig},
-            ExternalGroup, ExternalReceivedMessage, ExternalSnapshot,
-        },
-        group::{
-            framing::{Content, MlsMessagePayload},
-            message_processor::CommitEffect,
-            proposal::{AddProposal, Proposal, ProposalOrRef},
-            proposal_ref::ProposalRef,
-            test_utils::{test_group, TestGroup},
-            CommitMessageDescription, ProposalMessageDescription,
-        },
-        identity::{test_utils::get_test_signing_identity, SigningIdentity},
-        key_package::test_utils::{test_key_package, test_key_package_message},
-        protocol_version::ProtocolVersion,
-        ExtensionList, MlsMessage,
+    use crate::cipher_suite::CipherSuite;
+    use crate::client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION};
+    use crate::client::MlsError;
+    use crate::crypto::test_utils::TestCryptoProvider;
+    use crate::crypto::SignatureSecretKey;
+    use crate::extension::ExternalSendersExt;
+    use crate::external_client::group::test_utils::make_external_group_with_config;
+    use crate::external_client::tests_utils::{
+        TestExternalClientBuilder, TestExternalClientConfig,
     };
+    use crate::external_client::{ExternalGroup, ExternalReceivedMessage, ExternalSnapshot};
+    use crate::group::framing::{Content, MlsMessagePayload};
+    use crate::group::message_processor::CommitEffect;
+    use crate::group::proposal::{AddProposal, Proposal, ProposalOrRef};
+    use crate::group::proposal_ref::ProposalRef;
+    use crate::group::test_utils::{test_group, TestGroup};
+    use crate::group::{CommitMessageDescription, ProposalMessageDescription};
+    use crate::identity::test_utils::get_test_signing_identity;
+    use crate::identity::SigningIdentity;
+    use crate::key_package::test_utils::{test_key_package, test_key_package_message};
+    use crate::protocol_version::ProtocolVersion;
+    use crate::{ExtensionList, MlsMessage};
     use assert_matches::assert_matches;
     use mls_rs_codec::{MlsDecode, MlsEncode};
 

--- a/mls-rs/src/grease.rs
+++ b/mls-rs/src/grease.rs
@@ -2,14 +2,14 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs_core::{crypto::CipherSuiteProvider, extension::ExtensionList, group::Capabilities};
+use mls_rs_core::crypto::CipherSuiteProvider;
+use mls_rs_core::extension::ExtensionList;
+use mls_rs_core::group::Capabilities;
 
-use crate::{
-    client::MlsError,
-    group::{GroupInfo, NewMemberInfo},
-    key_package::KeyPackage,
-    tree_kem::leaf_node::LeafNode,
-};
+use crate::client::MlsError;
+use crate::group::{GroupInfo, NewMemberInfo};
+use crate::key_package::KeyPackage;
+use crate::tree_kem::leaf_node::LeafNode;
 
 impl LeafNode {
     pub fn ungreased_capabilities(&self) -> Capabilities {
@@ -67,11 +67,9 @@ impl NewMemberInfo {
 mod grease_functions {
     use core::ops::Deref;
 
-    use mls_rs_core::{
-        crypto::CipherSuiteProvider,
-        error::IntoAnyError,
-        extension::{Extension, ExtensionList, ExtensionType},
-    };
+    use mls_rs_core::crypto::CipherSuiteProvider;
+    use mls_rs_core::error::IntoAnyError;
+    use mls_rs_core::extension::{Extension, ExtensionList, ExtensionType};
 
     use super::MlsError;
 
@@ -122,10 +120,8 @@ mod grease_functions {
 
     use alloc::vec::Vec;
 
-    use mls_rs_core::{
-        crypto::CipherSuiteProvider,
-        extension::{ExtensionList, ExtensionType},
-    };
+    use mls_rs_core::crypto::CipherSuiteProvider;
+    use mls_rs_core::extension::{ExtensionList, ExtensionType};
 
     use super::MlsError;
 
@@ -157,10 +153,10 @@ mod tests {
 
     use mls_rs_core::extension::ExtensionList;
 
-    use crate::{
-        client::test_utils::{test_client_with_key_pkg, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
-        group::test_utils::test_group,
+    use crate::client::test_utils::{
+        test_client_with_key_pkg, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION,
     };
+    use crate::group::test_utils::test_group;
 
     use super::grease_functions::GREASE_VALUES;
 

--- a/mls-rs/src/group/ciphertext_processor.rs
+++ b/mls-rs/src/group/ciphertext_processor.rs
@@ -2,26 +2,21 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use self::{
-    message_key::MessageKey,
-    reuse_guard::ReuseGuard,
-    sender_data_key::{SenderData, SenderDataAAD, SenderDataKey},
-};
+use self::message_key::MessageKey;
+use self::reuse_guard::ReuseGuard;
+use self::sender_data_key::{SenderData, SenderDataAAD, SenderDataKey};
 
-use super::{
-    epoch::EpochSecrets,
-    framing::{ContentType, FramedContent, Sender, WireFormat},
-    message_signature::AuthenticatedContent,
-    padding::PaddingMode,
-    secret_tree::{KeyType, MessageKeyData},
-    GroupContext,
-};
-use crate::{
-    client::MlsError,
-    tree_kem::node::{LeafIndex, NodeIndex},
-};
+use super::epoch::EpochSecrets;
+use super::framing::{ContentType, FramedContent, Sender, WireFormat};
+use super::message_signature::AuthenticatedContent;
+use super::padding::PaddingMode;
+use super::secret_tree::{KeyType, MessageKeyData};
+use super::GroupContext;
+use crate::client::MlsError;
+use crate::tree_kem::node::{LeafIndex, NodeIndex};
 use mls_rs_codec::MlsEncode;
-use mls_rs_core::{crypto::CipherSuiteProvider, error::IntoAnyError};
+use mls_rs_core::crypto::CipherSuiteProvider;
+use mls_rs_core::error::IntoAnyError;
 use zeroize::Zeroizing;
 
 mod message_key;
@@ -264,21 +259,15 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        cipher_suite::CipherSuite,
-        client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
-        crypto::{
-            test_utils::{test_cipher_suite_provider, TestCryptoProvider},
-            CipherSuiteProvider,
-        },
-        group::{
-            framing::{ApplicationData, Content, Sender, WireFormat},
-            message_signature::AuthenticatedContent,
-            padding::PaddingMode,
-            test_utils::{random_bytes, test_group, TestGroup},
-        },
-        tree_kem::node::LeafIndex,
-    };
+    use crate::cipher_suite::CipherSuite;
+    use crate::client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION};
+    use crate::crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider};
+    use crate::crypto::CipherSuiteProvider;
+    use crate::group::framing::{ApplicationData, Content, Sender, WireFormat};
+    use crate::group::message_signature::AuthenticatedContent;
+    use crate::group::padding::PaddingMode;
+    use crate::group::test_utils::{random_bytes, test_group, TestGroup};
+    use crate::tree_kem::node::LeafIndex;
 
     use super::{CiphertextProcessor, GroupStateProvider, MlsError};
 

--- a/mls-rs/src/group/ciphertext_processor/message_key.rs
+++ b/mls-rs/src/group/ciphertext_processor/message_key.rs
@@ -5,7 +5,8 @@
 use alloc::vec::Vec;
 use zeroize::Zeroizing;
 
-use crate::{crypto::CipherSuiteProvider, group::secret_tree::MessageKeyData};
+use crate::crypto::CipherSuiteProvider;
+use crate::group::secret_tree::MessageKeyData;
 
 use super::reuse_guard::ReuseGuard;
 

--- a/mls-rs/src/group/ciphertext_processor/reuse_guard.rs
+++ b/mls-rs/src/group/ciphertext_processor/reuse_guard.rs
@@ -68,9 +68,8 @@ mod tests {
     use alloc::vec::Vec;
     use mls_rs_core::crypto::CipherSuiteProvider;
 
-    use crate::{
-        client::test_utils::TEST_CIPHER_SUITE, crypto::test_utils::test_cipher_suite_provider,
-    };
+    use crate::client::test_utils::TEST_CIPHER_SUITE;
+    use crate::crypto::test_utils::test_cipher_suite_provider;
 
     use super::{ReuseGuard, REUSE_GUARD_SIZE};
 

--- a/mls-rs/src/group/ciphertext_processor/sender_data_key.rs
+++ b/mls-rs/src/group/ciphertext_processor/sender_data_key.rs
@@ -8,12 +8,12 @@ use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 use zeroize::Zeroizing;
 
-use crate::{
-    client::MlsError,
-    crypto::CipherSuiteProvider,
-    group::{epoch::SenderDataSecret, framing::ContentType, key_schedule::kdf_expand_with_label},
-    tree_kem::node::LeafIndex,
-};
+use crate::client::MlsError;
+use crate::crypto::CipherSuiteProvider;
+use crate::group::epoch::SenderDataSecret;
+use crate::group::framing::ContentType;
+use crate::group::key_schedule::kdf_expand_with_label;
+use crate::tree_kem::node::LeafIndex;
 
 use super::ReuseGuard;
 
@@ -193,11 +193,10 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
-    use crate::{
-        crypto::test_utils::try_test_cipher_suite_provider,
-        group::{ciphertext_processor::reuse_guard::ReuseGuard, framing::ContentType},
-        tree_kem::node::LeafIndex,
-    };
+    use crate::crypto::test_utils::try_test_cipher_suite_provider;
+    use crate::group::ciphertext_processor::reuse_guard::ReuseGuard;
+    use crate::group::framing::ContentType;
+    use crate::tree_kem::node::LeafIndex;
 
     use super::{SenderData, SenderDataAAD, SenderDataKey};
 

--- a/mls-rs/src/group/confirmation_tag.rs
+++ b/mls-rs/src/group/confirmation_tag.rs
@@ -2,13 +2,12 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+use crate::client::MlsError;
+use crate::group::transcript_hash::ConfirmedTranscriptHash;
 use crate::CipherSuiteProvider;
-use crate::{client::MlsError, group::transcript_hash::ConfirmedTranscriptHash};
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 

--- a/mls-rs/src/group/context.rs
+++ b/mls-rs/src/group/context.rs
@@ -7,7 +7,9 @@ use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
-use crate::{cipher_suite::CipherSuite, protocol_version::ProtocolVersion, ExtensionList};
+use crate::cipher_suite::CipherSuite;
+use crate::protocol_version::ProtocolVersion;
+use crate::ExtensionList;
 
 use super::ConfirmedTranscriptHash;
 

--- a/mls-rs/src/group/epoch.rs
+++ b/mls-rs/src/group/epoch.rs
@@ -9,10 +9,8 @@ use crate::tree_kem::node::NodeIndex;
 #[cfg(feature = "prior_epoch")]
 use crate::{crypto::SignaturePublicKey, group::GroupContext, tree_kem::node::LeafIndex};
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use zeroize::Zeroizing;
 

--- a/mls-rs/src/group/exported_tree.rs
+++ b/mls-rs/src/group/exported_tree.rs
@@ -2,10 +2,12 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use alloc::{borrow::Cow, vec::Vec};
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
-use crate::{client::MlsError, tree_kem::node::NodeVec};
+use crate::client::MlsError;
+use crate::tree_kem::node::NodeVec;
 
 #[cfg_attr(
     all(feature = "ffi", not(test)),

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -2,19 +2,18 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs_core::{crypto::SignatureSecretKey, identity::SigningIdentity};
+use mls_rs_core::crypto::SignatureSecretKey;
+use mls_rs_core::identity::SigningIdentity;
 
-use crate::{
-    client_config::ClientConfig,
-    group::{
-        cipher_suite_provider,
-        epoch::SenderDataSecret,
-        key_schedule::{InitSecret, KeySchedule},
-        proposal::{ExternalInit, Proposal, RemoveProposal},
-        EpochSecrets, ExternalPubExt, LeafIndex, LeafNode, MlsError, TreeKemPrivate,
-    },
-    Group, MlsMessage,
+use crate::client_config::ClientConfig;
+use crate::group::epoch::SenderDataSecret;
+use crate::group::key_schedule::{InitSecret, KeySchedule};
+use crate::group::proposal::{ExternalInit, Proposal, RemoveProposal};
+use crate::group::{
+    cipher_suite_provider, EpochSecrets, ExternalPubExt, LeafIndex, LeafNode, MlsError,
+    TreeKemPrivate,
 };
+use crate::{Group, MlsMessage};
 
 #[cfg(any(feature = "secret_tree_access", feature = "private_message"))]
 use crate::group::secret_tree::SecretTree;

--- a/mls-rs/src/group/framing.rs
+++ b/mls-rs/src/group/framing.rs
@@ -4,7 +4,9 @@
 
 use core::ops::Deref;
 
-use crate::{client::MlsError, tree_kem::node::LeafIndex, KeyPackage, KeyPackageRef};
+use crate::client::MlsError;
+use crate::tree_kem::node::LeafIndex;
+use crate::{KeyPackage, KeyPackageRef};
 
 use super::{Commit, FramedContentAuthData, GroupInfo, MembershipTag, Welcome};
 
@@ -14,10 +16,8 @@ use crate::{group::Proposal, mls_rules::ProposalRef};
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
-use mls_rs_core::{
-    crypto::{CipherSuite, CipherSuiteProvider},
-    protocol_version::ProtocolVersion,
-};
+use mls_rs_core::crypto::{CipherSuite, CipherSuiteProvider};
+use mls_rs_core::protocol_version::ProtocolVersion;
 use zeroize::ZeroizeOnDrop;
 
 #[cfg(feature = "private_message")]
@@ -670,14 +670,11 @@ pub(crate) mod test_utils {
 mod tests {
     use assert_matches::assert_matches;
 
-    use crate::{
-        client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
-        crypto::test_utils::test_cipher_suite_provider,
-        group::{
-            framing::test_utils::get_test_ciphertext_content,
-            proposal_ref::test_utils::auth_content_from_proposal, RemoveProposal,
-        },
-    };
+    use crate::client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION};
+    use crate::crypto::test_utils::test_cipher_suite_provider;
+    use crate::group::framing::test_utils::get_test_ciphertext_content;
+    use crate::group::proposal_ref::test_utils::auth_content_from_proposal;
+    use crate::group::RemoveProposal;
 
     use super::*;
 

--- a/mls-rs/src/group/group_info.rs
+++ b/mls-rs/src/group/group_info.rs
@@ -7,7 +7,8 @@ use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::extension::ExtensionList;
 
-use crate::{signer::Signable, tree_kem::node::LeafIndex};
+use crate::signer::Signable;
+use crate::tree_kem::node::LeafIndex;
 
 use super::{ConfirmationTag, GroupContext};
 

--- a/mls-rs/src/group/interop_test_vectors/framing.rs
+++ b/mls-rs/src/group/interop_test_vectors/framing.rs
@@ -7,25 +7,22 @@ use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode};
 use mls_rs_core::crypto::{CipherSuite, CipherSuiteProvider, SignaturePublicKey};
 
-use crate::{
-    client::test_utils::{TestClientConfig, TEST_PROTOCOL_VERSION},
-    crypto::test_utils::{test_cipher_suite_provider, try_test_cipher_suite_provider},
-    group::{
-        confirmation_tag::ConfirmationTag,
-        epoch::EpochSecrets,
-        framing::{Content, WireFormat},
-        message_processor::{EventOrContent, MessageProcessor},
-        mls_rules::EncryptionOptions,
-        padding::PaddingMode,
-        proposal::{Proposal, RemoveProposal},
-        secret_tree::test_utils::get_test_tree,
-        test_utils::{random_bytes, test_group_custom_config},
-        AuthenticatedContent, Commit, Group, GroupContext, MlsMessage, Sender,
-    },
-    mls_rules::DefaultMlsRules,
-    test_utils::is_edwards,
-    tree_kem::{leaf_node::test_utils::get_basic_test_node, node::LeafIndex},
-};
+use crate::client::test_utils::{TestClientConfig, TEST_PROTOCOL_VERSION};
+use crate::crypto::test_utils::{test_cipher_suite_provider, try_test_cipher_suite_provider};
+use crate::group::confirmation_tag::ConfirmationTag;
+use crate::group::epoch::EpochSecrets;
+use crate::group::framing::{Content, WireFormat};
+use crate::group::message_processor::{EventOrContent, MessageProcessor};
+use crate::group::mls_rules::EncryptionOptions;
+use crate::group::padding::PaddingMode;
+use crate::group::proposal::{Proposal, RemoveProposal};
+use crate::group::secret_tree::test_utils::get_test_tree;
+use crate::group::test_utils::{random_bytes, test_group_custom_config};
+use crate::group::{AuthenticatedContent, Commit, Group, GroupContext, MlsMessage, Sender};
+use crate::mls_rules::DefaultMlsRules;
+use crate::test_utils::is_edwards;
+use crate::tree_kem::leaf_node::test_utils::get_basic_test_node;
+use crate::tree_kem::node::LeafIndex;
 
 const FRAMING_N_LEAVES: u32 = 2;
 

--- a/mls-rs/src/group/interop_test_vectors/passive_client.rs
+++ b/mls-rs/src/group/interop_test_vectors/passive_client.rs
@@ -6,30 +6,27 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use itertools::Itertools;
-use mls_rs_core::{
-    crypto::{CipherSuite, CipherSuiteProvider, CryptoProvider},
-    identity::SigningIdentity,
-    protocol_version::ProtocolVersion,
-    psk::ExternalPskId,
-    time::MlsTime,
-};
-use rand::{seq::IteratorRandom, Rng, SeedableRng};
+use mls_rs_core::crypto::{CipherSuite, CipherSuiteProvider, CryptoProvider};
+use mls_rs_core::identity::SigningIdentity;
+use mls_rs_core::protocol_version::ProtocolVersion;
+use mls_rs_core::psk::ExternalPskId;
+use mls_rs_core::time::MlsTime;
+use rand::seq::IteratorRandom;
+use rand::{Rng, SeedableRng};
 
-use crate::{
-    client_builder::{ClientBuilder, MlsConfig},
-    crypto::test_utils::TestCryptoProvider,
-    group::{ClientConfig, CommitBuilder, ExportedTree},
-    identity::basic::BasicIdentityProvider,
-    key_package::KeyPackageGeneration,
-    mls_rules::CommitOptions,
-    storage_provider::in_memory::InMemoryKeyPackageStorage,
-    test_utils::{
-        all_process_message, generate_basic_client, get_test_basic_credential, get_test_groups,
-        make_test_ext_psk, TEST_EXT_PSK_ID,
-    },
-    tree_kem::Lifetime,
-    Client, Group, MlsMessage,
+use crate::client_builder::{ClientBuilder, MlsConfig};
+use crate::crypto::test_utils::TestCryptoProvider;
+use crate::group::{ClientConfig, CommitBuilder, ExportedTree};
+use crate::identity::basic::BasicIdentityProvider;
+use crate::key_package::KeyPackageGeneration;
+use crate::mls_rules::CommitOptions;
+use crate::storage_provider::in_memory::InMemoryKeyPackageStorage;
+use crate::test_utils::{
+    all_process_message, generate_basic_client, get_test_basic_credential, get_test_groups,
+    make_test_ext_psk, TEST_EXT_PSK_ID,
 };
+use crate::tree_kem::Lifetime;
+use crate::{Client, Group, MlsMessage};
 
 const VERSION: ProtocolVersion = ProtocolVersion::MLS_10;
 

--- a/mls-rs/src/group/interop_test_vectors/serialization.rs
+++ b/mls-rs/src/group/interop_test_vectors/serialization.rs
@@ -7,17 +7,12 @@ use mls_rs_codec::{MlsDecode, MlsEncode};
 
 use mls_rs_core::extension::ExtensionList;
 
-use crate::{
-    group::{
-        framing::ContentType,
-        proposal::{
-            AddProposal, ExternalInit, PreSharedKeyProposal, ReInitProposal, RemoveProposal,
-            UpdateProposal,
-        },
-        Commit, GroupSecrets, MlsMessage,
-    },
-    tree_kem::node::NodeVec,
+use crate::group::framing::ContentType;
+use crate::group::proposal::{
+    AddProposal, ExternalInit, PreSharedKeyProposal, ReInitProposal, RemoveProposal, UpdateProposal,
 };
+use crate::group::{Commit, GroupSecrets, MlsMessage};
+use crate::tree_kem::node::NodeVec;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
 struct TestCase {

--- a/mls-rs/src/group/interop_test_vectors/tree_kem.rs
+++ b/mls-rs/src/group/interop_test_vectors/tree_kem.rs
@@ -2,25 +2,23 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{
-    client::test_utils::TEST_PROTOCOL_VERSION,
-    crypto::test_utils::try_test_cipher_suite_provider,
-    group::{
-        confirmation_tag::ConfirmationTag, framing::Content, message_processor::MessageProcessor,
-        message_signature::AuthenticatedContent, test_utils::GroupWithoutKeySchedule, Commit,
-        GroupContext, PathSecret, Sender,
-    },
-    identity::basic::BasicIdentityProvider,
-    tree_kem::{
-        node::{LeafIndex, NodeVec},
-        TreeKemPrivate, TreeKemPublic, UpdatePath,
-    },
-    WireFormat,
-};
+use crate::client::test_utils::TEST_PROTOCOL_VERSION;
+use crate::crypto::test_utils::try_test_cipher_suite_provider;
+use crate::group::confirmation_tag::ConfirmationTag;
+use crate::group::framing::Content;
+use crate::group::message_processor::MessageProcessor;
+use crate::group::message_signature::AuthenticatedContent;
+use crate::group::test_utils::GroupWithoutKeySchedule;
+use crate::group::{Commit, GroupContext, PathSecret, Sender};
+use crate::identity::basic::BasicIdentityProvider;
+use crate::tree_kem::node::{LeafIndex, NodeVec};
+use crate::tree_kem::{TreeKemPrivate, TreeKemPublic, UpdatePath};
+use crate::WireFormat;
 use alloc::vec;
 use alloc::vec::Vec;
 use mls_rs_codec::MlsDecode;
-use mls_rs_core::{crypto::CipherSuiteProvider, extension::ExtensionList};
+use mls_rs_core::crypto::CipherSuiteProvider;
+use mls_rs_core::extension::ExtensionList;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
 struct TreeKemTestCase {

--- a/mls-rs/src/group/interop_test_vectors/tree_modifications.rs
+++ b/mls-rs/src/group/interop_test_vectors/tree_modifications.rs
@@ -8,22 +8,20 @@ use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode};
 use mls_rs_core::crypto::CipherSuite;
 
-use crate::{
-    client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
-    crypto::test_utils::{test_cipher_suite_provider, try_test_cipher_suite_provider},
-    group::{
-        proposal::{AddProposal, Proposal, ProposalOrRef, RemoveProposal, UpdateProposal},
-        proposal_cache::test_utils::CommitReceiver,
-        proposal_ref::ProposalRef,
-        test_utils::TEST_GROUP,
-        LeafIndex, Sender, TreeKemPublic,
-    },
-    identity::basic::BasicIdentityProvider,
-    key_package::test_utils::test_key_package,
-    tree_kem::{
-        leaf_node::test_utils::default_properties, node::NodeVec, test_utils::TreeWithSigners,
-    },
+use crate::client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION};
+use crate::crypto::test_utils::{test_cipher_suite_provider, try_test_cipher_suite_provider};
+use crate::group::proposal::{
+    AddProposal, Proposal, ProposalOrRef, RemoveProposal, UpdateProposal,
 };
+use crate::group::proposal_cache::test_utils::CommitReceiver;
+use crate::group::proposal_ref::ProposalRef;
+use crate::group::test_utils::TEST_GROUP;
+use crate::group::{LeafIndex, Sender, TreeKemPublic};
+use crate::identity::basic::BasicIdentityProvider;
+use crate::key_package::test_utils::test_key_package;
+use crate::tree_kem::leaf_node::test_utils::default_properties;
+use crate::tree_kem::node::NodeVec;
+use crate::tree_kem::test_utils::TreeWithSigners;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
 struct TreeModsTestCase {

--- a/mls-rs/src/group/key_schedule.rs
+++ b/mls-rs/src/group/key_schedule.rs
@@ -509,7 +509,8 @@ pub(crate) mod test_utils {
     use mls_rs_core::crypto::CipherSuiteProvider;
     use zeroize::Zeroizing;
 
-    use crate::{cipher_suite::CipherSuite, crypto::test_utils::test_cipher_suite_provider};
+    use crate::cipher_suite::CipherSuite;
+    use crate::crypto::test_utils::test_cipher_suite_provider;
 
     use super::{InitSecret, JoinerSecret, KeySchedule};
 

--- a/mls-rs/src/group/membership_tag.rs
+++ b/mls-rs/src/group/membership_tag.rs
@@ -7,10 +7,8 @@ use crate::crypto::CipherSuiteProvider;
 use crate::group::message_signature::{AuthenticatedContentTBS, FramedContentAuthData};
 use crate::group::GroupContext;
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 
@@ -92,9 +90,8 @@ impl MembershipTag {
 mod tests {
     use super::*;
     use crate::crypto::test_utils::{test_cipher_suite_provider, try_test_cipher_suite_provider};
-    use crate::group::{
-        framing::test_utils::get_test_auth_content, test_utils::get_test_group_context,
-    };
+    use crate::group::framing::test_utils::get_test_auth_content;
+    use crate::group::test_utils::get_test_group_context;
 
     #[cfg(not(mls_build_async))]
     use crate::crypto::test_utils::TestCryptoProvider;

--- a/mls-rs/src/group/message_hash.rs
+++ b/mls-rs/src/group/message_hash.rs
@@ -5,7 +5,9 @@ use core::fmt::Debug;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::crypto::CipherSuiteProvider;
 
-use crate::{client::MlsError, error::IntoAnyError, MlsMessage};
+use crate::client::MlsError;
+use crate::error::IntoAnyError;
+use crate::MlsMessage;
 
 #[derive(Clone, PartialEq, Eq, MlsEncode, MlsDecode, MlsSize, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/mls-rs/src/group/message_processor.rs
+++ b/mls-rs/src/group/message_processor.rs
@@ -2,41 +2,36 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+use super::confirmation_tag::ConfirmationTag;
+use super::framing::{
+    ApplicationData, Content, ContentType, MlsMessage, MlsMessagePayload, PublicMessage, Sender,
+};
+use super::message_signature::AuthenticatedContent;
+use super::mls_rules::{CommitDirection, MlsRules};
+use super::proposal_filter::ProposalBundle;
+use super::state::GroupState;
+use super::transcript_hash::InterimTranscriptHash;
 use super::{
-    commit_sender,
-    confirmation_tag::ConfirmationTag,
-    framing::{
-        ApplicationData, Content, ContentType, MlsMessage, MlsMessagePayload, PublicMessage, Sender,
-    },
-    message_signature::AuthenticatedContent,
-    mls_rules::{CommitDirection, MlsRules},
-    proposal_filter::ProposalBundle,
-    state::GroupState,
-    transcript_hash::InterimTranscriptHash,
-    transcript_hashes, validate_group_info_member, GroupContext, GroupInfo, ReInitProposal,
-    RemoveProposal, Welcome,
+    commit_sender, transcript_hashes, validate_group_info_member, GroupContext, GroupInfo,
+    ReInitProposal, RemoveProposal, Welcome,
 };
-use crate::{
-    client::MlsError,
-    key_package::validate_key_package_properties,
-    time::MlsTime,
-    tree_kem::{
-        leaf_node_validator::{LeafNodeValidator, ValidationContext},
-        node::LeafIndex,
-        path_secret::PathSecret,
-        validate_update_path, TreeKemPrivate, TreeKemPublic, ValidatedUpdatePath,
-    },
-    CipherSuiteProvider, KeyPackage,
-};
+use crate::client::MlsError;
+use crate::key_package::validate_key_package_properties;
+use crate::time::MlsTime;
+use crate::tree_kem::leaf_node_validator::{LeafNodeValidator, ValidationContext};
+use crate::tree_kem::node::LeafIndex;
+use crate::tree_kem::path_secret::PathSecret;
+use crate::tree_kem::{validate_update_path, TreeKemPrivate, TreeKemPublic, ValidatedUpdatePath};
+use crate::{CipherSuiteProvider, KeyPackage};
 use itertools::Itertools;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
-use mls_rs_core::{
-    identity::IdentityProvider, protocol_version::ProtocolVersion, psk::PreSharedKeyStorage,
-};
+use mls_rs_core::identity::IdentityProvider;
+use mls_rs_core::protocol_version::ProtocolVersion;
+use mls_rs_core::psk::PreSharedKeyStorage;
 
 #[cfg(feature = "by_ref_proposal")]
 use super::proposal_ref::ProposalRef;

--- a/mls-rs/src/group/message_signature.rs
+++ b/mls-rs/src/group/message_signature.rs
@@ -11,10 +11,8 @@ use crate::signer::Signable;
 use crate::CipherSuiteProvider;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::protocol_version::ProtocolVersion;
 

--- a/mls-rs/src/group/message_verifier.rs
+++ b/mls-rs/src/group/message_verifier.rs
@@ -5,23 +5,20 @@
 #[cfg(feature = "by_ref_proposal")]
 use alloc::{vec, vec::Vec};
 
-use crate::{
-    client::MlsError,
-    crypto::SignaturePublicKey,
-    group::{GroupContext, PublicMessage, Sender},
-    signer::Signable,
-    tree_kem::{node::LeafIndex, TreeKemPublic},
-    CipherSuiteProvider,
-};
+use crate::client::MlsError;
+use crate::crypto::SignaturePublicKey;
+use crate::group::{GroupContext, PublicMessage, Sender};
+use crate::signer::Signable;
+use crate::tree_kem::node::LeafIndex;
+use crate::tree_kem::TreeKemPublic;
+use crate::CipherSuiteProvider;
 
 #[cfg(feature = "by_ref_proposal")]
 use crate::{extension::ExternalSendersExt, identity::SigningIdentity};
 
-use super::{
-    key_schedule::KeySchedule,
-    message_signature::{AuthenticatedContent, MessageSigningContext},
-    state::GroupState,
-};
+use super::key_schedule::KeySchedule;
+use super::message_signature::{AuthenticatedContent, MessageSigningContext};
+use super::state::GroupState;
 
 #[cfg(feature = "by_ref_proposal")]
 use super::proposal::Proposal;
@@ -213,21 +210,17 @@ fn signing_identity_for_new_member_proposal(
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        client::{
-            test_utils::{test_client_with_key_pkg, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
-            MlsError,
-        },
-        client_builder::test_utils::TestClientConfig,
-        crypto::test_utils::test_cipher_suite_provider,
-        group::{
-            membership_tag::MembershipTag,
-            message_signature::{AuthenticatedContent, MessageSignature},
-            test_utils::{test_group_custom, TestGroup},
-            Group, PublicMessage,
-        },
-        tree_kem::node::LeafIndex,
+    use crate::client::test_utils::{
+        test_client_with_key_pkg, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION,
     };
+    use crate::client::MlsError;
+    use crate::client_builder::test_utils::TestClientConfig;
+    use crate::crypto::test_utils::test_cipher_suite_provider;
+    use crate::group::membership_tag::MembershipTag;
+    use crate::group::message_signature::{AuthenticatedContent, MessageSignature};
+    use crate::group::test_utils::{test_group_custom, TestGroup};
+    use crate::group::{Group, PublicMessage};
+    use crate::tree_kem::node::LeafIndex;
     use alloc::vec;
     use assert_matches::assert_matches;
 
@@ -250,10 +243,8 @@ mod tests {
     #[cfg(feature = "by_ref_proposal")]
     use alloc::boxed::Box;
 
-    use crate::group::{
-        test_utils::{test_group, test_member},
-        Sender,
-    };
+    use crate::group::test_utils::{test_group, test_member};
+    use crate::group::Sender;
 
     #[cfg(feature = "by_ref_proposal")]
     use crate::identity::test_utils::get_test_signing_identity;

--- a/mls-rs/src/group/mls_rules.rs
+++ b/mls-rs/src/group/mls_rules.rs
@@ -2,7 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::group::{proposal_filter::ProposalBundle, Roster};
+use crate::group::proposal_filter::ProposalBundle;
+use crate::group::Roster;
 
 #[cfg(feature = "private_message")]
 use crate::{
@@ -12,9 +13,10 @@ use crate::{
 
 use alloc::boxed::Box;
 use core::convert::Infallible;
-use mls_rs_core::{
-    error::IntoAnyError, extension::ExtensionList, group::Member, identity::SigningIdentity,
-};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::extension::ExtensionList;
+use mls_rs_core::group::Member;
+use mls_rs_core::identity::SigningIdentity;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CommitDirection {

--- a/mls-rs/src/group/proposal.rs
+++ b/mls-rs/src/group/proposal.rs
@@ -2,18 +2,19 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 #[cfg(feature = "by_ref_proposal")]
 use crate::tree_kem::leaf_node::LeafNode;
 
-use crate::{
-    client::MlsError, tree_kem::node::LeafIndex, CipherSuite, KeyPackage, MlsMessage,
-    ProtocolVersion,
-};
+use crate::client::MlsError;
+use crate::tree_kem::node::LeafIndex;
+use crate::{CipherSuite, KeyPackage, MlsMessage, ProtocolVersion};
 use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
-use mls_rs_core::{group::Capabilities, identity::SigningIdentity};
+use mls_rs_core::group::Capabilities;
+use mls_rs_core::identity::SigningIdentity;
 
 #[cfg(feature = "by_ref_proposal")]
 use crate::group::proposal_ref::ProposalRef;

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -8,13 +8,11 @@ use alloc::vec::Vec;
 #[cfg(feature = "custom_proposal")]
 use itertools::Itertools;
 
-use crate::{
-    group::{
-        AddProposal, BorrowedProposal, Proposal, ProposalOrRef, ProposalType, ReInitProposal,
-        RemoveProposal, Sender,
-    },
-    ExtensionList,
+use crate::group::{
+    AddProposal, BorrowedProposal, Proposal, ProposalOrRef, ProposalType, ReInitProposal,
+    RemoveProposal, Sender,
 };
+use crate::ExtensionList;
 
 #[cfg(feature = "by_ref_proposal")]
 use crate::group::{proposal_cache::CachedProposal, LeafIndex, ProposalRef, UpdateProposal};

--- a/mls-rs/src/group/proposal_filter/filtering.rs
+++ b/mls-rs/src/group/proposal_filter/filtering.rs
@@ -2,23 +2,17 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{
-    client::MlsError,
-    group::{
-        proposal::ReInitProposal,
-        proposal_filter::{ProposalBundle, ProposalInfo},
-        AddProposal, ProposalType, RemoveProposal, Sender, UpdateProposal,
-    },
-    iter::wrap_iter,
-    protocol_version::ProtocolVersion,
-    time::MlsTime,
-    tree_kem::{
-        leaf_node_validator::{LeafNodeValidator, ValidationContext},
-        node::LeafIndex,
-        TreeKemPublic,
-    },
-    CipherSuiteProvider, ExtensionList,
-};
+use crate::client::MlsError;
+use crate::group::proposal::ReInitProposal;
+use crate::group::proposal_filter::{ProposalBundle, ProposalInfo};
+use crate::group::{AddProposal, ProposalType, RemoveProposal, Sender, UpdateProposal};
+use crate::iter::wrap_iter;
+use crate::protocol_version::ProtocolVersion;
+use crate::time::MlsTime;
+use crate::tree_kem::leaf_node_validator::{LeafNodeValidator, ValidationContext};
+use crate::tree_kem::node::LeafIndex;
+use crate::tree_kem::TreeKemPublic;
+use crate::{CipherSuiteProvider, ExtensionList};
 
 use super::filtering_common::{filter_out_invalid_psks, ApplyProposalsOutput, ProposalApplier};
 
@@ -26,7 +20,9 @@ use super::filtering_common::{filter_out_invalid_psks, ApplyProposalsOutput, Pro
 use crate::extension::ExternalSendersExt;
 
 use alloc::vec::Vec;
-use mls_rs_core::{error::IntoAnyError, identity::IdentityProvider, psk::PreSharedKeyStorage};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::identity::IdentityProvider;
+use mls_rs_core::psk::PreSharedKeyStorage;
 
 #[cfg(any(
     feature = "custom_proposal",

--- a/mls-rs/src/group/proposal_filter/filtering_common.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_common.rs
@@ -2,19 +2,16 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{
-    client::MlsError,
-    group::{proposal_filter::ProposalBundle, Sender},
-    key_package::{validate_key_package_properties, KeyPackage},
-    protocol_version::ProtocolVersion,
-    time::MlsTime,
-    tree_kem::{
-        leaf_node_validator::{LeafNodeValidator, ValidationContext},
-        node::LeafIndex,
-        TreeKemPublic,
-    },
-    CipherSuiteProvider, ExtensionList,
-};
+use crate::client::MlsError;
+use crate::group::proposal_filter::ProposalBundle;
+use crate::group::Sender;
+use crate::key_package::{validate_key_package_properties, KeyPackage};
+use crate::protocol_version::ProtocolVersion;
+use crate::time::MlsTime;
+use crate::tree_kem::leaf_node_validator::{LeafNodeValidator, ValidationContext};
+use crate::tree_kem::node::LeafIndex;
+use crate::tree_kem::TreeKemPublic;
+use crate::{CipherSuiteProvider, ExtensionList};
 
 use crate::tree_kem::leaf_node::LeafNode;
 
@@ -28,7 +25,8 @@ use crate::extension::ExternalSendersExt;
 use mls_rs_core::error::IntoAnyError;
 
 use alloc::vec::Vec;
-use mls_rs_core::{identity::IdentityProvider, psk::PreSharedKeyStorage};
+use mls_rs_core::identity::IdentityProvider;
+use mls_rs_core::psk::PreSharedKeyStorage;
 
 use crate::group::{ExternalInit, ProposalType, RemoveProposal};
 

--- a/mls-rs/src/group/proposal_filter/filtering_lite.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_lite.rs
@@ -2,22 +2,22 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{
-    client::MlsError,
-    group::proposal_filter::ProposalBundle,
-    iter::wrap_iter,
-    protocol_version::ProtocolVersion,
-    time::MlsTime,
-    tree_kem::{leaf_node_validator::LeafNodeValidator, node::LeafIndex},
-    CipherSuiteProvider, ExtensionList,
-};
+use crate::client::MlsError;
+use crate::group::proposal_filter::ProposalBundle;
+use crate::iter::wrap_iter;
+use crate::protocol_version::ProtocolVersion;
+use crate::time::MlsTime;
+use crate::tree_kem::leaf_node_validator::LeafNodeValidator;
+use crate::tree_kem::node::LeafIndex;
+use crate::{CipherSuiteProvider, ExtensionList};
 
 use super::filtering_common::{filter_out_invalid_psks, ApplyProposalsOutput, ProposalApplier};
 
 #[cfg(feature = "by_ref_proposal")]
 use {crate::extension::ExternalSendersExt, mls_rs_core::error::IntoAnyError};
 
-use mls_rs_core::{identity::IdentityProvider, psk::PreSharedKeyStorage};
+use mls_rs_core::identity::IdentityProvider;
+use mls_rs_core::psk::PreSharedKeyStorage;
 
 #[cfg(feature = "custom_proposal")]
 use itertools::Itertools;

--- a/mls-rs/src/group/proposal_ref.rs
+++ b/mls-rs/src/group/proposal_ref.rs
@@ -82,11 +82,9 @@ pub(crate) mod test_utils {
 mod test {
     use super::test_utils::auth_content_from_proposal;
     use super::*;
-    use crate::{
-        crypto::test_utils::{test_cipher_suite_provider, try_test_cipher_suite_provider},
-        key_package::test_utils::test_key_package,
-        tree_kem::leaf_node::test_utils::get_basic_test_node,
-    };
+    use crate::crypto::test_utils::{test_cipher_suite_provider, try_test_cipher_suite_provider};
+    use crate::key_package::test_utils::test_key_package;
+    use crate::tree_kem::leaf_node::test_utils::get_basic_test_node;
     use alloc::boxed::Box;
 
     use crate::extension::RequiredCapabilitiesExt;

--- a/mls-rs/src/group/resumption.rs
+++ b/mls-rs/src/group/resumption.rs
@@ -4,18 +4,18 @@
 
 use alloc::vec::Vec;
 
-use mls_rs_core::{
-    crypto::{CipherSuite, SignatureSecretKey},
-    extension::ExtensionList,
-    identity::SigningIdentity,
-    protocol_version::ProtocolVersion,
-};
+use mls_rs_core::crypto::{CipherSuite, SignatureSecretKey};
+use mls_rs_core::extension::ExtensionList;
+use mls_rs_core::identity::SigningIdentity;
+use mls_rs_core::protocol_version::ProtocolVersion;
 
-use crate::{client::MlsError, Client, Group, MlsMessage};
+use crate::client::MlsError;
+use crate::{Client, Group, MlsMessage};
 
+use super::proposal::ReInitProposal;
 use super::{
-    proposal::ReInitProposal, ClientConfig, ExportedTree, JustPreSharedKeyID, MessageProcessor,
-    NewMemberInfo, PreSharedKeyID, PskGroupId, PskSecretInput, ResumptionPSKUsage, ResumptionPsk,
+    ClientConfig, ExportedTree, JustPreSharedKeyID, MessageProcessor, NewMemberInfo,
+    PreSharedKeyID, PskGroupId, PskSecretInput, ResumptionPSKUsage, ResumptionPsk,
 };
 
 struct ResumptionGroupParameters<'a> {

--- a/mls-rs/src/group/secret_tree.rs
+++ b/mls-rs/src/group/secret_tree.rs
@@ -3,14 +3,15 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::{Deref, DerefMut},
-};
+use core::fmt::{self, Debug};
+use core::ops::{Deref, DerefMut};
 
 use zeroize::Zeroizing;
 
-use crate::{client::MlsError, map::LargeMap, tree_kem::math::TreeIndex, CipherSuiteProvider};
+use crate::client::MlsError;
+use crate::map::LargeMap;
+use crate::tree_kem::math::TreeIndex;
+use crate::CipherSuiteProvider;
 
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
@@ -507,11 +508,13 @@ impl SecretKeyRatchet {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use alloc::{string::String, vec::Vec};
+    use alloc::string::String;
+    use alloc::vec::Vec;
     use mls_rs_core::crypto::CipherSuiteProvider;
     use zeroize::Zeroizing;
 
-    use crate::{crypto::test_utils::try_test_cipher_suite_provider, tree_kem::math::TreeIndex};
+    use crate::crypto::test_utils::try_test_cipher_suite_provider;
+    use crate::tree_kem::math::TreeIndex;
 
     use super::{KeyType, SecretKeyRatchet, SecretTree};
 
@@ -584,19 +587,18 @@ pub(crate) mod test_utils {
 mod tests {
     use alloc::vec;
 
-    use crate::{
-        cipher_suite::CipherSuite,
-        client::test_utils::TEST_CIPHER_SUITE,
-        crypto::test_utils::{
-            test_cipher_suite_provider, try_test_cipher_suite_provider, TestCryptoProvider,
-        },
-        tree_kem::node::NodeIndex,
+    use crate::cipher_suite::CipherSuite;
+    use crate::client::test_utils::TEST_CIPHER_SUITE;
+    use crate::crypto::test_utils::{
+        test_cipher_suite_provider, try_test_cipher_suite_provider, TestCryptoProvider,
     };
+    use crate::tree_kem::node::NodeIndex;
 
     #[cfg(not(mls_build_async))]
     use crate::group::test_utils::random_bytes;
 
-    use super::{test_utils::get_test_tree, *};
+    use super::test_utils::get_test_tree;
+    use super::*;
 
     use assert_matches::assert_matches;
 
@@ -921,10 +923,9 @@ mod interop_tests {
     use mls_rs_core::crypto::{CipherSuite, CipherSuiteProvider};
     use zeroize::Zeroizing;
 
-    use crate::{
-        crypto::test_utils::try_test_cipher_suite_provider,
-        group::{ciphertext_processor::InteropSenderData, secret_tree::KeyType},
-    };
+    use crate::crypto::test_utils::try_test_cipher_suite_provider;
+    use crate::group::ciphertext_processor::InteropSenderData;
+    use crate::group::secret_tree::KeyType;
 
     use super::SecretTree;
 

--- a/mls-rs/src/group/snapshot.rs
+++ b/mls-rs/src/group/snapshot.rs
@@ -2,16 +2,16 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{
-    client::MlsError,
-    client_config::ClientConfig,
-    group::{
-        cipher_suite_provider, epoch::EpochSecrets, key_schedule::KeySchedule,
-        state_repo::GroupStateRepository, CommitGeneration, ConfirmationTag, Group, GroupContext,
-        GroupState, InterimTranscriptHash, ReInitProposal, TreeKemPublic,
-    },
-    tree_kem::TreeKemPrivate,
+use crate::client::MlsError;
+use crate::client_config::ClientConfig;
+use crate::group::epoch::EpochSecrets;
+use crate::group::key_schedule::KeySchedule;
+use crate::group::state_repo::GroupStateRepository;
+use crate::group::{
+    cipher_suite_provider, CommitGeneration, ConfirmationTag, Group, GroupContext, GroupState,
+    InterimTranscriptHash, ReInitProposal, TreeKemPublic,
 };
+use crate::tree_kem::TreeKemPrivate;
 
 #[cfg(feature = "by_ref_proposal")]
 use crate::{
@@ -214,16 +214,15 @@ where
 pub(crate) mod test_utils {
     use alloc::vec;
 
-    use crate::{
-        cipher_suite::CipherSuite,
-        crypto::test_utils::test_cipher_suite_provider,
-        group::{
-            confirmation_tag::ConfirmationTag, epoch::test_utils::get_test_epoch_secrets,
-            key_schedule::test_utils::get_test_key_schedule, test_utils::get_test_group_context,
-            transcript_hash::InterimTranscriptHash,
-        },
-        tree_kem::{node::LeafIndex, TreeKemPrivate},
-    };
+    use crate::cipher_suite::CipherSuite;
+    use crate::crypto::test_utils::test_cipher_suite_provider;
+    use crate::group::confirmation_tag::ConfirmationTag;
+    use crate::group::epoch::test_utils::get_test_epoch_secrets;
+    use crate::group::key_schedule::test_utils::get_test_key_schedule;
+    use crate::group::test_utils::get_test_group_context;
+    use crate::group::transcript_hash::InterimTranscriptHash;
+    use crate::tree_kem::node::LeafIndex;
+    use crate::tree_kem::TreeKemPrivate;
 
     use super::{RawGroupState, Snapshot};
 
@@ -258,13 +257,9 @@ pub(crate) mod test_utils {
 mod tests {
     use alloc::vec;
 
-    use crate::{
-        client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
-        group::{
-            test_utils::{test_group, TestGroup},
-            Group,
-        },
-    };
+    use crate::client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION};
+    use crate::group::test_utils::{test_group, TestGroup};
+    use crate::group::Group;
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     async fn snapshot_restore(group: TestGroup) {

--- a/mls-rs/src/group/state.rs
+++ b/mls-rs/src/group/state.rs
@@ -4,14 +4,12 @@
 
 use mls_rs_core::group::Member;
 
-use super::{
-    confirmation_tag::ConfirmationTag, member_from_leaf_node, proposal::ReInitProposal,
-    transcript_hash::InterimTranscriptHash,
-};
-use crate::{
-    group::{GroupContext, TreeKemPublic},
-    tree_kem::node::LeafIndex,
-};
+use super::confirmation_tag::ConfirmationTag;
+use super::member_from_leaf_node;
+use super::proposal::ReInitProposal;
+use super::transcript_hash::InterimTranscriptHash;
+use crate::group::{GroupContext, TreeKemPublic};
+use crate::tree_kem::node::LeafIndex;
 
 #[cfg_attr(
     all(feature = "ffi", not(test)),

--- a/mls-rs/src/group/state_repo.rs
+++ b/mls-rs/src/group/state_repo.rs
@@ -3,14 +3,16 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use crate::client::MlsError;
-use crate::{group::PriorEpoch, key_package::KeyPackageRef};
+use crate::group::PriorEpoch;
+use crate::key_package::KeyPackageRef;
 
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode};
-use mls_rs_core::group::{EpochRecord, GroupState};
-use mls_rs_core::{error::IntoAnyError, group::GroupStateStorage, key_package::KeyPackageStorage};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::group::{EpochRecord, GroupState, GroupStateStorage};
+use mls_rs_core::key_package::KeyPackageStorage;
 
 use super::snapshot::Snapshot;
 
@@ -244,14 +246,13 @@ mod tests {
     use alloc::vec;
     use mls_rs_codec::MlsEncode;
 
-    use crate::{
-        client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
-        group::{
-            epoch::{test_utils::get_test_epoch_with_id, SenderDataSecret},
-            test_utils::{random_bytes, test_member, TEST_GROUP},
-            PskGroupId, ResumptionPSKUsage,
-        },
-        storage_provider::in_memory::{InMemoryGroupStateStorage, InMemoryKeyPackageStorage},
+    use crate::client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION};
+    use crate::group::epoch::test_utils::get_test_epoch_with_id;
+    use crate::group::epoch::SenderDataSecret;
+    use crate::group::test_utils::{random_bytes, test_member, TEST_GROUP};
+    use crate::group::{PskGroupId, ResumptionPSKUsage};
+    use crate::storage_provider::in_memory::{
+        InMemoryGroupStateStorage, InMemoryKeyPackageStorage,
     };
 
     use super::*;

--- a/mls-rs/src/group/state_repo_light.rs
+++ b/mls-rs/src/group/state_repo_light.rs
@@ -7,11 +7,9 @@ use crate::key_package::KeyPackageRef;
 
 use alloc::vec::Vec;
 use mls_rs_codec::MlsEncode;
-use mls_rs_core::{
-    error::IntoAnyError,
-    group::{GroupState, GroupStateStorage},
-    key_package::KeyPackageStorage,
-};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::group::{GroupState, GroupStateStorage};
+use mls_rs_core::key_package::KeyPackageStorage;
 
 use super::snapshot::Snapshot;
 
@@ -69,13 +67,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
-        group::{
-            snapshot::{test_utils::get_test_snapshot, Snapshot},
-            test_utils::{test_member, TEST_GROUP},
-        },
-        storage_provider::in_memory::{InMemoryGroupStateStorage, InMemoryKeyPackageStorage},
+    use crate::client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION};
+    use crate::group::snapshot::test_utils::get_test_snapshot;
+    use crate::group::snapshot::Snapshot;
+    use crate::group::test_utils::{test_member, TEST_GROUP};
+    use crate::storage_provider::in_memory::{
+        InMemoryGroupStateStorage, InMemoryKeyPackageStorage,
     };
 
     use alloc::vec;

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -8,22 +8,19 @@ use alloc::format;
 use rand::RngCore;
 
 use super::*;
-use crate::{
-    client::{
-        test_utils::{
-            test_client_with_key_pkg, test_client_with_key_pkg_custom, TEST_CIPHER_SUITE,
-            TEST_PROTOCOL_VERSION,
-        },
-        MlsError,
-    },
-    client_builder::test_utils::{TestClientBuilder, TestClientConfig},
-    crypto::test_utils::test_cipher_suite_provider,
-    extension::ExtensionType,
-    identity::test_utils::get_test_signing_identity,
-    key_package::{KeyPackageGeneration, KeyPackageGenerator},
-    mls_rules::{CommitOptions, DefaultMlsRules},
-    tree_kem::{leaf_node::test_utils::get_test_capabilities, Lifetime},
+use crate::client::test_utils::{
+    test_client_with_key_pkg, test_client_with_key_pkg_custom, TEST_CIPHER_SUITE,
+    TEST_PROTOCOL_VERSION,
 };
+use crate::client::MlsError;
+use crate::client_builder::test_utils::{TestClientBuilder, TestClientConfig};
+use crate::crypto::test_utils::test_cipher_suite_provider;
+use crate::extension::ExtensionType;
+use crate::identity::test_utils::get_test_signing_identity;
+use crate::key_package::{KeyPackageGeneration, KeyPackageGenerator};
+use crate::mls_rules::{CommitOptions, DefaultMlsRules};
+use crate::tree_kem::leaf_node::test_utils::get_test_capabilities;
+use crate::tree_kem::Lifetime;
 
 use crate::extension::RequiredCapabilitiesExt;
 

--- a/mls-rs/src/group/transcript_hash.rs
+++ b/mls-rs/src/group/transcript_hash.rs
@@ -3,19 +3,17 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
-use mls_rs_core::{crypto::CipherSuiteProvider, error::IntoAnyError};
+use mls_rs_core::crypto::CipherSuiteProvider;
+use mls_rs_core::error::IntoAnyError;
 
-use crate::{
-    client::MlsError,
-    group::{framing::FramedContent, MessageSignature},
-    WireFormat,
-};
+use crate::client::MlsError;
+use crate::group::framing::FramedContent;
+use crate::group::MessageSignature;
+use crate::WireFormat;
 
 use super::{AuthenticatedContent, ConfirmationTag};
 
@@ -144,10 +142,10 @@ mod tests {
 
     use mls_rs_codec::MlsDecode;
 
-    use crate::{
-        crypto::test_utils::try_test_cipher_suite_provider,
-        group::{framing::ContentType, message_signature::AuthenticatedContent, transcript_hashes},
-    };
+    use crate::crypto::test_utils::try_test_cipher_suite_provider;
+    use crate::group::framing::ContentType;
+    use crate::group::message_signature::AuthenticatedContent;
+    use crate::group::transcript_hashes;
 
     #[cfg(not(mls_build_async))]
     use alloc::{boxed::Box, vec};

--- a/mls-rs/src/group/util.rs
+++ b/mls-rs/src/group/util.rs
@@ -2,29 +2,28 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs_core::{
-    error::IntoAnyError, identity::IdentityProvider, key_package::KeyPackageStorage,
-};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::identity::IdentityProvider;
+use mls_rs_core::key_package::KeyPackageStorage;
 
-use crate::{
-    cipher_suite::CipherSuite,
-    client::MlsError,
-    extension::RatchetTreeExt,
-    key_package::KeyPackageGeneration,
-    protocol_version::ProtocolVersion,
-    signer::Signable,
-    tree_kem::{node::LeafIndex, tree_validator::TreeValidator, TreeKemPublic},
-    CipherSuiteProvider, CryptoProvider,
-};
+use crate::cipher_suite::CipherSuite;
+use crate::client::MlsError;
+use crate::extension::RatchetTreeExt;
+use crate::key_package::KeyPackageGeneration;
+use crate::protocol_version::ProtocolVersion;
+use crate::signer::Signable;
+use crate::tree_kem::node::LeafIndex;
+use crate::tree_kem::tree_validator::TreeValidator;
+use crate::tree_kem::TreeKemPublic;
+use crate::{CipherSuiteProvider, CryptoProvider};
 
 #[cfg(feature = "by_ref_proposal")]
 use crate::extension::ExternalSendersExt;
 
-use super::{
-    framing::Sender, message_signature::AuthenticatedContent,
-    transcript_hash::InterimTranscriptHash, ConfirmedTranscriptHash, EncryptedGroupSecrets,
-    ExportedTree, GroupInfo, GroupState,
-};
+use super::framing::Sender;
+use super::message_signature::AuthenticatedContent;
+use super::transcript_hash::InterimTranscriptHash;
+use super::{ConfirmedTranscriptHash, EncryptedGroupSecrets, ExportedTree, GroupInfo, GroupState};
 
 use super::message_processor::ProvisionalState;
 

--- a/mls-rs/src/hash_reference.rs
+++ b/mls-rs/src/hash_reference.rs
@@ -2,10 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 
 use crate::client::MlsError;
 use crate::CipherSuiteProvider;

--- a/mls-rs/src/identity.rs
+++ b/mls-rs/src/identity.rs
@@ -20,13 +20,11 @@ pub(crate) mod test_utils {
     use alloc::boxed::Box;
     use alloc::vec;
     use alloc::vec::Vec;
-    use mls_rs_core::{
-        crypto::{CipherSuite, CipherSuiteProvider, SignatureSecretKey},
-        error::IntoAnyError,
-        extension::ExtensionList,
-        identity::{Credential, CredentialType, IdentityProvider, SigningIdentity},
-        time::MlsTime,
-    };
+    use mls_rs_core::crypto::{CipherSuite, CipherSuiteProvider, SignatureSecretKey};
+    use mls_rs_core::error::IntoAnyError;
+    use mls_rs_core::extension::ExtensionList;
+    use mls_rs_core::identity::{Credential, CredentialType, IdentityProvider, SigningIdentity};
+    use mls_rs_core::time::MlsTime;
 
     use crate::crypto::test_utils::test_cipher_suite_provider;
 

--- a/mls-rs/src/identity/basic.rs
+++ b/mls-rs/src/identity/basic.rs
@@ -2,11 +2,14 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{identity::CredentialType, identity::SigningIdentity, time::MlsTime};
+use crate::identity::{CredentialType, SigningIdentity};
+use crate::time::MlsTime;
 use alloc::vec;
 use alloc::vec::Vec;
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::extension::ExtensionList;
 pub use mls_rs_core::identity::BasicCredential;
-use mls_rs_core::{error::IntoAnyError, extension::ExtensionList, identity::IdentityProvider};
+use mls_rs_core::identity::IdentityProvider;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]

--- a/mls-rs/src/iter.rs
+++ b/mls-rs/src/iter.rs
@@ -4,9 +4,9 @@
 
 #[cfg(all(not(mls_build_async), feature = "rayon"))]
 mod sync_rayon {
-    use rayon::{
-        iter::IterBridge,
-        prelude::{FromParallelIterator, IntoParallelIterator, ParallelBridge, ParallelIterator},
+    use rayon::iter::IterBridge;
+    use rayon::prelude::{
+        FromParallelIterator, IntoParallelIterator, ParallelBridge, ParallelIterator,
     };
 
     pub fn wrap_iter<I>(it: I) -> I::Iter

--- a/mls-rs/src/key_package/generator.rs
+++ b/mls-rs/src/key_package/generator.rs
@@ -5,21 +5,18 @@
 use alloc::vec;
 use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode};
-use mls_rs_core::{error::IntoAnyError, key_package::KeyPackageData};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::key_package::KeyPackageData;
 
 use crate::client::MlsError;
-use crate::{
-    crypto::{HpkeSecretKey, SignatureSecretKey},
-    group::framing::MlsMessagePayload,
-    identity::SigningIdentity,
-    protocol_version::ProtocolVersion,
-    signer::Signable,
-    tree_kem::{
-        leaf_node::{ConfigProperties, LeafNode},
-        Capabilities, Lifetime,
-    },
-    CipherSuiteProvider, ExtensionList, MlsMessage,
-};
+use crate::crypto::{HpkeSecretKey, SignatureSecretKey};
+use crate::group::framing::MlsMessagePayload;
+use crate::identity::SigningIdentity;
+use crate::protocol_version::ProtocolVersion;
+use crate::signer::Signable;
+use crate::tree_kem::leaf_node::{ConfigProperties, LeafNode};
+use crate::tree_kem::{Capabilities, Lifetime};
+use crate::{CipherSuiteProvider, ExtensionList, MlsMessage};
 
 use super::{KeyPackage, KeyPackageRef};
 
@@ -141,21 +138,18 @@ mod tests {
     use assert_matches::assert_matches;
     use mls_rs_core::crypto::CipherSuiteProvider;
 
-    use crate::{
-        crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider},
-        extension::test_utils::TestExtension,
-        group::test_utils::random_bytes,
-        identity::basic::BasicIdentityProvider,
-        identity::test_utils::get_test_signing_identity,
-        key_package::validate_key_package_properties,
-        protocol_version::ProtocolVersion,
-        tree_kem::{
-            leaf_node::{test_utils::get_test_capabilities, LeafNodeSource},
-            leaf_node_validator::{LeafNodeValidator, ValidationContext},
-            Lifetime,
-        },
-        ExtensionList,
-    };
+    use crate::crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider};
+    use crate::extension::test_utils::TestExtension;
+    use crate::group::test_utils::random_bytes;
+    use crate::identity::basic::BasicIdentityProvider;
+    use crate::identity::test_utils::get_test_signing_identity;
+    use crate::key_package::validate_key_package_properties;
+    use crate::protocol_version::ProtocolVersion;
+    use crate::tree_kem::leaf_node::test_utils::get_test_capabilities;
+    use crate::tree_kem::leaf_node::LeafNodeSource;
+    use crate::tree_kem::leaf_node_validator::{LeafNodeValidator, ValidationContext};
+    use crate::tree_kem::Lifetime;
+    use crate::ExtensionList;
 
     use super::KeyPackageGenerator;
 

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -12,13 +12,9 @@ use crate::signer::Signable;
 use crate::tree_kem::leaf_node::{LeafNode, LeafNodeSource};
 use crate::CipherSuiteProvider;
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
-use mls_rs_codec::MlsDecode;
-use mls_rs_codec::MlsEncode;
-use mls_rs_codec::MlsSize;
+use core::fmt::{self, Debug};
+use core::ops::Deref;
+use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::extension::ExtensionList;
 
 mod validator;
@@ -170,13 +166,12 @@ impl<'a> Signable<'a> for KeyPackage {
 #[cfg(test)]
 pub(crate) mod test_utils {
     use super::*;
-    use crate::{
-        crypto::test_utils::test_cipher_suite_provider,
-        group::framing::MlsMessagePayload,
-        identity::test_utils::get_test_signing_identity,
-        tree_kem::{leaf_node::test_utils::get_test_capabilities, Lifetime},
-        MlsMessage,
-    };
+    use crate::crypto::test_utils::test_cipher_suite_provider;
+    use crate::group::framing::MlsMessagePayload;
+    use crate::identity::test_utils::get_test_signing_identity;
+    use crate::tree_kem::leaf_node::test_utils::get_test_capabilities;
+    use crate::tree_kem::Lifetime;
+    use crate::MlsMessage;
 
     use mls_rs_core::crypto::SignatureSecretKey;
 
@@ -238,12 +233,11 @@ pub(crate) mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
-        crypto::test_utils::{test_cipher_suite_provider, try_test_cipher_suite_provider},
-    };
+    use crate::client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION};
+    use crate::crypto::test_utils::{test_cipher_suite_provider, try_test_cipher_suite_provider};
 
-    use super::{test_utils::test_key_package, *};
+    use super::test_utils::test_key_package;
+    use super::*;
     use alloc::format;
     use assert_matches::assert_matches;
 

--- a/mls-rs/src/key_package/validator.rs
+++ b/mls-rs/src/key_package/validator.rs
@@ -2,9 +2,12 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use mls_rs_core::{crypto::CipherSuiteProvider, protocol_version::ProtocolVersion};
+use mls_rs_core::crypto::CipherSuiteProvider;
+use mls_rs_core::protocol_version::ProtocolVersion;
 
-use crate::{client::MlsError, signer::Signable, KeyPackage};
+use crate::client::MlsError;
+use crate::signer::Signable;
+use crate::KeyPackage;
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
 pub(crate) async fn validate_key_package_properties<CSP: CipherSuiteProvider>(

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -156,22 +156,18 @@ mod signer;
 /// [`ClientBuilder`](client_builder::ClientBuilder).
 pub mod storage_provider;
 
-pub use mls_rs_core::{
-    crypto::{CipherSuiteProvider, CryptoProvider},
-    group::GroupStateStorage,
-    identity::IdentityProvider,
-    key_package::KeyPackageStorage,
-    psk::PreSharedKeyStorage,
-};
+pub use mls_rs_core::crypto::{CipherSuiteProvider, CryptoProvider};
+pub use mls_rs_core::group::GroupStateStorage;
+pub use mls_rs_core::identity::IdentityProvider;
+pub use mls_rs_core::key_package::KeyPackageStorage;
+pub use mls_rs_core::psk::PreSharedKeyStorage;
 
 /// Dependencies of [`MlsRules`].
 pub mod mls_rules {
-    pub use crate::group::{
-        mls_rules::{
-            CommitDirection, CommitOptions, CommitSource, DefaultMlsRules, EncryptionOptions,
-        },
-        proposal_filter::{ProposalBundle, ProposalInfo, ProposalSource},
+    pub use crate::group::mls_rules::{
+        CommitDirection, CommitOptions, CommitSource, DefaultMlsRules, EncryptionOptions,
     };
+    pub use crate::group::proposal_filter::{ProposalBundle, ProposalInfo, ProposalSource};
 
     #[cfg(feature = "by_ref_proposal")]
     pub use crate::group::proposal_ref::ProposalRef;
@@ -179,15 +175,11 @@ pub mod mls_rules {
 
 pub use mls_rs_core::extension::{Extension, ExtensionList};
 
-pub use crate::{
-    client::Client,
-    group::{
-        framing::{MlsMessage, WireFormat},
-        mls_rules::MlsRules,
-        Group,
-    },
-    key_package::{KeyPackage, KeyPackageRef},
-};
+pub use crate::client::Client;
+pub use crate::group::framing::{MlsMessage, WireFormat};
+pub use crate::group::mls_rules::MlsRules;
+pub use crate::group::Group;
+pub use crate::key_package::{KeyPackage, KeyPackageRef};
 
 /// Error types.
 pub mod error {

--- a/mls-rs/src/map.rs
+++ b/mls-rs/src/map.rs
@@ -3,10 +3,8 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
-use core::{
-    hash::Hash,
-    ops::{Deref, DerefMut},
-};
+use core::hash::Hash;
+use core::ops::{Deref, DerefMut};
 
 use map_impl::SmallMapInner;
 pub use map_impl::{LargeMap, LargeMapEntry, SmallMap};
@@ -15,7 +13,8 @@ use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 #[cfg(feature = "std")]
 mod map_impl {
     use core::hash::Hash;
-    use std::collections::{hash_map::Entry, HashMap};
+    use std::collections::hash_map::Entry;
+    use std::collections::HashMap;
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -30,10 +29,9 @@ mod map_impl {
 mod map_impl {
     use core::hash::Hash;
 
-    use alloc::{
-        collections::{btree_map::Entry, BTreeMap},
-        vec::Vec,
-    };
+    use alloc::collections::btree_map::Entry;
+    use alloc::collections::BTreeMap;
+    use alloc::vec::Vec;
     #[cfg(feature = "by_ref_proposal")]
     use itertools::Itertools;
 

--- a/mls-rs/src/psk/resolver.rs
+++ b/mls-rs/src/psk/resolver.rs
@@ -3,21 +3,20 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
-use mls_rs_core::{
-    crypto::CipherSuiteProvider,
-    error::IntoAnyError,
-    group::GroupStateStorage,
-    key_package::KeyPackageStorage,
-    psk::{ExternalPskId, PreSharedKey, PreSharedKeyStorage},
-};
+use mls_rs_core::crypto::CipherSuiteProvider;
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::group::GroupStateStorage;
+use mls_rs_core::key_package::KeyPackageStorage;
+use mls_rs_core::psk::{ExternalPskId, PreSharedKey, PreSharedKeyStorage};
 
-use crate::{
-    client::MlsError,
-    group::{epoch::EpochSecrets, state_repo::GroupStateRepository, GroupContext},
-    psk::secret::PskSecret,
-};
+use crate::client::MlsError;
+use crate::group::epoch::EpochSecrets;
+use crate::group::state_repo::GroupStateRepository;
+use crate::group::GroupContext;
+use crate::psk::secret::PskSecret;
 
-use super::{secret::PskSecretInput, JustPreSharedKeyID, PreSharedKeyID, ResumptionPsk};
+use super::secret::PskSecretInput;
+use super::{JustPreSharedKeyID, PreSharedKeyID, ResumptionPsk};
 
 pub(crate) struct PskResolver<'a, GS, K, PS>
 where

--- a/mls-rs/src/psk/secret.rs
+++ b/mls-rs/src/psk/secret.rs
@@ -4,10 +4,8 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 use mls_rs_core::crypto::CipherSuiteProvider;
 use zeroize::Zeroizing;
 
@@ -116,12 +114,9 @@ mod tests {
     use core::iter;
     use serde::{Deserialize, Serialize};
 
-    use crate::{
-        crypto::test_utils::try_test_cipher_suite_provider,
-        psk::ExternalPskId,
-        psk::{JustPreSharedKeyID, PreSharedKeyID, PskNonce},
-        CipherSuiteProvider,
-    };
+    use crate::crypto::test_utils::try_test_cipher_suite_provider;
+    use crate::psk::{ExternalPskId, JustPreSharedKeyID, PreSharedKeyID, PskNonce};
+    use crate::CipherSuiteProvider;
 
     #[cfg(not(mls_build_async))]
     use crate::{

--- a/mls-rs/src/signer.rs
+++ b/mls-rs/src/signer.rs
@@ -95,8 +95,9 @@ pub(crate) trait Signable<'a> {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
+    use alloc::string::String;
     use alloc::vec;
-    use alloc::{string::String, vec::Vec};
+    use alloc::vec::Vec;
     use mls_rs_core::crypto::CipherSuiteProvider;
 
     use crate::crypto::test_utils::try_test_cipher_suite_provider;
@@ -177,14 +178,13 @@ pub(crate) mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use super::{test_utils::TestSignable, *};
-    use crate::{
-        client::test_utils::TEST_CIPHER_SUITE,
-        crypto::test_utils::{
-            test_cipher_suite_provider, try_test_cipher_suite_provider, TestCryptoProvider,
-        },
-        group::test_utils::random_bytes,
+    use super::test_utils::TestSignable;
+    use super::*;
+    use crate::client::test_utils::TEST_CIPHER_SUITE;
+    use crate::crypto::test_utils::{
+        test_cipher_suite_provider, try_test_cipher_suite_provider, TestCryptoProvider,
     };
+    use crate::group::test_utils::random_bytes;
     use alloc::vec;
     use assert_matches::assert_matches;
 

--- a/mls-rs/src/storage_provider/in_memory/group_state_storage.rs
+++ b/mls-rs/src/storage_provider/in_memory/group_state_storage.rs
@@ -10,18 +10,14 @@ use alloc::sync::Arc;
 #[cfg(mls_build_async)]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::{
-    convert::Infallible,
-    fmt::{self, Debug},
-};
+use core::convert::Infallible;
+use core::fmt::{self, Debug};
 use mls_rs_core::group::{EpochRecord, GroupState, GroupStateStorage};
 #[cfg(not(target_has_atomic = "ptr"))]
 use portable_atomic_util::Arc;
 
-use crate::{
-    client::MlsError,
-    map::{LargeMap, LargeMapEntry},
-};
+use crate::client::MlsError;
+use crate::map::{LargeMap, LargeMapEntry};
 
 #[cfg(feature = "std")]
 use std::sync::{Mutex, MutexGuard};
@@ -226,11 +222,13 @@ impl GroupStateStorage for InMemoryGroupStateStorage {
 
 #[cfg(all(test, feature = "prior_epoch"))]
 mod tests {
-    use alloc::{format, vec, vec::Vec};
+    use alloc::vec::Vec;
+    use alloc::{format, vec};
     use assert_matches::assert_matches;
 
     use super::{InMemoryGroupData, InMemoryGroupStateStorage};
-    use crate::{client::MlsError, group::test_utils::TEST_GROUP};
+    use crate::client::MlsError;
+    use crate::group::test_utils::TEST_GROUP;
 
     use mls_rs_core::group::{EpochRecord, GroupState, GroupStateStorage};
 

--- a/mls-rs/src/storage_provider/in_memory/key_package_storage.rs
+++ b/mls-rs/src/storage_provider/in_memory/key_package_storage.rs
@@ -8,10 +8,8 @@ use alloc::sync::Arc;
 #[cfg(not(target_has_atomic = "ptr"))]
 use portable_atomic_util::Arc;
 
-use core::{
-    convert::Infallible,
-    fmt::{self, Debug},
-};
+use core::convert::Infallible;
+use core::fmt::{self, Debug};
 
 use alloc::vec::Vec;
 use mls_rs_core::key_package::{KeyPackageData, KeyPackageStorage};

--- a/mls-rs/src/test_utils/benchmarks.rs
+++ b/mls-rs/src/test_utils/benchmarks.rs
@@ -1,13 +1,12 @@
 use mls_rs_codec::MlsEncode;
 use mls_rs_core::protocol_version::ProtocolVersion;
 
-use crate::{
-    cipher_suite::CipherSuite,
-    client_builder::{BaseConfig, MlsConfig, WithCryptoProvider, WithIdentityProvider},
-    group::{framing::MlsMessage, Group},
-    identity::basic::BasicIdentityProvider,
-    test_utils::{generate_basic_client, get_test_groups},
-};
+use crate::cipher_suite::CipherSuite;
+use crate::client_builder::{BaseConfig, MlsConfig, WithCryptoProvider, WithIdentityProvider};
+use crate::group::framing::MlsMessage;
+use crate::group::Group;
+use crate::identity::basic::BasicIdentityProvider;
+use crate::test_utils::{generate_basic_client, get_test_groups};
 
 pub use mls_rs_crypto_openssl::OpensslCryptoProvider as MlsCryptoProvider;
 

--- a/mls-rs/src/test_utils/fuzz_tests.rs
+++ b/mls-rs/src/test_utils/fuzz_tests.rs
@@ -1,25 +1,20 @@
 use std::sync::Mutex;
 
-use mls_rs_core::{
-    crypto::{CipherSuiteProvider, CryptoProvider, SignatureSecretKey},
-    identity::BasicCredential,
-};
+use mls_rs_core::crypto::{CipherSuiteProvider, CryptoProvider, SignatureSecretKey};
+use mls_rs_core::identity::BasicCredential;
 
 use once_cell::sync::Lazy;
 
-use crate::{
-    cipher_suite::CipherSuite,
-    client::MlsError,
-    client_builder::{BaseConfig, WithCryptoProvider, WithIdentityProvider},
-    group::{
-        framing::{Content, MlsMessage, Sender, WireFormat},
-        message_processor::MessageProcessor,
-        message_signature::AuthenticatedContent,
-        Commit, Group,
-    },
-    identity::{basic::BasicIdentityProvider, SigningIdentity},
-    Client, ExtensionList,
-};
+use crate::cipher_suite::CipherSuite;
+use crate::client::MlsError;
+use crate::client_builder::{BaseConfig, WithCryptoProvider, WithIdentityProvider};
+use crate::group::framing::{Content, MlsMessage, Sender, WireFormat};
+use crate::group::message_processor::MessageProcessor;
+use crate::group::message_signature::AuthenticatedContent;
+use crate::group::{Commit, Group};
+use crate::identity::basic::BasicIdentityProvider;
+use crate::identity::SigningIdentity;
+use crate::{Client, ExtensionList};
 
 #[cfg(awslc)]
 pub use mls_rs_crypto_awslc::AwsLcCryptoProvider as MlsCryptoProvider;

--- a/mls-rs/src/test_utils/mod.rs
+++ b/mls-rs/src/test_utils/mod.rs
@@ -8,25 +8,22 @@ pub mod benchmarks;
 #[cfg(all(feature = "fuzz_util", not(mls_build_async)))]
 pub mod fuzz_tests;
 
-use mls_rs_core::{
-    crypto::{CipherSuite, CipherSuiteProvider, CryptoProvider},
-    identity::{BasicCredential, Credential, SigningIdentity},
-    protocol_version::ProtocolVersion,
-    psk::ExternalPskId,
-};
+use mls_rs_core::crypto::{CipherSuite, CipherSuiteProvider, CryptoProvider};
+use mls_rs_core::identity::{BasicCredential, Credential, SigningIdentity};
+use mls_rs_core::protocol_version::ProtocolVersion;
+use mls_rs_core::psk::ExternalPskId;
 
-use crate::{
-    client_builder::{ClientBuilder, MlsConfig},
-    identity::basic::BasicIdentityProvider,
-    mls_rules::{CommitOptions, DefaultMlsRules},
-    tree_kem::Lifetime,
-    Client, Group, MlsMessage,
-};
+use crate::client_builder::{ClientBuilder, MlsConfig};
+use crate::identity::basic::BasicIdentityProvider;
+use crate::mls_rules::{CommitOptions, DefaultMlsRules};
+use crate::tree_kem::Lifetime;
+use crate::{Client, Group, MlsMessage};
 
 #[cfg(feature = "private_message")]
 use crate::group::{mls_rules::EncryptionOptions, padding::PaddingMode};
 
-use alloc::{vec, vec::Vec};
+use alloc::vec;
+use alloc::vec::Vec;
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn get_test_basic_credential(identity: Vec<u8>) -> Credential {

--- a/mls-rs/src/tree_kem/hpke_encryption.rs
+++ b/mls-rs/src/tree_kem/hpke_encryption.rs
@@ -5,10 +5,8 @@
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsEncode, MlsSize};
-use mls_rs_core::{
-    crypto::{CipherSuiteProvider, HpkeCiphertext, HpkePublicKey, HpkeSecretKey},
-    error::IntoAnyError,
-};
+use mls_rs_core::crypto::{CipherSuiteProvider, HpkeCiphertext, HpkePublicKey, HpkeSecretKey};
+use mls_rs_core::error::IntoAnyError;
 use zeroize::Zeroizing;
 
 use crate::client::MlsError;
@@ -90,11 +88,13 @@ pub(crate) trait HpkeEncryptable: Sized {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use alloc::{string::String, vec::Vec};
+    use alloc::string::String;
+    use alloc::vec::Vec;
     use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
     use mls_rs_core::crypto::{CipherSuiteProvider, HpkeCiphertext};
 
-    use crate::{client::MlsError, crypto::test_utils::try_test_cipher_suite_provider};
+    use crate::client::MlsError;
+    use crate::crypto::test_utils::try_test_cipher_suite_provider;
 
     use super::HpkeEncryptable;
 

--- a/mls-rs/src/tree_kem/interop_test_vectors.rs
+++ b/mls-rs/src/tree_kem/interop_test_vectors.rs
@@ -9,13 +9,13 @@ use mls_rs_core::crypto::{CipherSuite, CipherSuiteProvider};
 
 use itertools::Itertools;
 
-use crate::{
-    crypto::test_utils::try_test_cipher_suite_provider, identity::basic::BasicIdentityProvider,
-};
+use crate::crypto::test_utils::try_test_cipher_suite_provider;
+use crate::identity::basic::BasicIdentityProvider;
 
-use super::{
-    node::NodeVec, test_utils::TreeWithSigners, tree_validator::TreeValidator, TreeKemPublic,
-};
+use super::node::NodeVec;
+use super::test_utils::TreeWithSigners;
+use super::tree_validator::TreeValidator;
+use super::TreeKemPublic;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
 struct ValidationTestCase {

--- a/mls-rs/src/tree_kem/kem.rs
+++ b/mls-rs/src/tree_kem/kem.rs
@@ -25,12 +25,9 @@ use std::collections::HashSet;
 
 use super::hpke_encryption::HpkeEncryptable;
 use super::leaf_node::ConfigProperties;
-use super::node::NodeTypeResolver;
-use super::{
-    node::{LeafIndex, NodeIndex},
-    path_secret::{PathSecret, PathSecretGenerator},
-    TreeKemPrivate, TreeKemPublic, UpdatePath, UpdatePathNode, ValidatedUpdatePath,
-};
+use super::node::{LeafIndex, NodeIndex, NodeTypeResolver};
+use super::path_secret::{PathSecret, PathSecretGenerator};
+use super::{TreeKemPrivate, TreeKemPublic, UpdatePath, UpdatePathNode, ValidatedUpdatePath};
 
 #[cfg(test)]
 use crate::{group::CommitModifiers, signer::Signable};
@@ -412,24 +409,23 @@ impl<'a> TreeKem<'a> {
 #[cfg(test)]
 mod tests {
     use super::{tree_math, TreeKem};
-    use crate::{
-        cipher_suite::CipherSuite,
-        client::test_utils::TEST_CIPHER_SUITE,
-        crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider},
-        extension::test_utils::TestExtension,
-        group::test_utils::{get_test_group_context, random_bytes},
-        identity::basic::BasicIdentityProvider,
-        tree_kem::{
-            leaf_node::{
-                test_utils::{get_basic_test_node_sig_key, get_test_capabilities},
-                ConfigProperties,
-            },
-            node::LeafIndex,
-            Capabilities, TreeKemPrivate, TreeKemPublic, UpdatePath, ValidatedUpdatePath,
-        },
-        ExtensionList,
+    use crate::cipher_suite::CipherSuite;
+    use crate::client::test_utils::TEST_CIPHER_SUITE;
+    use crate::crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider};
+    use crate::extension::test_utils::TestExtension;
+    use crate::group::test_utils::{get_test_group_context, random_bytes};
+    use crate::identity::basic::BasicIdentityProvider;
+    use crate::tree_kem::leaf_node::test_utils::{
+        get_basic_test_node_sig_key, get_test_capabilities,
     };
-    use alloc::{format, vec, vec::Vec};
+    use crate::tree_kem::leaf_node::ConfigProperties;
+    use crate::tree_kem::node::LeafIndex;
+    use crate::tree_kem::{
+        Capabilities, TreeKemPrivate, TreeKemPublic, UpdatePath, ValidatedUpdatePath,
+    };
+    use crate::ExtensionList;
+    use alloc::vec::Vec;
+    use alloc::{format, vec};
     use mls_rs_codec::MlsEncode;
     use mls_rs_core::crypto::CipherSuiteProvider;
     use tree_math::TreeIndex;

--- a/mls-rs/src/tree_kem/leaf_node.rs
+++ b/mls-rs/src/tree_kem/leaf_node.rs
@@ -2,10 +2,13 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use super::{parent_hash::ParentHash, Capabilities, Lifetime};
+use super::parent_hash::ParentHash;
+use super::{Capabilities, Lifetime};
 use crate::client::MlsError;
 use crate::crypto::{CipherSuiteProvider, HpkePublicKey, HpkeSecretKey, SignatureSecretKey};
-use crate::{identity::SigningIdentity, signer::Signable, ExtensionList};
+use crate::identity::SigningIdentity;
+use crate::signer::Signable;
+use crate::ExtensionList;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
@@ -264,11 +267,9 @@ pub(crate) mod test_utils {
     use alloc::vec;
     use mls_rs_core::identity::{BasicCredential, CredentialType};
 
-    use crate::{
-        cipher_suite::CipherSuite,
-        crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider},
-        identity::test_utils::{get_test_signing_identity, BasicWithCustomProvider},
-    };
+    use crate::cipher_suite::CipherSuite;
+    use crate::crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider};
+    use crate::identity::test_utils::{get_test_signing_identity, BasicWithCustomProvider};
 
     use crate::extension::ApplicationIdExt;
 
@@ -404,8 +405,7 @@ mod tests {
     use super::*;
 
     use crate::client::test_utils::TEST_CIPHER_SUITE;
-    use crate::crypto::test_utils::test_cipher_suite_provider;
-    use crate::crypto::test_utils::TestCryptoProvider;
+    use crate::crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider};
     use crate::group::test_utils::random_bytes;
     use crate::identity::test_utils::get_test_signing_identity;
     use assert_matches::assert_matches;

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -4,9 +4,12 @@
 
 use super::leaf_node::{LeafNode, LeafNodeSigningContext, LeafNodeSource};
 use crate::client::MlsError;
+use crate::signer::Signable;
+use crate::time::MlsTime;
 use crate::CipherSuiteProvider;
-use crate::{signer::Signable, time::MlsTime};
-use mls_rs_core::{error::IntoAnyError, extension::ExtensionList, identity::IdentityProvider};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::extension::ExtensionList;
+use mls_rs_core::identity::IdentityProvider;
 
 use crate::extension::RequiredCapabilitiesExt;
 
@@ -242,13 +245,11 @@ mod tests {
     use super::*;
 
     use crate::client::test_utils::TEST_CIPHER_SUITE;
-    use crate::crypto::test_utils::test_cipher_suite_provider;
-    use crate::crypto::test_utils::TestCryptoProvider;
+    use crate::crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider};
     use crate::crypto::SignatureSecretKey;
     use crate::extension::test_utils::TestExtension;
     use crate::group::test_utils::random_bytes;
-    use crate::identity::basic::BasicCredential;
-    use crate::identity::basic::BasicIdentityProvider;
+    use crate::identity::basic::{BasicCredential, BasicIdentityProvider};
     use crate::identity::test_utils::get_test_signing_identity;
     use crate::tree_kem::leaf_node::test_utils::*;
     use crate::tree_kem::leaf_node_validator::test_utils::FailureIdentityProvider;
@@ -625,16 +626,16 @@ mod tests {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
+    use alloc::boxed::Box;
     use alloc::vec;
-    use alloc::{boxed::Box, vec::Vec};
+    use alloc::vec::Vec;
     use mls_rs_codec::MlsEncode;
-    use mls_rs_core::{
-        error::IntoAnyError,
-        extension::ExtensionList,
-        identity::{BasicCredential, IdentityProvider},
-    };
+    use mls_rs_core::error::IntoAnyError;
+    use mls_rs_core::extension::ExtensionList;
+    use mls_rs_core::identity::{BasicCredential, IdentityProvider};
 
-    use crate::{identity::SigningIdentity, time::MlsTime};
+    use crate::identity::SigningIdentity;
+    use crate::time::MlsTime;
 
     #[derive(Clone, Debug, Default)]
     pub struct FailureIdentityProvider;

--- a/mls-rs/src/tree_kem/lifetime.rs
+++ b/mls-rs/src/tree_kem/lifetime.rs
@@ -2,7 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{client::MlsError, time::MlsTime};
+use crate::client::MlsError;
+use crate::time::MlsTime;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
 #[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode, Default)]

--- a/mls-rs/src/tree_kem/math.rs
+++ b/mls-rs/src/tree_kem/math.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use alloc::vec::Vec;
-use core::{fmt::Debug, hash::Hash};
+use core::fmt::Debug;
+use core::hash::Hash;
 use mls_rs_codec::{MlsDecode, MlsEncode};
 
 use super::node::LeafIndex;

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -10,7 +10,8 @@ use itertools::Itertools;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::extension::ExtensionList;
 
-use mls_rs_core::{error::IntoAnyError, identity::IdentityProvider};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::identity::IdentityProvider;
 
 #[cfg(feature = "tree_index")]
 use mls_rs_core::identity::SigningIdentity;
@@ -723,21 +724,16 @@ pub(crate) mod test_utils {
     use mls_rs_core::group::Capabilities;
     use mls_rs_core::identity::BasicCredential;
 
+    use crate::cipher_suite::CipherSuite;
+    use crate::crypto::{HpkeSecretKey, SignatureSecretKey};
+    use crate::identity::basic::BasicIdentityProvider;
     use crate::identity::test_utils::get_test_signing_identity;
-    use crate::{
-        cipher_suite::CipherSuite,
-        crypto::{HpkeSecretKey, SignatureSecretKey},
-        identity::basic::BasicIdentityProvider,
-        tree_kem::leaf_node::test_utils::get_basic_test_node_sig_key,
-    };
+    use crate::tree_kem::leaf_node::test_utils::get_basic_test_node_sig_key;
 
-    use super::leaf_node::{ConfigProperties, LeafNodeSigningContext};
+    use super::leaf_node::test_utils::get_basic_test_node;
+    use super::leaf_node::{ConfigProperties, LeafNode, LeafNodeSigningContext};
     use super::node::LeafIndex;
-    use super::Lifetime;
-    use super::{
-        leaf_node::{test_utils::get_basic_test_node, LeafNode},
-        TreeKemPrivate, TreeKemPublic,
-    };
+    use super::{Lifetime, TreeKemPrivate, TreeKemPublic};
 
     #[derive(Debug)]
     pub(crate) struct TestTree {

--- a/mls-rs/src/tree_kem/node.rs
+++ b/mls-rs/src/tree_kem/node.rs
@@ -414,9 +414,8 @@ impl NodeVec {
 #[cfg(test)]
 pub(crate) mod test_utils {
     use super::*;
-    use crate::{
-        client::test_utils::TEST_CIPHER_SUITE, tree_kem::leaf_node::test_utils::get_basic_test_node,
-    };
+    use crate::client::test_utils::TEST_CIPHER_SUITE;
+    use crate::tree_kem::leaf_node::test_utils::get_basic_test_node;
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub(crate) async fn get_test_node_vec() -> NodeVec {
@@ -441,12 +440,9 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        client::test_utils::TEST_CIPHER_SUITE,
-        tree_kem::{
-            leaf_node::test_utils::get_basic_test_node, node::test_utils::get_test_node_vec,
-        },
-    };
+    use crate::client::test_utils::TEST_CIPHER_SUITE;
+    use crate::tree_kem::leaf_node::test_utils::get_basic_test_node;
+    use crate::tree_kem::node::test_utils::get_test_node_vec;
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn node_key_getters() {

--- a/mls-rs/src/tree_kem/parent_hash.rs
+++ b/mls-rs/src/tree_kem/parent_hash.rs
@@ -4,14 +4,11 @@
 
 use crate::client::MlsError;
 use crate::crypto::{CipherSuiteProvider, HpkePublicKey};
-use crate::tree_kem::math as tree_math;
 use crate::tree_kem::node::{LeafIndex, Node, NodeIndex};
-use crate::tree_kem::TreeKemPublic;
+use crate::tree_kem::{math as tree_math, TreeKemPublic};
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 use tree_math::TreeIndex;
@@ -284,12 +281,11 @@ impl TreeKemPublic {
 pub(crate) mod test_utils {
 
     use super::*;
-    use crate::{
-        cipher_suite::CipherSuite,
-        crypto::test_utils::test_cipher_suite_provider,
-        identity::basic::BasicIdentityProvider,
-        tree_kem::{leaf_node::test_utils::get_basic_test_node, node::Parent},
-    };
+    use crate::cipher_suite::CipherSuite;
+    use crate::crypto::test_utils::test_cipher_suite_provider;
+    use crate::identity::basic::BasicIdentityProvider;
+    use crate::tree_kem::leaf_node::test_utils::get_basic_test_node;
+    use crate::tree_kem::node::Parent;
 
     use alloc::vec;
 

--- a/mls-rs/src/tree_kem/path_secret.rs
+++ b/mls-rs/src/tree_kem/path_secret.rs
@@ -7,10 +7,8 @@ use crate::crypto::{CipherSuiteProvider, HpkePublicKey, HpkeSecretKey};
 use crate::group::key_schedule::kdf_derive_secret;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::{
-    fmt::{self, Debug},
-    ops::Deref,
-};
+use core::fmt::{self, Debug};
+use core::ops::Deref;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 use zeroize::Zeroizing;
@@ -138,12 +136,10 @@ impl<'a, P: CipherSuiteProvider> PathSecretGenerator<'a, P> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        cipher_suite::CipherSuite,
-        client::test_utils::TEST_CIPHER_SUITE,
-        crypto::test_utils::{
-            test_cipher_suite_provider, try_test_cipher_suite_provider, TestCryptoProvider,
-        },
+    use crate::cipher_suite::CipherSuite;
+    use crate::client::test_utils::TEST_CIPHER_SUITE;
+    use crate::crypto::test_utils::{
+        test_cipher_suite_provider, try_test_cipher_suite_provider, TestCryptoProvider,
     };
 
     use super::*;

--- a/mls-rs/src/tree_kem/private.rs
+++ b/mls-rs/src/tree_kem/private.rs
@@ -1,19 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
-use alloc::{vec, vec::Vec};
+use alloc::vec;
+use alloc::vec::Vec;
 
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::crypto::HpkeSecretKey;
 
-use crate::{client::MlsError, crypto::CipherSuiteProvider};
+use crate::client::MlsError;
+use crate::crypto::CipherSuiteProvider;
 
-use super::{
-    math::leaf_lca_level,
-    node::LeafIndex,
-    path_secret::{PathSecret, PathSecretGenerator},
-    TreeKemPublic,
-};
+use super::math::leaf_lca_level;
+use super::node::LeafIndex;
+use super::path_secret::{PathSecret, PathSecretGenerator};
+use super::TreeKemPublic;
 
 #[derive(Clone, Debug, MlsEncode, MlsDecode, MlsSize, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -111,21 +111,17 @@ impl TreeKemPrivate {
 mod tests {
     use assert_matches::assert_matches;
 
-    use crate::{
-        cipher_suite::CipherSuite,
-        client::test_utils::TEST_CIPHER_SUITE,
-        crypto::test_utils::test_cipher_suite_provider,
-        group::test_utils::{get_test_group_context, random_bytes},
-        identity::basic::BasicIdentityProvider,
-        tree_kem::{
-            kem::TreeKem,
-            leaf_node::test_utils::{
-                default_properties, get_basic_test_node, get_basic_test_node_sig_key,
-            },
-            math::TreeIndex,
-            node::LeafIndex,
-        },
+    use crate::cipher_suite::CipherSuite;
+    use crate::client::test_utils::TEST_CIPHER_SUITE;
+    use crate::crypto::test_utils::test_cipher_suite_provider;
+    use crate::group::test_utils::{get_test_group_context, random_bytes};
+    use crate::identity::basic::BasicIdentityProvider;
+    use crate::tree_kem::kem::TreeKem;
+    use crate::tree_kem::leaf_node::test_utils::{
+        default_properties, get_basic_test_node, get_basic_test_node_sig_key,
     };
+    use crate::tree_kem::math::TreeIndex;
+    use crate::tree_kem::node::LeafIndex;
 
     use super::*;
 

--- a/mls-rs/src/tree_kem/tree_hash.rs
+++ b/mls-rs/src/tree_kem/tree_hash.rs
@@ -7,9 +7,8 @@ use super::node::{LeafIndex, NodeVec};
 use super::tree_math::BfsIterTopDown;
 use crate::client::MlsError;
 use crate::crypto::CipherSuiteProvider;
-use crate::tree_kem::math as tree_math;
 use crate::tree_kem::node::Parent;
-use crate::tree_kem::TreeKemPublic;
+use crate::tree_kem::{math as tree_math, TreeKemPublic};
 use alloc::collections::VecDeque;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -361,12 +360,11 @@ async fn hash_for_parent<P: CipherSuiteProvider>(
 mod tests {
     use mls_rs_codec::MlsDecode;
 
-    use crate::{
-        cipher_suite::CipherSuite,
-        crypto::test_utils::{test_cipher_suite_provider, try_test_cipher_suite_provider},
-        identity::basic::BasicIdentityProvider,
-        tree_kem::{node::NodeVec, parent_hash::test_utils::get_test_tree_fig_12},
-    };
+    use crate::cipher_suite::CipherSuite;
+    use crate::crypto::test_utils::{test_cipher_suite_provider, try_test_cipher_suite_provider};
+    use crate::identity::basic::BasicIdentityProvider;
+    use crate::tree_kem::node::NodeVec;
+    use crate::tree_kem::parent_hash::test_utils::get_test_tree_fig_12;
 
     use super::*;
 

--- a/mls-rs/src/tree_kem/tree_index.rs
+++ b/mls-rs/src/tree_kem/tree_index.rs
@@ -303,10 +303,8 @@ struct TypeCounter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        client::test_utils::TEST_CIPHER_SUITE,
-        tree_kem::leaf_node::test_utils::{get_basic_test_node, get_test_client_identity},
-    };
+    use crate::client::test_utils::TEST_CIPHER_SUITE;
+    use crate::tree_kem::leaf_node::test_utils::{get_basic_test_node, get_test_client_identity};
     use alloc::format;
     use assert_matches::assert_matches;
 

--- a/mls-rs/src/tree_kem/tree_utils.rs
+++ b/mls-rs/src/tree_kem/tree_utils.rs
@@ -9,7 +9,8 @@ use core::borrow::BorrowMut;
 use debug_tree::TreeBuilder;
 
 use super::node::{NodeIndex, NodeVec};
-use crate::{client::MlsError, tree_kem::math::TreeIndex};
+use crate::client::MlsError;
+use crate::tree_kem::math::TreeIndex;
 
 pub(crate) fn build_tree(
     tree: &mut TreeBuilder,
@@ -73,16 +74,12 @@ pub(crate) fn build_ascii_tree(nodes: &NodeVec) -> String {
 mod tests {
     use alloc::vec;
 
-    use crate::{
-        client::test_utils::TEST_CIPHER_SUITE,
-        crypto::test_utils::test_cipher_suite_provider,
-        identity::basic::BasicIdentityProvider,
-        tree_kem::{
-            node::Parent,
-            parent_hash::ParentHash,
-            test_utils::{get_test_leaf_nodes, get_test_tree},
-        },
-    };
+    use crate::client::test_utils::TEST_CIPHER_SUITE;
+    use crate::crypto::test_utils::test_cipher_suite_provider;
+    use crate::identity::basic::BasicIdentityProvider;
+    use crate::tree_kem::node::Parent;
+    use crate::tree_kem::parent_hash::ParentHash;
+    use crate::tree_kem::test_utils::{get_test_leaf_nodes, get_test_tree};
 
     use super::build_ascii_tree;
 

--- a/mls-rs/src/tree_kem/tree_validator.rs
+++ b/mls-rs/src/tree_kem/tree_validator.rs
@@ -14,8 +14,8 @@ use crate::client::MlsError;
 use crate::crypto::CipherSuiteProvider;
 use crate::group::GroupContext;
 use crate::iter::wrap_impl_iter;
-use crate::tree_kem::math as tree_math;
-use crate::tree_kem::{leaf_node_validator::LeafNodeValidator, TreeKemPublic};
+use crate::tree_kem::leaf_node_validator::LeafNodeValidator;
+use crate::tree_kem::{math as tree_math, TreeKemPublic};
 use mls_rs_core::identity::IdentityProvider;
 
 #[cfg(all(not(mls_build_async), feature = "rayon"))]
@@ -161,21 +161,17 @@ mod tests {
     use assert_matches::assert_matches;
 
     use super::*;
-    use crate::{
-        cipher_suite::CipherSuite,
-        client::test_utils::TEST_CIPHER_SUITE,
-        crypto::test_utils::test_cipher_suite_provider,
-        crypto::test_utils::TestCryptoProvider,
-        group::test_utils::{get_test_group_context, random_bytes},
-        identity::basic::BasicIdentityProvider,
-        tree_kem::{
-            kem::TreeKem,
-            leaf_node::test_utils::{default_properties, get_basic_test_node},
-            node::{LeafIndex, Node, Parent},
-            parent_hash::{test_utils::get_test_tree_fig_12, ParentHash},
-            test_utils::get_test_tree,
-        },
-    };
+    use crate::cipher_suite::CipherSuite;
+    use crate::client::test_utils::TEST_CIPHER_SUITE;
+    use crate::crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider};
+    use crate::group::test_utils::{get_test_group_context, random_bytes};
+    use crate::identity::basic::BasicIdentityProvider;
+    use crate::tree_kem::kem::TreeKem;
+    use crate::tree_kem::leaf_node::test_utils::{default_properties, get_basic_test_node};
+    use crate::tree_kem::node::{LeafIndex, Node, Parent};
+    use crate::tree_kem::parent_hash::test_utils::get_test_tree_fig_12;
+    use crate::tree_kem::parent_hash::ParentHash;
+    use crate::tree_kem::test_utils::get_test_tree;
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     async fn test_parent_node(cipher_suite: CipherSuite) -> Parent {

--- a/mls-rs/src/tree_kem/update_path.rs
+++ b/mls-rs/src/tree_kem/update_path.rs
@@ -2,20 +2,19 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use alloc::{vec, vec::Vec};
+use alloc::vec;
+use alloc::vec::Vec;
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
-use mls_rs_core::{error::IntoAnyError, identity::IdentityProvider};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::identity::IdentityProvider;
 
-use super::{
-    leaf_node::LeafNode,
-    leaf_node_validator::{LeafNodeValidator, ValidationContext},
-    node::LeafIndex,
-};
-use crate::{
-    client::MlsError,
-    crypto::{CipherSuiteProvider, HpkeCiphertext, HpkePublicKey},
-};
-use crate::{group::message_processor::ProvisionalState, time::MlsTime};
+use super::leaf_node::LeafNode;
+use super::leaf_node_validator::{LeafNodeValidator, ValidationContext};
+use super::node::LeafIndex;
+use crate::client::MlsError;
+use crate::crypto::{CipherSuiteProvider, HpkeCiphertext, HpkePublicKey};
+use crate::group::message_processor::ProvisionalState;
+use crate::time::MlsTime;
 
 #[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -117,8 +116,7 @@ mod tests {
     use crate::group::message_processor::ProvisionalState;
     use crate::group::test_utils::{get_test_group_context, random_bytes, TEST_GROUP};
     use crate::identity::basic::BasicIdentityProvider;
-    use crate::tree_kem::leaf_node::test_utils::default_properties;
-    use crate::tree_kem::leaf_node::test_utils::get_basic_test_node_sig_key;
+    use crate::tree_kem::leaf_node::test_utils::{default_properties, get_basic_test_node_sig_key};
     use crate::tree_kem::leaf_node::LeafNodeSource;
     use crate::tree_kem::node::LeafIndex;
     use crate::tree_kem::parent_hash::ParentHash;
@@ -126,7 +124,8 @@ mod tests {
     use crate::tree_kem::validate_update_path;
 
     use super::{UpdatePath, UpdatePathNode};
-    use crate::{cipher_suite::CipherSuite, tree_kem::MlsError};
+    use crate::cipher_suite::CipherSuite;
+    use crate::tree_kem::MlsError;
 
     use alloc::vec::Vec;
 

--- a/mls-rs/test_harness_integration/src/branch_reinit.rs
+++ b/mls-rs/test_harness_integration/src/branch_reinit.rs
@@ -1,21 +1,19 @@
 #[cfg(feature = "psk")]
 pub(crate) mod inner {
-    use mls_rs::{
-        group::CommitEffect, identity::SigningIdentity, mls_rs_codec::MlsEncode,
-        mls_rules::ProposalInfo, CipherSuiteProvider, CryptoProvider, MlsMessage,
-    };
+    use mls_rs::group::CommitEffect;
+    use mls_rs::identity::SigningIdentity;
+    use mls_rs::mls_rs_codec::MlsEncode;
+    use mls_rs::mls_rules::ProposalInfo;
+    use mls_rs::{CipherSuiteProvider, CryptoProvider, MlsMessage};
     use mls_rs_crypto_openssl::OpensslCryptoProvider;
     use tonic::{Request, Response, Status};
 
-    use crate::{
-        abort, get_tree,
-        mls_client::{
-            CreateSubgroupResponse, HandleBranchRequest, HandleBranchResponse,
-            HandleCommitResponse, HandlePendingCommitRequest, HandleReInitCommitResponse,
-            HandleReInitWelcomeRequest, JoinGroupResponse,
-        },
-        MlsClientImpl,
+    use crate::mls_client::{
+        CreateSubgroupResponse, HandleBranchRequest, HandleBranchResponse, HandleCommitResponse,
+        HandlePendingCommitRequest, HandleReInitCommitResponse, HandleReInitWelcomeRequest,
+        JoinGroupResponse,
     };
+    use crate::{abort, get_tree, MlsClientImpl};
 
     impl MlsClientImpl {
         pub(crate) async fn handle_pending_re_init_commit(
@@ -268,14 +266,12 @@ pub(crate) mod inner {
 
     use mls_rs::group::CommitEffect;
 
-    use crate::{
-        mls_client::{
-            CreateSubgroupResponse, HandleBranchRequest, HandleBranchResponse,
-            HandleCommitResponse, HandlePendingCommitRequest, HandleReInitCommitResponse,
-            HandleReInitWelcomeRequest, JoinGroupResponse,
-        },
-        MlsClientImpl,
+    use crate::mls_client::{
+        CreateSubgroupResponse, HandleBranchRequest, HandleBranchResponse, HandleCommitResponse,
+        HandlePendingCommitRequest, HandleReInitCommitResponse, HandleReInitWelcomeRequest,
+        JoinGroupResponse,
     };
+    use crate::MlsClientImpl;
 
     impl MlsClientImpl {
         pub(crate) async fn handle_pending_re_init_commit(

--- a/mls-rs/test_harness_integration/src/by_ref_proposal.rs
+++ b/mls-rs/test_harness_integration/src/by_ref_proposal.rs
@@ -9,25 +9,23 @@ pub(crate) trait ByRefProposalSender<T> {
 
 #[cfg(feature = "by_ref_proposal")]
 pub(crate) mod inner {
-    use mls_rs::{
-        extension::built_in::ExternalSendersExt,
-        identity::{basic::BasicCredential, Credential, SigningIdentity},
-        mls_rs_codec::MlsDecode,
-        psk::ExternalPskId,
-        Group, MlsMessage, ProtocolVersion,
-    };
+    use mls_rs::extension::built_in::ExternalSendersExt;
+    use mls_rs::identity::basic::BasicCredential;
+    use mls_rs::identity::{Credential, SigningIdentity};
+    use mls_rs::mls_rs_codec::MlsDecode;
+    use mls_rs::psk::ExternalPskId;
+    use mls_rs::{Group, MlsMessage, ProtocolVersion};
     use tonic::{Request, Response, Status};
 
+    use crate::mls_client::{
+        AddExternalSignerRequest, AddProposalRequest, ExternalPskProposalRequest,
+        ExternalSignerProposalRequest, GroupContextExtensionsProposalRequest, ProposalResponse,
+        ReInitProposalRequest, RemoveProposalRequest, ResumptionPskProposalRequest,
+        UpdateProposalRequest,
+    };
     use crate::{
-        abort, find_member, get_tree,
-        mls_client::{
-            AddExternalSignerRequest, AddProposalRequest, ExternalPskProposalRequest,
-            ExternalSignerProposalRequest, GroupContextExtensionsProposalRequest, ProposalResponse,
-            ReInitProposalRequest, RemoveProposalRequest, ResumptionPskProposalRequest,
-            UpdateProposalRequest,
-        },
-        parse_extensions, MlsClientImpl, TestClientConfig, PROPOSAL_DESC_ADD, PROPOSAL_DESC_GCE,
-        PROPOSAL_DESC_REMOVE,
+        abort, find_member, get_tree, parse_extensions, MlsClientImpl, TestClientConfig,
+        PROPOSAL_DESC_ADD, PROPOSAL_DESC_GCE, PROPOSAL_DESC_REMOVE,
     };
 
     #[cfg(feature = "psk")]
@@ -333,24 +331,17 @@ pub(crate) mod external_proposal {
     use mls_rs_crypto_openssl::OpensslCryptoProvider;
     use tonic::{Request, Response, Status};
 
-    use mls_rs::{
-        external_client::builder::ExternalClientBuilder,
-        identity::{
-            basic::{BasicCredential, BasicIdentityProvider},
-            SigningIdentity,
-        },
-        mls_rs_codec::MlsEncode,
-        CipherSuiteProvider, CryptoProvider, MlsMessage,
-    };
+    use mls_rs::external_client::builder::ExternalClientBuilder;
+    use mls_rs::identity::basic::{BasicCredential, BasicIdentityProvider};
+    use mls_rs::identity::SigningIdentity;
+    use mls_rs::mls_rs_codec::MlsEncode;
+    use mls_rs::{CipherSuiteProvider, CryptoProvider, MlsMessage};
 
-    use crate::{
-        abort, create_client,
-        mls_client::{
-            CreateExternalSignerRequest, CreateExternalSignerResponse, NewMemberAddProposalRequest,
-            NewMemberAddProposalResponse,
-        },
-        ExternalClientDetails,
+    use crate::mls_client::{
+        CreateExternalSignerRequest, CreateExternalSignerResponse, NewMemberAddProposalRequest,
+        NewMemberAddProposalResponse,
     };
+    use crate::{abort, create_client, ExternalClientDetails};
 
     use crate::MlsClientImpl;
 

--- a/mls-rs/test_harness_integration/src/main.rs
+++ b/mls-rs/test_harness_integration/src/main.rs
@@ -12,20 +12,20 @@ use by_ref_proposal::ByRefProposalSender;
 
 mod branch_reinit;
 
+use mls_rs::client_builder::{
+    BaseInMemoryConfig, ClientBuilder, WithCryptoProvider, WithIdentityProvider, WithMlsRules,
+};
+use mls_rs::crypto::SignatureSecretKey;
+use mls_rs::external_client::ExternalClient;
+use mls_rs::group::{CommitEffect, ExportedTree, Member, ReceivedMessage, Roster};
+use mls_rs::identity::basic::{BasicCredential, BasicIdentityProvider};
+use mls_rs::identity::{Credential, SigningIdentity};
+use mls_rs::mls_rules::{
+    CommitDirection, CommitOptions, CommitSource, EncryptionOptions, ProposalBundle,
+};
+use mls_rs::psk::ExternalPskId;
+use mls_rs::storage_provider::in_memory::{InMemoryKeyPackageStorage, InMemoryPreSharedKeyStorage};
 use mls_rs::{
-    client_builder::{
-        BaseInMemoryConfig, ClientBuilder, WithCryptoProvider, WithIdentityProvider, WithMlsRules,
-    },
-    crypto::SignatureSecretKey,
-    external_client::ExternalClient,
-    group::{CommitEffect, ExportedTree, Member, ReceivedMessage, Roster},
-    identity::{
-        basic::{BasicCredential, BasicIdentityProvider},
-        Credential, SigningIdentity,
-    },
-    mls_rules::{CommitDirection, CommitOptions, CommitSource, EncryptionOptions, ProposalBundle},
-    psk::ExternalPskId,
-    storage_provider::in_memory::{InMemoryKeyPackageStorage, InMemoryPreSharedKeyStorage},
     CipherSuite, CipherSuiteProvider, Client, CryptoProvider, Extension, ExtensionList, Group,
     MlsMessage, MlsRules,
 };
@@ -36,9 +36,13 @@ use mls_rs::external_client::builder::ExternalBaseConfig;
 use mls_rs_crypto_openssl::OpensslCryptoProvider;
 
 use clap::Parser;
-use std::{collections::HashMap, convert::Infallible, net::IpAddr, sync::Arc};
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::net::IpAddr;
+use std::sync::Arc;
 use tokio::sync::Mutex;
-use tonic::{transport::Server, Request, Response, Status};
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
 
 use mls_client::mls_client_server::{MlsClient, MlsClientServer};
 

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -10,11 +10,9 @@ use mls_rs::group::proposal::Proposal;
 use mls_rs::group::ReceivedMessage;
 use mls_rs::identity::SigningIdentity;
 use mls_rs::mls_rules::CommitOptions;
-use mls_rs::ExtensionList;
-use mls_rs::MlsMessage;
-use mls_rs::ProtocolVersion;
-use mls_rs::{CipherSuite, Group};
-use mls_rs::{Client, CryptoProvider};
+use mls_rs::{
+    CipherSuite, Client, CryptoProvider, ExtensionList, Group, MlsMessage, ProtocolVersion,
+};
 use mls_rs_core::crypto::CipherSuiteProvider;
 use rand::prelude::SliceRandom;
 use rand::RngCore;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,5 @@
 edition = "2021"
+
+# Run `cargo +nightly fmt` occasionaly to activate this unstable
+# option:
+imports_granularity = "Module"


### PR DESCRIPTION
### Description of changes:

This is the result of running `cargo +nightly fmt` with the unstable `rustfmt` option `imports_granularity = "Module"`.

Personally, I find this style much easier to use:

- The lack of deep nesting makes it easier for me to understand the imports at a glance.
- Because most imports are on a single line, I can add/remove them easier. Copy-pasting between files is easier.

### Call-outs:

This option is unstable, meaning that it has no effect on a stable `rustfmt`. Luckily, the default value for `imports_granularity` is `Preserve`, which means that the formatting done here will be preserved by future `cargo fmt` calls:

  https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#imports_granularity

This applies to both on the stable and nightly channels.

This is a personal preference, so this PR is just there to demonstrate the delta in case it hadn't been considered. Somewhat unintuitively, this style is more compact: the diffstat says `971 insertions(+), 1187 deletions(-)`, meaning that the imports take up 18% less vertical space now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
