### PR TITLE
Add GroupInfo and Welcome message decryption APIs

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.41.3"
+version = "0.41.4"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -26,7 +26,7 @@ use crate::{
         snapshot::RawGroupState,
         state::GroupState,
         transcript_hash::InterimTranscriptHash,
-        validate_group_info_joiner, ContentType, ExportedTree, GroupContext, GroupInfo, Roster,
+        validate_tree_and_info_joiner, ContentType, ExportedTree, GroupContext, GroupInfo, Roster,
         Welcome,
     },
     identity::SigningIdentity,
@@ -129,7 +129,7 @@ impl<C: ExternalClientConfig + Clone> ExternalGroup<C> {
             group_info.group_context.cipher_suite,
         )?;
 
-        let public_tree = validate_group_info_joiner(
+        let public_tree = validate_tree_and_info_joiner(
             protocol_version,
             &group_info,
             tree_data,

--- a/mls-rs/src/grease.rs
+++ b/mls-rs/src/grease.rs
@@ -55,6 +55,10 @@ impl GroupInfo {
     pub fn grease<P: CipherSuiteProvider>(&mut self, cs: &P) -> Result<(), MlsError> {
         grease_functions::grease_extensions(&mut self.extensions, cs).map(|_| ())
     }
+
+    pub fn ungrease(&mut self) {
+        grease_functions::ungrease_extensions(&mut self.extensions)
+    }
 }
 
 impl NewMemberInfo {

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -39,7 +39,7 @@ use crate::group::{
     PreSharedKeyProposal, {JustPreSharedKeyID, PreSharedKeyID},
 };
 
-use super::{validate_group_info_joiner, ExportedTree};
+use super::{validate_tree_and_info_joiner, ExportedTree};
 
 /// A builder that aids with the construction of an external commit.
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::ffi_type(opaque))]
@@ -163,7 +163,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             .get_as::<ExternalPubExt>()?
             .ok_or(MlsError::MissingExternalPubExtension)?;
 
-        let public_tree = validate_group_info_joiner(
+        let public_tree = validate_tree_and_info_joiner(
             protocol_version,
             &group_info,
             self.tree_data,

--- a/mls-rs/src/group/util.rs
+++ b/mls-rs/src/group/util.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use mls_rs_core::{
-    error::IntoAnyError, identity::IdentityProvider, key_package::KeyPackageStorage,
+    error::IntoAnyError,
+    identity::{IdentityProvider, SigningIdentity},
+    key_package::KeyPackageStorage,
 };
 
 use crate::{
@@ -32,7 +34,7 @@ use super::message_processor::ProvisionalState;
 pub(crate) async fn validate_group_info_common<C: CipherSuiteProvider>(
     msg_version: ProtocolVersion,
     group_info: &GroupInfo,
-    tree: &TreeKemPublic,
+    signer: &SigningIdentity,
     cs: &C,
 ) -> Result<(), MlsError> {
     if msg_version != group_info.group_context.protocol_version {
@@ -43,11 +45,7 @@ pub(crate) async fn validate_group_info_common<C: CipherSuiteProvider>(
         return Err(MlsError::CipherSuiteMismatch);
     }
 
-    let sender_leaf = &tree.get_leaf_node(group_info.signer)?;
-
-    group_info
-        .verify(cs, &sender_leaf.signing_identity.signature_key, &())
-        .await?;
+    group_info.verify(cs, &signer.signature_key, &()).await?;
 
     Ok(())
 }
@@ -59,7 +57,8 @@ pub(crate) async fn validate_group_info_member<C: CipherSuiteProvider>(
     group_info: &GroupInfo,
     cs: &C,
 ) -> Result<(), MlsError> {
-    validate_group_info_common(msg_version, group_info, &self_state.public_tree, cs).await?;
+    let signer = &self_state.public_tree.get_leaf_node(group_info.signer)?;
+    validate_group_info_common(msg_version, group_info, &signer.signing_identity, cs).await?;
 
     let self_tree = ExportedTree::new_borrowed(&self_state.public_tree.nodes);
 
@@ -78,17 +77,31 @@ pub(crate) async fn validate_group_info_member<C: CipherSuiteProvider>(
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
-pub(crate) async fn validate_group_info_joiner<C, I>(
+pub(crate) async fn validate_tree_and_info_joiner<C: CipherSuiteProvider, I: IdentityProvider>(
     msg_version: ProtocolVersion,
     group_info: &GroupInfo,
     tree: Option<ExportedTree<'_>>,
     id_provider: &I,
     cs: &C,
-) -> Result<TreeKemPublic, MlsError>
-where
-    C: CipherSuiteProvider,
-    I: IdentityProvider,
-{
+) -> Result<TreeKemPublic, MlsError> {
+    let public_tree = validate_tree_joiner(group_info, tree, id_provider, cs).await?;
+
+    let signer = &public_tree
+        .get_leaf_node(group_info.signer)?
+        .signing_identity;
+
+    validate_group_info_joiner(msg_version, group_info, signer, id_provider, cs).await?;
+
+    Ok(public_tree)
+}
+
+#[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+pub(crate) async fn validate_tree_joiner<C: CipherSuiteProvider, I: IdentityProvider>(
+    group_info: &GroupInfo,
+    tree: Option<ExportedTree<'_>>,
+    id_provider: &I,
+    cs: &C,
+) -> Result<TreeKemPublic, MlsError> {
     let tree = match group_info.extensions.get_as::<RatchetTreeExt>()? {
         Some(ext) => ext.tree_data,
         None => tree.ok_or(MlsError::RatchetTreeNotFound)?,
@@ -104,6 +117,21 @@ where
         .validate(&mut tree)
         .await?;
 
+    Ok(tree)
+}
+
+#[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+pub(crate) async fn validate_group_info_joiner<C: CipherSuiteProvider, I: IdentityProvider>(
+    msg_version: ProtocolVersion,
+    group_info: &GroupInfo,
+    signer: &SigningIdentity,
+    #[cfg(feature = "by_ref_proposal")] id_provider: &I,
+    #[cfg(not(feature = "by_ref_proposal"))] _id_provider: &I,
+    cs: &C,
+) -> Result<(), MlsError> {
+    #[cfg(feature = "by_ref_proposal")]
+    let context = &group_info.group_context;
+
     #[cfg(feature = "by_ref_proposal")]
     if let Some(ext_senders) = context.extensions.get_as::<ExternalSendersExt>()? {
         // TODO do joiners verify group against current time??
@@ -113,9 +141,9 @@ where
             .map_err(|e| MlsError::IdentityProviderError(e.into_any_error()))?;
     }
 
-    validate_group_info_common(msg_version, group_info, &tree, cs).await?;
+    validate_group_info_common(msg_version, group_info, signer, cs).await?;
 
-    Ok(tree)
+    Ok(())
 }
 
 pub(crate) fn commit_sender(


### PR DESCRIPTION
Add APIs to decrypt group info from welcome message (without tree) and validate group info (without tree). They may be useful.

*Code in group/mod.rs was copied to a new function but not modified*

### Testing:
Added unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
