### PR TITLE
Support AWS-LC in FIPS mode

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Install cargo-hack
         run: cargo install cargo-hack
       - name: Build one feature at a time
-        run: cargo hack build --each-feature --workspace --exclude harness_client,mls-rs-crypto-awslc
+        run: cargo hack build --each-feature --workspace --exclude harness_client --exclude mls-rs-crypto-awslc

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Install cargo-hack
         run: cargo install cargo-hack
       - name: Build one feature at a time
-        run: cargo hack build --each-feature --workspace --exclude harness_client
+        run: cargo hack build --each-feature --workspace --exclude harness_client,,mls-rs-crypto-awslc

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Install cargo-hack
         run: cargo install cargo-hack
       - name: Build one feature at a time
-        run: cargo hack build --each-feature --workspace --exclude harness_client,,mls-rs-crypto-awslc
+        run: cargo hack build --each-feature --workspace --exclude harness_client,mls-rs-crypto-awslc

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -25,6 +25,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ilammy/setup-nasm@v1
         if: runner.os == 'Windows'
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
+      - uses: seanmiddleditch/gha-setup-ninja@master
+        if: runner.os == 'Windows'
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows-static-md sqlite3:x64-windows-static-md
@@ -59,6 +64,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ilammy/setup-nasm@v1
         if: runner.os == 'Windows'
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
+      - uses: seanmiddleditch/gha-setup-ninja@master
+        if: runner.os == 'Windows'
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows-static-md sqlite3:x64-windows-static-md
@@ -85,6 +95,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.18'
+      - uses: seanmiddleditch/gha-setup-ninja@master
       - name: Rust Fmt
         run: cargo fmt --all -- --check
       - name: Clippy Full RFC Compliance

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Test Full RFC Compliance
         run: cargo test --all-features --verbose --workspace
       - name: Test Bare Bones
-        run: cargo test --no-default-features --features std,test_util  --verbose --workspace
+        run: cargo test --no-default-features --features std,test_util,non-fips  --verbose --workspace
       - name: Examples
         working-directory: mls-rs
         run: cargo run --example basic_usage
@@ -87,7 +87,7 @@ jobs:
       - name: Clippy Full RFC Compliance
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
       - name: Clippy Bare Bones
-        run: cargo clippy --all-targets --no-default-features --features std,test_util --workspace -- -D warnings
+        run: cargo clippy --all-targets --no-default-features --features std,test_util,non-fips --workspace -- -D warnings
   LintAndFormattingMacOS:
     # XXX(RLB): It would be good to just use macos-latest here, but
     # apparently if you do that, sometimes you get an older (not latest)

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -82,6 +82,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
       - name: Rust Fmt
         run: cargo fmt --all -- --check
       - name: Clippy Full RFC Compliance

--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-awslc"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "AWS-LC based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -8,9 +8,14 @@ repository = "https://github.com/awslabs/mls-rs"
 keywords = ["mls", "mls-rs", "aws-lc"]
 license = "Apache-2.0 OR MIT"
 
+[features]
+fips = ["aws-lc-rs/fips", "dep:aws-lc-fips-sys"]
+default = ["aws-lc-rs/aws-lc-sys"]
+
 [dependencies]
-aws-lc-rs = "=1.8.0"
-aws-lc-sys = { version = "0.19.0" }
+aws-lc-rs = { version = "=1.10.0", default-features = false, features = ["alloc"] }
+aws-lc-sys = { version = "0.22.0", optional = true }
+aws-lc-fips-sys = { version = "0.12.0", optional = true }
 mls-rs-core = { path = "../mls-rs-core", version = "0.19.0" }
 mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.10.0" }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.11.0" }

--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 OR MIT"
 
 [features]
 fips = ["aws-lc-rs/fips", "dep:aws-lc-fips-sys"]
-default = ["aws-lc-rs/aws-lc-sys"]
+default = ["aws-lc-rs/aws-lc-sys", "dep:aws-lc-sys"]
 
 [dependencies]
 aws-lc-rs = { version = "=1.10.0", default-features = false, features = ["alloc"] }

