### PR TITLE
feat(mls-rs): CommitOutput stores an update path flag

### DIFF
--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -122,6 +122,8 @@ pub struct CommitOutput {
     /// Proposals that were received in the prior epoch but not included in the following commit.
     #[cfg(feature = "by_ref_proposal")]
     pub unused_proposals: Vec<crate::mls_rules::ProposalInfo<Proposal>>,
+    /// Indicator that the commit contains a path update
+    pub contains_update_path: bool,
 }
 
 #[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
@@ -824,6 +826,7 @@ where
             welcome_messages,
             ratchet_tree,
             external_commit_group_info,
+            contains_update_path: perform_path_update,
             #[cfg(feature = "by_ref_proposal")]
             unused_proposals: provisional_state.unused_proposals,
         };


### PR DESCRIPTION
### Description of changes:

Expose a flag in `CommitOutput` describing if the commit performs a path update.
This is useful for consumer performing periodic updates to reset their internal timer.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
