### PR TITLE
Do not enable modern_sqlite feature

### DIFF
--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-provider-sqlite"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 description = "SQLite based state storage for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -27,7 +27,7 @@ anyhow = "1"
 [features]
 default = ["sqlcipher-bundled"]
 
-sqlite = ["rusqlite/modern_sqlite"]
+sqlite = []
 sqlite-bundled = ["sqlite", "rusqlite/bundled"]
 sqlcipher = ["sqlite", "rusqlite/sqlcipher"]
 sqlcipher-bundled = ["sqlite", "rusqlite/bundled-sqlcipher"]


### PR DESCRIPTION
### Description of changes:

That is a dangerous feature as this allows an easy mismatch between headers built against and the library linked to.

### Call-outs:

No quite sure if that should be considered a breaking change. Strictly speaking, it probably is. Let me know if I should bump the minor version number instead.

### Testing:

Built locally and ran tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