--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -10,7 +10,8 @@ license = "Apache-2.0 OR MIT"
 
 [features]
 fips = ["aws-lc-rs/fips", "dep:aws-lc-fips-sys"]
-default = ["aws-lc-rs/aws-lc-sys", "dep:aws-lc-sys"]
+non-fips = ["aws-lc-rs/aws-lc-sys", "dep:aws-lc-sys"]
+default = ["non-fips"]
 
 [dependencies]
 aws-lc-rs = { version = "=1.10.0", default-features = false, features = ["alloc"] }

--- a/mls-rs-crypto-awslc/src/ec.rs
+++ b/mls-rs-crypto-awslc/src/ec.rs
@@ -4,7 +4,7 @@
 
 use std::{os::raw::c_void, ptr::null_mut};
 
-use crate::aws_lc_sys::{
+use crate::aws_lc_sys_impl::{
     d2i_ECPrivateKey, point_conversion_form_t, BN_bin2bn, BN_bn2bin, BN_free, ECDH_compute_key,
     EC_GROUP_free, EC_GROUP_new_by_curve_name, EC_KEY_free, EC_KEY_generate_key, EC_KEY_get0_group,
     EC_KEY_get0_private_key, EC_KEY_get0_public_key, EC_KEY_new_by_curve_name,
@@ -172,7 +172,7 @@ pub fn x25519_public_key(secret_key: &[u8]) -> Result<Vec<u8>, AwsLcCryptoError>
 }
 
 pub struct EcPrivateKey {
-    pub(crate) inner: *mut crate::aws_lc_sys::ec_key_st,
+    pub(crate) inner: *mut crate::aws_lc_sys_impl::ec_key_st,
     curve: Curve,
 }
 
@@ -298,7 +298,7 @@ impl EcPrivateKey {
 
 impl Drop for EcPrivateKey {
     fn drop(&mut self) {
-        unsafe { crate::aws_lc_sys::EC_KEY_free(self.inner) }
+        unsafe { crate::aws_lc_sys_impl::EC_KEY_free(self.inner) }
     }
 }
 

--- a/mls-rs-crypto-awslc/src/ec.rs
+++ b/mls-rs-crypto-awslc/src/ec.rs
@@ -4,8 +4,7 @@
 
 use std::{os::raw::c_void, ptr::null_mut};
 
-use aws_lc_rs::error::Unspecified;
-use aws_lc_sys::{
+use crate::aws_lc_sys::{
     d2i_ECPrivateKey, point_conversion_form_t, BN_bin2bn, BN_bn2bin, BN_free, ECDH_compute_key,
     EC_GROUP_free, EC_GROUP_new_by_curve_name, EC_KEY_free, EC_KEY_generate_key, EC_KEY_get0_group,
     EC_KEY_get0_private_key, EC_KEY_get0_public_key, EC_KEY_new_by_curve_name,
@@ -14,6 +13,7 @@ use aws_lc_sys::{
     EVP_PKEY_set1_EC_KEY, NID_X9_62_prime256v1, NID_secp384r1, NID_secp521r1, X25519_keypair,
     X25519_public_from_private, EC_POINT, EVP_PKEY, X25519,
 };
+use aws_lc_rs::error::Unspecified;
 use mls_rs_core::crypto::{CipherSuite, HpkePublicKey, HpkeSecretKey};
 use mls_rs_crypto_traits::Curve;
 
@@ -172,7 +172,7 @@ pub fn x25519_public_key(secret_key: &[u8]) -> Result<Vec<u8>, AwsLcCryptoError>
 }
 
 pub struct EcPrivateKey {
-    pub(crate) inner: *mut aws_lc_sys::ec_key_st,
+    pub(crate) inner: *mut crate::aws_lc_sys::ec_key_st,
     curve: Curve,
 }
 
@@ -298,7 +298,7 @@ impl EcPrivateKey {
 
 impl Drop for EcPrivateKey {
     fn drop(&mut self) {
-        unsafe { aws_lc_sys::EC_KEY_free(self.inner) }
+        unsafe { crate::aws_lc_sys::EC_KEY_free(self.inner) }
     }
 }
 

--- a/mls-rs-crypto-awslc/src/ecdsa.rs
+++ b/mls-rs-crypto-awslc/src/ecdsa.rs
@@ -10,7 +10,7 @@ use aws_lc_rs::{
     signature::{self, UnparsedPublicKey, ED25519_PUBLIC_KEY_LEN},
 };
 
-use aws_lc_sys::{
+use crate::aws_lc_sys::{
     ECDSA_SIG_free, ECDSA_SIG_to_bytes, ECDSA_do_sign, ED25519_keypair, ED25519_sign,
     EVP_PKEY_new_raw_private_key, EVP_PKEY_new_raw_public_key, OPENSSL_free,
     ED25519_PRIVATE_KEY_LEN, ED25519_SIGNATURE_LEN, EVP_PKEY_ED25519,

--- a/mls-rs-crypto-awslc/src/ecdsa.rs
+++ b/mls-rs-crypto-awslc/src/ecdsa.rs
@@ -10,7 +10,7 @@ use aws_lc_rs::{
     signature::{self, UnparsedPublicKey, ED25519_PUBLIC_KEY_LEN},
 };
 
-use crate::aws_lc_sys::{
+use crate::aws_lc_sys_impl::{
     ECDSA_SIG_free, ECDSA_SIG_to_bytes, ECDSA_do_sign, ED25519_keypair, ED25519_sign,
     EVP_PKEY_new_raw_private_key, EVP_PKEY_new_raw_public_key, OPENSSL_free,
     ED25519_PRIVATE_KEY_LEN, ED25519_SIGNATURE_LEN, EVP_PKEY_ED25519,

--- a/mls-rs-crypto-awslc/src/kdf.rs
+++ b/mls-rs-crypto-awslc/src/kdf.rs
@@ -4,8 +4,8 @@
 
 use std::mem::MaybeUninit;
 
+use crate::aws_lc_sys::{EVP_sha256, EVP_sha384, EVP_sha512, HKDF_expand, HKDF_extract, EVP_MD};
 use aws_lc_rs::error::Unspecified;
-use aws_lc_sys::{EVP_sha256, EVP_sha384, EVP_sha512, HKDF_expand, HKDF_extract, EVP_MD};
 use mls_rs_core::crypto::CipherSuite;
 use mls_rs_crypto_traits::KdfId;
 

--- a/mls-rs-crypto-awslc/src/kdf.rs
+++ b/mls-rs-crypto-awslc/src/kdf.rs
@@ -4,7 +4,9 @@
 
 use std::mem::MaybeUninit;
 
-use crate::aws_lc_sys::{EVP_sha256, EVP_sha384, EVP_sha512, HKDF_expand, HKDF_extract, EVP_MD};
+use crate::aws_lc_sys_impl::{
+    EVP_sha256, EVP_sha384, EVP_sha512, HKDF_expand, HKDF_extract, EVP_MD,
+};
 use aws_lc_rs::error::Unspecified;
 use mls_rs_core::crypto::CipherSuite;
 use mls_rs_crypto_traits::KdfId;

--- a/mls-rs-crypto-awslc/src/lib.rs
+++ b/mls-rs-crypto-awslc/src/lib.rs
@@ -9,12 +9,18 @@ mod kdf;
 
 pub mod x509;
 
+#[cfg(feature = "fips")]
+use aws_lc_fips_sys as aws_lc_sys;
+
+#[cfg(not(feature = "fips"))]
+use aws_lc_sys;
+
 use std::{ffi::c_int, mem::MaybeUninit};
 
 use aead::AwsLcAead;
 use aws_lc_rs::{digest, error::Unspecified, hmac};
 
-use aws_lc_sys::SHA256;
+use crate::aws_lc_sys::SHA256;
 use mls_rs_core::{
     crypto::{
         CipherSuite, CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkePublicKey,
@@ -315,7 +321,7 @@ impl CipherSuiteProvider for AwsLcCipherSuite {
 
     fn random_bytes(&self, out: &mut [u8]) -> Result<(), Self::Error> {
         unsafe {
-            if 1 != aws_lc_sys::RAND_bytes(out.as_mut_ptr(), out.len()) {
+            if 1 != crate::aws_lc_sys::RAND_bytes(out.as_mut_ptr(), out.len()) {
                 return Err(Unspecified.into());
             }
         }

--- a/mls-rs-crypto-awslc/src/x509.rs
+++ b/mls-rs-crypto-awslc/src/x509.rs
@@ -15,7 +15,7 @@ pub use writer::CertificateRequestWriter;
 mod test_utils {
     use std::ptr::null_mut;
 
-    use aws_lc_sys::{
+    use crate::aws_lc_sys::{
         i2d_X509_REQ, BIO_free, BIO_new_mem_buf, EVP_PKEY_free, EVP_PKEY_get_raw_private_key,
         EVP_PKEY_get_raw_public_key, PEM_read_bio_PrivateKey, PEM_read_bio_X509_REQ, X509_REQ_free,
     };

--- a/mls-rs-crypto-awslc/src/x509.rs
+++ b/mls-rs-crypto-awslc/src/x509.rs
@@ -15,7 +15,7 @@ pub use writer::CertificateRequestWriter;
 mod test_utils {
     use std::ptr::null_mut;
 
-    use crate::aws_lc_sys::{
+    use crate::aws_lc_sys_impl::{
         i2d_X509_REQ, BIO_free, BIO_new_mem_buf, EVP_PKEY_free, EVP_PKEY_get_raw_private_key,
         EVP_PKEY_get_raw_public_key, PEM_read_bio_PrivateKey, PEM_read_bio_X509_REQ, X509_REQ_free,
     };

--- a/mls-rs-crypto-awslc/src/x509/certificate.rs
+++ b/mls-rs-crypto-awslc/src/x509/certificate.rs
@@ -9,16 +9,16 @@ use std::{
     time::Duration,
 };
 
-use aws_lc_sys::{
+use crate::aws_lc_sys::{
     d2i_X509, i2d_X509, i2d_X509_NAME, ASN1_INTEGER_free, ASN1_INTEGER_to_BN, ASN1_TIME_free,
     ASN1_TIME_new, ASN1_TIME_set_posix, ASN1_TIME_to_posix, BN_bin2bn, BN_bn2bin, BN_free,
     BN_num_bytes, BN_to_ASN1_INTEGER, EC_KEY_get0_group, EC_KEY_get0_public_key,
     EC_POINT_point2oct, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get_raw_public_key, NID_subject_alt_name,
     X509V3_set_ctx, X509_EXTENSION_dup, X509_add_ext, X509_free, X509_get0_notAfter,
-    X509_get0_notBefore, X509_get0_pubkey, X509_get_ext, X509_get_ext_count, X509_get_ext_d2i,
-    X509_get_issuer_name, X509_get_serialNumber, X509_get_subject_name, X509_new,
-    X509_set_issuer_name, X509_set_notAfter, X509_set_notBefore, X509_set_pubkey,
-    X509_set_serialNumber, X509_set_subject_name, X509_set_version, X509_sign, ASN1_TIME, X509,
+    X509_get0_notBefore, X509_get_ext, X509_get_ext_count, X509_get_ext_d2i, X509_get_issuer_name,
+    X509_get_pubkey, X509_get_serialNumber, X509_get_subject_name, X509_new, X509_set_issuer_name,
+    X509_set_notAfter, X509_set_notBefore, X509_set_pubkey, X509_set_serialNumber,
+    X509_set_subject_name, X509_set_version, X509_sign, ASN1_TIME, X509,
 };
 use mls_rs_core::{
     crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey},
@@ -197,7 +197,7 @@ impl Certificate {
 
     pub fn public_key(&self) -> Result<SignaturePublicKey, AwsLcCryptoError> {
         unsafe {
-            let pub_key = X509_get0_pubkey(self.0);
+            let pub_key = X509_get_pubkey(self.0);
             let ec_key = EVP_PKEY_get0_EC_KEY(pub_key);
 
             if !ec_key.is_null() {
@@ -206,7 +206,7 @@ impl Certificate {
                 let len = EC_POINT_point2oct(
                     EC_KEY_get0_group(ec_key),
                     EC_KEY_get0_public_key(ec_key),
-                    aws_lc_sys::point_conversion_form_t::POINT_CONVERSION_UNCOMPRESSED,
+                    crate::aws_lc_sys::point_conversion_form_t::POINT_CONVERSION_UNCOMPRESSED,
                     out_buf.as_mut_ptr(),
                     256,
                     null_mut(),

--- a/mls-rs-crypto-awslc/src/x509/certificate.rs
+++ b/mls-rs-crypto-awslc/src/x509/certificate.rs
@@ -13,12 +13,12 @@ use crate::aws_lc_sys::{
     d2i_X509, i2d_X509, i2d_X509_NAME, ASN1_INTEGER_free, ASN1_INTEGER_to_BN, ASN1_TIME_free,
     ASN1_TIME_new, ASN1_TIME_set_posix, ASN1_TIME_to_posix, BN_bin2bn, BN_bn2bin, BN_free,
     BN_num_bytes, BN_to_ASN1_INTEGER, EC_KEY_get0_group, EC_KEY_get0_public_key,
-    EC_POINT_point2oct, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get_raw_public_key, NID_subject_alt_name,
-    X509V3_set_ctx, X509_EXTENSION_dup, X509_add_ext, X509_free, X509_get0_notAfter,
-    X509_get0_notBefore, X509_get_ext, X509_get_ext_count, X509_get_ext_d2i, X509_get_issuer_name,
-    X509_get_pubkey, X509_get_serialNumber, X509_get_subject_name, X509_new, X509_set_issuer_name,
-    X509_set_notAfter, X509_set_notBefore, X509_set_pubkey, X509_set_serialNumber,
-    X509_set_subject_name, X509_set_version, X509_sign, ASN1_TIME, X509,
+    EC_POINT_point2oct, EVP_PKEY_free, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get_raw_public_key,
+    NID_subject_alt_name, X509V3_set_ctx, X509_EXTENSION_dup, X509_add_ext, X509_free,
+    X509_get0_notAfter, X509_get0_notBefore, X509_get_ext, X509_get_ext_count, X509_get_ext_d2i,
+    X509_get_issuer_name, X509_get_pubkey, X509_get_serialNumber, X509_get_subject_name, X509_new,
+    X509_set_issuer_name, X509_set_notAfter, X509_set_notBefore, X509_set_pubkey,
+    X509_set_serialNumber, X509_set_subject_name, X509_set_version, X509_sign, ASN1_TIME, X509,
 };
 use mls_rs_core::{
     crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey},
@@ -199,6 +199,7 @@ impl Certificate {
         unsafe {
             let pub_key = X509_get_pubkey(self.0);
             let ec_key = EVP_PKEY_get0_EC_KEY(pub_key);
+            EVP_PKEY_free(pub_key);
 
             if !ec_key.is_null() {
                 let mut out_buf = vec![0u8; 256];

--- a/mls-rs-crypto-awslc/src/x509/certificate.rs
+++ b/mls-rs-crypto-awslc/src/x509/certificate.rs
@@ -9,7 +9,7 @@ use std::{
     time::Duration,
 };
 
-use crate::aws_lc_sys::{
+use crate::aws_lc_sys_impl::{
     d2i_X509, i2d_X509, i2d_X509_NAME, ASN1_INTEGER_free, ASN1_INTEGER_to_BN, ASN1_TIME_free,
     ASN1_TIME_new, ASN1_TIME_set_posix, ASN1_TIME_to_posix, BN_bin2bn, BN_bn2bin, BN_free,
     BN_num_bytes, BN_to_ASN1_INTEGER, EC_KEY_get0_group, EC_KEY_get0_public_key,
@@ -207,7 +207,7 @@ impl Certificate {
                 let len = EC_POINT_point2oct(
                     EC_KEY_get0_group(ec_key),
                     EC_KEY_get0_public_key(ec_key),
-                    crate::aws_lc_sys::point_conversion_form_t::POINT_CONVERSION_UNCOMPRESSED,
+                    crate::aws_lc_sys_impl::point_conversion_form_t::POINT_CONVERSION_UNCOMPRESSED,
                     out_buf.as_mut_ptr(),
                     256,
                     null_mut(),

--- a/mls-rs-crypto-awslc/src/x509/component.rs
+++ b/mls-rs-crypto-awslc/src/x509/component.rs
@@ -10,21 +10,32 @@ use std::{
     ptr::null_mut,
 };
 
-use crate::aws_lc_sys::{
-    sk_free, sk_new_null, sk_pop, sk_push, stack_st, ASN1_STRING_data, ASN1_STRING_free,
-    ASN1_STRING_get0_data, ASN1_STRING_length, ASN1_STRING_set, ASN1_STRING_type_new, BIO_free,
-    BIO_new, BIO_number_written, BIO_read, BIO_s_mem, GENERAL_NAME_free, GENERAL_NAME_get0_value,
-    GENERAL_NAME_new, GENERAL_NAME_set0_value, NID_authority_key_identifier, NID_basic_constraints,
-    NID_commonName, NID_countryName, NID_distinguishedName, NID_domainComponent,
-    NID_generationQualifier, NID_givenName, NID_initials, NID_key_usage, NID_localityName,
-    NID_organizationName, NID_organizationalUnitName, NID_pkcs9_emailAddress, NID_pseudonym,
-    NID_serialNumber, NID_stateOrProvinceName, NID_streetAddress, NID_subject_alt_name,
-    NID_subject_key_identifier, NID_surname, NID_title, NID_userId, OBJ_obj2nid,
-    X509V3_EXT_conf_nid, X509V3_EXT_i2d, X509V3_EXT_print, X509_EXTENSION_free,
-    X509_NAME_ENTRY_get_data, X509_NAME_ENTRY_get_object, X509_NAME_add_entry_by_NID,
-    X509_NAME_entry_count, X509_NAME_free, X509_NAME_get_entry, X509_NAME_new, X509_name_st,
-    ASN1_STRING, GENERAL_NAME, GEN_DNS, GEN_EMAIL, GEN_IPADD, GEN_RID, GEN_URI, MBSTRING_UTF8,
-    V_ASN1_IA5STRING, V_ASN1_OCTET_STRING, X509V3_CTX, X509_EXTENSION, X509_NAME,
+#[cfg(feature = "fips")]
+use crate::aws_lc_sys_impl::{
+    sk_free as OPENSSL_sk_free, sk_new_null as OPENSSL_sk_new_null, sk_pop as OPENSSL_sk_pop,
+    sk_push as OPENSSL_sk_push,
+};
+
+#[cfg(not(feature = "fips"))]
+use crate::aws_lc_sys_impl::{
+    OPENSSL_sk_free, OPENSSL_sk_new_null, OPENSSL_sk_pop, OPENSSL_sk_push,
+};
+
+use crate::aws_lc_sys_impl::{
+    stack_st, ASN1_STRING_data, ASN1_STRING_free, ASN1_STRING_get0_data, ASN1_STRING_length,
+    ASN1_STRING_set, ASN1_STRING_type_new, BIO_free, BIO_new, BIO_number_written, BIO_read,
+    BIO_s_mem, GENERAL_NAME_free, GENERAL_NAME_get0_value, GENERAL_NAME_new,
+    GENERAL_NAME_set0_value, NID_authority_key_identifier, NID_basic_constraints, NID_commonName,
+    NID_countryName, NID_distinguishedName, NID_domainComponent, NID_generationQualifier,
+    NID_givenName, NID_initials, NID_key_usage, NID_localityName, NID_organizationName,
+    NID_organizationalUnitName, NID_pkcs9_emailAddress, NID_pseudonym, NID_serialNumber,
+    NID_stateOrProvinceName, NID_streetAddress, NID_subject_alt_name, NID_subject_key_identifier,
+    NID_surname, NID_title, NID_userId, OBJ_obj2nid, X509V3_EXT_conf_nid, X509V3_EXT_i2d,
+    X509V3_EXT_print, X509_EXTENSION_free, X509_NAME_ENTRY_get_data, X509_NAME_ENTRY_get_object,
+    X509_NAME_add_entry_by_NID, X509_NAME_entry_count, X509_NAME_free, X509_NAME_get_entry,
+    X509_NAME_new, X509_name_st, ASN1_STRING, GENERAL_NAME, GEN_DNS, GEN_EMAIL, GEN_IPADD, GEN_RID,
+    GEN_URI, MBSTRING_UTF8, V_ASN1_IA5STRING, V_ASN1_OCTET_STRING, X509V3_CTX, X509_EXTENSION,
+    X509_NAME,
 };
 use mls_rs_identity_x509::{SubjectAltName, SubjectComponent};
 
@@ -87,7 +98,7 @@ impl X509Name {
 
     #[cfg(test)]
     pub fn to_der(&self) -> Result<Vec<u8>, AwsLcCryptoError> {
-        use crate::aws_lc_sys::i2d_X509_NAME;
+        use crate::aws_lc_sys_impl::i2d_X509_NAME;
 
         unsafe {
             let len = check_int_return(i2d_X509_NAME(self.0, null_mut()))?;
@@ -262,7 +273,7 @@ where
 {
     pub fn new() -> Result<Self, AwsLcCryptoError> {
         unsafe {
-            check_non_null(sk_new_null()).map(|v| Self {
+            check_non_null(OPENSSL_sk_new_null()).map(|v| Self {
                 inner: v,
                 phantom: Default::default(),
             })
@@ -278,13 +289,13 @@ where
 
     pub fn push(&mut self, val: T) {
         unsafe {
-            sk_push(self.inner, val.into_raw_pointer());
+            OPENSSL_sk_push(self.inner, val.into_raw_pointer());
         }
     }
 
     pub fn pop(&mut self) -> Option<T> {
         unsafe {
-            let val = sk_pop(self.inner);
+            let val = OPENSSL_sk_pop(self.inner);
 
             if val.is_null() {
                 return None;
@@ -316,7 +327,7 @@ where
     fn drop(&mut self) {
         unsafe {
             loop {
-                let val = sk_pop(self.inner);
+                let val = OPENSSL_sk_pop(self.inner);
 
                 if val.is_null() {
                     break;
@@ -325,7 +336,7 @@ where
                 let _ = T::from_raw_pointer(val);
             }
 
-            sk_free(self.inner)
+            OPENSSL_sk_free(self.inner)
         }
     }
 }
@@ -489,7 +500,19 @@ impl X509Extension {
                 return Err(AwsLcCryptoError::CryptoError);
             }
 
-            let mut out_buffer = vec![0u8; BIO_number_written(bio_out)];
+            #[cfg(feature = "fips")]
+            let out_len = BIO_number_written(bio_out);
+
+            #[cfg(not(feature = "fips"))]
+            let out_len = match BIO_number_written(bio_out).try_into() {
+                Ok(out_len) => out_len,
+                Err(e) => {
+                    BIO_free(bio_out);
+                    return Err(AwsLcCryptoError::from(e));
+                }
+            };
+
+            let mut out_buffer = vec![0u8; out_len];
 
             let res = BIO_read(
                 bio_out,

--- a/mls-rs-crypto-awslc/src/x509/request.rs
+++ b/mls-rs-crypto-awslc/src/x509/request.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::{
-    aws_lc_sys::{
+    aws_lc_sys_impl::{
         i2d_X509_REQ, EVP_sha256, EVP_sha384, EVP_sha512, X509_REQ_add_extensions, X509_REQ_free,
         X509_REQ_new, X509_REQ_set_pubkey, X509_REQ_set_subject_name, X509_REQ_set_version,
         X509_REQ_sign, EVP_MD, X509_REQ,

--- a/mls-rs-crypto-awslc/src/x509/request.rs
+++ b/mls-rs-crypto-awslc/src/x509/request.rs
@@ -7,17 +7,18 @@ use std::{
     ptr::{null, null_mut},
 };
 
-use aws_lc_sys::{
-    i2d_X509_REQ, EVP_sha256, EVP_sha384, EVP_sha512, X509_REQ_add_extensions, X509_REQ_free,
-    X509_REQ_new, X509_REQ_set_pubkey, X509_REQ_set_subject_name, X509_REQ_set_version,
-    X509_REQ_sign, EVP_MD, X509_REQ,
+use crate::{
+    aws_lc_sys::{
+        i2d_X509_REQ, EVP_sha256, EVP_sha384, EVP_sha512, X509_REQ_add_extensions, X509_REQ_free,
+        X509_REQ_new, X509_REQ_set_pubkey, X509_REQ_set_subject_name, X509_REQ_set_version,
+        X509_REQ_sign, EVP_MD, X509_REQ,
+    },
+    ec::EvpPkey,
 };
 use mls_rs_core::crypto::SignatureSecretKey;
 use mls_rs_crypto_traits::Curve;
 
-use crate::{
-    check_int_return, check_non_null, check_res, ec::EvpPkey, ecdsa::AwsLcEcdsa, AwsLcCryptoError,
-};
+use crate::{check_int_return, check_non_null, check_res, ecdsa::AwsLcEcdsa, AwsLcCryptoError};
 
 use super::component::{Stack, X509Extension, X509Name};
 

--- a/mls-rs-crypto-awslc/src/x509/validator.rs
+++ b/mls-rs-crypto-awslc/src/x509/validator.rs
@@ -4,7 +4,7 @@
 
 use std::ffi::{c_long, c_ulong, CStr};
 
-use aws_lc_sys::{
+use crate::aws_lc_sys::{
     time_t, X509_STORE_CTX_free, X509_STORE_CTX_get0_param, X509_STORE_CTX_get_error,
     X509_STORE_CTX_init, X509_STORE_CTX_new, X509_STORE_CTX_set0_trusted_stack, X509_STORE_free,
     X509_STORE_new, X509_VERIFY_PARAM_get_flags, X509_VERIFY_PARAM_set_flags,

--- a/mls-rs-crypto-awslc/src/x509/validator.rs
+++ b/mls-rs-crypto-awslc/src/x509/validator.rs
@@ -4,7 +4,7 @@
 
 use std::ffi::{c_long, c_ulong, CStr};
 
-use crate::aws_lc_sys::{
+use crate::aws_lc_sys_impl::{
     time_t, X509_STORE_CTX_free, X509_STORE_CTX_get0_param, X509_STORE_CTX_get_error,
     X509_STORE_CTX_init, X509_STORE_CTX_new, X509_STORE_CTX_set0_trusted_stack, X509_STORE_free,
     X509_STORE_new, X509_VERIFY_PARAM_get_flags, X509_VERIFY_PARAM_set_flags,


### PR DESCRIPTION
Changes:
* FIPS does not have `X509_get0_pubkey` so it's replaced by `X509_get_pubkey` which differs in requiring `free` of the key
* It seems that aws-lc-rs updated `BIO_number_written` and now it returns `u64` instead of `usize`. This is not the case for FIPS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
