### PR TITLE
Add P384 suport for RustCrypto

### DIFF
--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -53,6 +53,7 @@ hkdf = { version = "0.12", default-features = false }
 
 # KEM
 p256 = { version = "0.13", default-features = false, features = ["alloc", "ecdh", "ecdsa", "pem"] }
+p384 = { version = "0.13", default-features = false, features = ["alloc", "ecdh", "ecdsa", "pem"] }
 x25519-dalek = { version = "2", default-features = false, features = ["alloc", "static_secrets"] }
 ed25519-dalek = { version = "2", default-features = false, features = ["alloc", "rand_core"] }
 sec1 = { version = "0.7", default-features = false, features = ["alloc"] }

--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-rustcrypto"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "RustCrypto based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs-crypto-rustcrypto/src/ec_for_x509.rs
+++ b/mls-rs-crypto-rustcrypto/src/ec_for_x509.rs
@@ -98,6 +98,10 @@ pub fn pub_key_to_spki(key: &EcPublicKey) -> Result<Vec<u8>, EcX509Error> {
             .to_public_key_der()
             .map_err(|_| EcX509Error::NistSpkiError)?
             .to_vec()),
+        EcPublicKey::P384(key) => Ok(key
+            .to_public_key_der()
+            .map_err(|_| EcX509Error::NistSpkiError)?
+            .to_vec()),
     }
 }
 

--- a/mls-rs-crypto-rustcrypto/src/ec_signer.rs
+++ b/mls-rs-crypto-rustcrypto/src/ec_signer.rs
@@ -4,8 +4,8 @@
 
 use crate::ec::{
     generate_keypair, private_key_bytes_to_public, private_key_from_bytes,
-    pub_key_from_uncompressed, sign_ed25519, sign_p256, verify_ed25519, verify_p256, EcError,
-    EcPrivateKey, EcPublicKey,
+    pub_key_from_uncompressed, sign_ed25519, sign_p256, sign_p384, verify_ed25519, verify_p256,
+    verify_p384, EcError, EcPrivateKey, EcPublicKey,
 };
 use alloc::vec::Vec;
 use core::ops::Deref;
@@ -74,6 +74,7 @@ impl EcSigner {
             EcPrivateKey::X25519(_) => Err(EcSignerError::EcKeyNotSignature),
             EcPrivateKey::Ed25519(private_key) => Ok(sign_ed25519(&private_key, data)?),
             EcPrivateKey::P256(private_key) => Ok(sign_p256(&private_key, data)?),
+            EcPrivateKey::P384(private_key) => Ok(sign_p384(&private_key, data)?),
         }
     }
 
@@ -89,6 +90,7 @@ impl EcSigner {
             EcPublicKey::X25519(_) => Err(EcSignerError::EcKeyNotSignature),
             EcPublicKey::Ed25519(key) => Ok(verify_ed25519(&key, signature, data)?),
             EcPublicKey::P256(key) => Ok(verify_p256(&key, signature, data)?),
+            EcPublicKey::P384(key) => Ok(verify_p384(&key, signature, data)?),
         }?;
 
         ver.then_some(()).ok_or(EcSignerError::InvalidSignature)

--- a/mls-rs-crypto-rustcrypto/src/lib.rs
+++ b/mls-rs-crypto-rustcrypto/src/lib.rs
@@ -111,6 +111,7 @@ impl RustCryptoProvider {
     pub fn all_supported_cipher_suites() -> Vec<CipherSuite> {
         vec![
             CipherSuite::P256_AES128,
+            CipherSuite::P384_AES256,
             CipherSuite::CURVE25519_AES128,
             CipherSuite::CURVE25519_CHACHA,
         ]


### PR DESCRIPTION
### Description of changes:

RustCrypto now supports P384.

### Testing:

Covered by the core test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
