### PR TITLE
Fix bug where client crashes if it has a pending commit and processes a commit removing it

### DIFF
--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1945,9 +1945,9 @@ where
         &self,
         provisional_state: &ProvisionalState,
     ) -> Option<ProposalInfo<RemoveProposal>> {
-        match self.pending_commit {
-            Some(_) => None,
-            None => provisional_state
+        match &self.pending_commit {
+            Some(c) if c.content.content.sender == Sender::NewMemberCommit => None,
+            _ => provisional_state
                 .applied_proposals
                 .removals
                 .iter()

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -850,3 +850,21 @@ async fn external_info_from_commit_allows_to_join() {
 
     alice.process_incoming_message(commit).await.unwrap();
 }
+
+#[test]
+fn can_process_own_removal_if_pending_commit() {
+    let mut groups = get_test_groups(ProtocolVersion::MLS_10, CipherSuite::P256_AES128, 2, false);
+
+    let commit = groups[1]
+        .commit_builder()
+        .remove_member(0)
+        .unwrap()
+        .build()
+        .unwrap();
+
+    groups[0].commit(vec![]).unwrap();
+
+    groups[0]
+        .process_incoming_message(commit.commit_message)
+        .unwrap();
+}


### PR DESCRIPTION
The added test is failing in main with "attempt to subtract with overflow"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
