### PR TITLE
Add more context to ms rules / identity provider callbacks

### DIFF
--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-core"
-version = "0.19.2"
+version = "0.20.0"
 edition = "2021"
 description = "Core components and traits for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs-core/src/context.rs
+++ b/mls-rs-core/src/context.rs
@@ -2,34 +2,59 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use alloc::vec;
+use crate::{crypto::CipherSuite, extension::ExtensionList, protocol_version::ProtocolVersion};
 use alloc::vec::Vec;
-use core::fmt::{self, Debug};
+use core::{
+    fmt::{self, Debug},
+    ops::Deref,
+};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
-use mls_rs_core::identity::CurrentEpochInfo;
 
-use crate::{cipher_suite::CipherSuite, protocol_version::ProtocolVersion, ExtensionList};
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ConfirmedTranscriptHash(
+    #[mls_codec(with = "mls_rs_codec::byte_vec")]
+    #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
+    Vec<u8>,
+);
 
-use super::ConfirmedTranscriptHash;
+impl Debug for ConfirmedTranscriptHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::debug::pretty_bytes(&self.0)
+            .named("ConfirmedTranscriptHash")
+            .fmt(f)
+    }
+}
+
+impl Deref for ConfirmedTranscriptHash {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for ConfirmedTranscriptHash {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+}
 
 #[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(
-    all(feature = "ffi", not(test)),
-    safer_ffi_gen::ffi_type(clone, opaque)
-)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GroupContext {
     pub protocol_version: ProtocolVersion,
     pub cipher_suite: CipherSuite,
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
-    #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
     pub group_id: Vec<u8>,
     pub epoch: u64,
-    #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::vec_serde"))]
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
-    pub(crate) tree_hash: Vec<u8>,
-    pub(crate) confirmed_transcript_hash: ConfirmedTranscriptHash,
+    pub tree_hash: Vec<u8>,
+    pub confirmed_transcript_hash: ConfirmedTranscriptHash,
     pub extensions: ExtensionList,
 }
 
@@ -38,51 +63,16 @@ impl Debug for GroupContext {
         f.debug_struct("GroupContext")
             .field("protocol_version", &self.protocol_version)
             .field("cipher_suite", &self.cipher_suite)
-            .field(
-                "group_id",
-                &mls_rs_core::debug::pretty_group_id(&self.group_id),
-            )
+            .field("group_id", &crate::debug::pretty_group_id(&self.group_id))
             .field("epoch", &self.epoch)
-            .field(
-                "tree_hash",
-                &mls_rs_core::debug::pretty_bytes(&self.tree_hash),
-            )
+            .field("tree_hash", &crate::debug::pretty_bytes(&self.tree_hash))
             .field("confirmed_transcript_hash", &self.confirmed_transcript_hash)
             .field("extensions", &self.extensions)
             .finish()
     }
 }
 
-impl<'a> From<&'a GroupContext> for CurrentEpochInfo<'a> {
-    fn from(value: &'a GroupContext) -> Self {
-        Self {
-            group_id: &value.group_id,
-            epoch: value.epoch,
-            extensions: &value.extensions,
-        }
-    }
-}
-
-#[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
 impl GroupContext {
-    pub(crate) fn new_group(
-        protocol_version: ProtocolVersion,
-        cipher_suite: CipherSuite,
-        group_id: Vec<u8>,
-        tree_hash: Vec<u8>,
-        extensions: ExtensionList,
-    ) -> Self {
-        GroupContext {
-            protocol_version,
-            cipher_suite,
-            group_id,
-            epoch: 0,
-            tree_hash,
-            confirmed_transcript_hash: ConfirmedTranscriptHash::from(vec![]),
-            extensions,
-        }
-    }
-
     /// Get the current protocol version in use by the group.
     pub fn version(&self) -> ProtocolVersion {
         self.protocol_version

--- a/mls-rs-core/src/context.rs
+++ b/mls-rs-core/src/context.rs
@@ -41,7 +41,7 @@ impl From<Vec<u8>> for ConfirmedTranscriptHash {
     }
 }
 
-#[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(
     all(feature = "ffi", not(test)),

--- a/mls-rs-core/src/context.rs
+++ b/mls-rs-core/src/context.rs
@@ -43,6 +43,10 @@ impl From<Vec<u8>> for ConfirmedTranscriptHash {
 
 #[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    all(feature = "ffi", not(test)),
+    safer_ffi_gen::ffi_type(clone, opaque)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GroupContext {
     pub protocol_version: ProtocolVersion,
@@ -72,6 +76,7 @@ impl Debug for GroupContext {
     }
 }
 
+#[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
 impl GroupContext {
     /// Get the current protocol version in use by the group.
     pub fn version(&self) -> ProtocolVersion {

--- a/mls-rs-core/src/crypto/test_suite.rs
+++ b/mls-rs-core/src/crypto/test_suite.rs
@@ -11,7 +11,7 @@ use super::{
     CipherSuiteProvider, CryptoProvider, HpkeCiphertext, HpkeContextS, HpkePublicKey, HpkeSecretKey,
 };
 
-#[cfg(all(not(mls_build_async), not(target_arch = "wasm32"), feature = "std"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
 const PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/test_data/crypto_provider.json"

--- a/mls-rs-core/src/group.rs
+++ b/mls-rs-core/src/group.rs
@@ -2,10 +2,12 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+mod context;
 mod group_state;
 mod proposal_type;
 mod roster;
 
+pub use context::*;
 pub use group_state::*;
 pub use proposal_type::*;
 pub use roster::*;

--- a/mls-rs-core/src/group/context.rs
+++ b/mls-rs-core/src/group/context.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use crate::{crypto::CipherSuite, extension::ExtensionList, protocol_version::ProtocolVersion};
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use core::{
     fmt::{self, Debug},
     ops::Deref,
@@ -78,6 +78,25 @@ impl Debug for GroupContext {
 
 #[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
 impl GroupContext {
+    /// Create a group context for a new MLS group.
+    pub fn new(
+        protocol_version: ProtocolVersion,
+        cipher_suite: CipherSuite,
+        group_id: Vec<u8>,
+        tree_hash: Vec<u8>,
+        extensions: ExtensionList,
+    ) -> GroupContext {
+        GroupContext {
+            protocol_version,
+            cipher_suite,
+            group_id,
+            epoch: 0,
+            tree_hash,
+            confirmed_transcript_hash: vec![].into(),
+            extensions,
+        }
+    }
+
     /// Get the current protocol version in use by the group.
     pub fn version(&self) -> ProtocolVersion {
         self.protocol_version

--- a/mls-rs-core/src/identity/provider.rs
+++ b/mls-rs-core/src/identity/provider.rs
@@ -2,19 +2,12 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{error::IntoAnyError, extension::ExtensionList, time::MlsTime};
+use crate::{context::GroupContext, error::IntoAnyError, extension::ExtensionList, time::MlsTime};
 #[cfg(mls_build_async)]
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use super::{CredentialType, SigningIdentity};
-
-#[derive(Clone, Debug, Copy)]
-pub struct CurrentEpochInfo<'a> {
-    pub group_id: &'a [u8],
-    pub epoch: u64,
-    pub extensions: &'a ExtensionList,
-}
 
 /// Identity system that can be used to validate a
 /// [`SigningIdentity`](mls-rs-core::identity::SigningIdentity)
@@ -33,7 +26,7 @@ pub trait IdentityProvider: Send + Sync {
         &self,
         signing_identity: &SigningIdentity,
         timestamp: Option<MlsTime>,
-        current_epoch: Option<CurrentEpochInfo<'_>>,
+        current_epoch: Option<&GroupContext>,
         new_extensions: Option<&ExtensionList>,
     ) -> Result<(), Self::Error>;
 

--- a/mls-rs-core/src/identity/provider.rs
+++ b/mls-rs-core/src/identity/provider.rs
@@ -2,7 +2,7 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{context::GroupContext, error::IntoAnyError, extension::ExtensionList, time::MlsTime};
+use crate::{error::IntoAnyError, extension::ExtensionList, group::GroupContext, time::MlsTime};
 #[cfg(mls_build_async)]
 use alloc::boxed::Box;
 use alloc::vec::Vec;

--- a/mls-rs-core/src/identity/provider.rs
+++ b/mls-rs-core/src/identity/provider.rs
@@ -33,7 +33,7 @@ pub trait IdentityProvider: Send + Sync {
         &self,
         signing_identity: &SigningIdentity,
         timestamp: Option<MlsTime>,
-        current_epoch: Option<CurrentEpochInfo>,
+        current_epoch: Option<CurrentEpochInfo<'_>>,
         new_extensions: Option<&ExtensionList>,
     ) -> Result<(), Self::Error>;
 

--- a/mls-rs-core/src/identity/provider.rs
+++ b/mls-rs-core/src/identity/provider.rs
@@ -9,6 +9,13 @@ use alloc::vec::Vec;
 
 use super::{CredentialType, SigningIdentity};
 
+#[derive(Clone, Debug, Copy)]
+pub struct CurrentEpochInfo<'a> {
+    pub group_id: &'a [u8],
+    pub epoch: u64,
+    pub extensions: &'a ExtensionList,
+}
+
 /// Identity system that can be used to validate a
 /// [`SigningIdentity`](mls-rs-core::identity::SigningIdentity)
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
@@ -26,7 +33,8 @@ pub trait IdentityProvider: Send + Sync {
         &self,
         signing_identity: &SigningIdentity,
         timestamp: Option<MlsTime>,
-        extensions: Option<&ExtensionList>,
+        current_epoch: Option<CurrentEpochInfo>,
+        new_extensions: Option<&ExtensionList>,
     ) -> Result<(), Self::Error>;
 
     /// Determine if `signing_identity` is valid for an external sender in

--- a/mls-rs-core/src/identity/provider.rs
+++ b/mls-rs-core/src/identity/provider.rs
@@ -9,6 +9,30 @@ use alloc::vec::Vec;
 
 use super::{CredentialType, SigningIdentity};
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize,))]
+#[non_exhaustive]
+pub enum MemberValidationContext<'a> {
+    ForCommit {
+        current_context: &'a GroupContext,
+        new_extensions: &'a ExtensionList,
+    },
+    ForNewGroup {
+        current_context: &'a GroupContext,
+    },
+    None,
+}
+
+impl<'a> MemberValidationContext<'a> {
+    pub fn new_extensions(&self) -> Option<&ExtensionList> {
+        match self {
+            Self::ForCommit { new_extensions, .. } => Some(*new_extensions),
+            Self::ForNewGroup { current_context } => Some(&current_context.extensions),
+            Self::None => None,
+        }
+    }
+}
+
 /// Identity system that can be used to validate a
 /// [`SigningIdentity`](mls-rs-core::identity::SigningIdentity)
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
@@ -26,8 +50,7 @@ pub trait IdentityProvider: Send + Sync {
         &self,
         signing_identity: &SigningIdentity,
         timestamp: Option<MlsTime>,
-        current_epoch: Option<&GroupContext>,
-        new_extensions: Option<&ExtensionList>,
+        context: MemberValidationContext<'_>,
     ) -> Result<(), Self::Error>;
 
     /// Determine if `signing_identity` is valid for an external sender in

--- a/mls-rs-core/src/lib.rs
+++ b/mls-rs-core/src/lib.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 #[cfg(all(test, target_arch = "wasm32"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
+pub mod context;
 pub mod crypto;
 pub mod debug;
 pub mod error;

--- a/mls-rs-core/src/lib.rs
+++ b/mls-rs-core/src/lib.rs
@@ -9,7 +9,6 @@ extern crate alloc;
 #[cfg(all(test, target_arch = "wasm32"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-pub mod context;
 pub mod crypto;
 pub mod debug;
 pub mod error;

--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-awslc"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 description = "AWS-LC based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -17,18 +17,18 @@ default = ["non-fips"]
 aws-lc-rs = { version = "=1.10.0", default-features = false, features = ["alloc"] }
 aws-lc-sys = { version = "0.22.0", optional = true }
 aws-lc-fips-sys = { version = "0.12.0", optional = true }
-mls-rs-core = { path = "../mls-rs-core", version = "0.19.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.10.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.11.0" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.12.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.20.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.11.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.12.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.13.0" }
 thiserror = "1.0.40"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.10"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.19.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.10.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.20.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.11.0", features = ["test_utils"] }
 futures-test = "0.3.25"
 
 [target.'cfg(mls_build_async)'.dependencies]

--- a/mls-rs-crypto-cryptokit/Cargo.toml
+++ b/mls-rs-crypto-cryptokit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-cryptokit"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "CryptoKit based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -20,12 +20,12 @@ serde_json = "1.0"
 [dev-dependencies]
 hex-literal = "0.4.1"
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.19.0", features = ["test_suite"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.20.0", features = ["test_suite"] }
 
 [dependencies]
 maybe-async = "0.2.10"
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.19.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.11.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.20.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.12.0" }
 thiserror = { version = "1.0.63", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 

--- a/mls-rs-crypto-hpke/Cargo.toml
+++ b/mls-rs-crypto-hpke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-hpke"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "HPKE implementation based on mls-rs-crypto-traits used by mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -15,8 +15,8 @@ std = ["mls-rs-core/std", "mls-rs-crypto-traits/std", "dep:thiserror", "zeroize/
 test_utils = ["mls-rs-core/test_suite"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.19.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.11.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.20.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.12.0" }
 thiserror = { version = "1.0.40", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 cfg-if = "^1"
@@ -28,7 +28,7 @@ serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
 mockall = "0.12"
 hex = { version = "^0.4.3", features = ["serde"] }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.11.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.12.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.26", default-features = false }

--- a/mls-rs-crypto-openssl/Cargo.toml
+++ b/mls-rs-crypto-openssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-openssl"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "OpenSSL based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -14,10 +14,10 @@ default = ["x509"]
 
 [dependencies]
 openssl = { version = "0.10.40" }
-mls-rs-core = { path = "../mls-rs-core", version = "0.19.0" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.12.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.10.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.11.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.20.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.13.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.11.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.12.0" }
 thiserror = "1.0.40"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.10"
@@ -27,8 +27,8 @@ hex = { version = "^0.4.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.19.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.10.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.20.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.11.0", features = ["test_utils"] }
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"

--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-rustcrypto"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 description = "RustCrypto based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -29,9 +29,9 @@ std = [
 ]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.19.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.10.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.11.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.20.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.11.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.12.0" }
 
 thiserror = { version = "1.0.40", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
@@ -59,7 +59,7 @@ ed25519-dalek = { version = "2", default-features = false, features = ["alloc", 
 sec1 = { version = "0.7", default-features = false, features = ["alloc"] }
 
 # X509 feature
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.12.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.13.0" }
 x509-cert = { version = "0.2", optional = true, features = ["std"] }
 spki = { version = "0.7", optional = true, features = ["std", "alloc"] }
 const-oid = { version = "0.9", optional = true, features = ["std"] }
@@ -70,8 +70,8 @@ hex = { version = "^0.4.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.19.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.10.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.20.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.11.0", features = ["test_utils"] }
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"

--- a/mls-rs-crypto-traits/Cargo.toml
+++ b/mls-rs-crypto-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-traits"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Crypto traits required to create a CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -14,7 +14,7 @@ std = ["mls-rs-core/std"]
 default = ["std"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "0.19.0", default-features = false }
+mls-rs-core = { path = "../mls-rs-core", version = "0.20.0", default-features = false }
 mockall = { version = "^0.11", optional = true }
 maybe-async = "0.2.10"
 

--- a/mls-rs-crypto-webcrypto/Cargo.toml
+++ b/mls-rs-crypto-webcrypto/Cargo.toml
@@ -9,9 +9,9 @@ keywords = ["mls", "mls-rs"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["std"], version = "0.19.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, features = ["std"], version = "0.10.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, features = ["std"], version = "0.11.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["std"], version = "0.20.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, features = ["std"], version = "0.11.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, features = ["std"], version = "0.12.0" }
 thiserror = "1.0.40"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.10"
@@ -26,7 +26,7 @@ web-sys = { version = "0.3.64", features = ["Window", "CryptoKey", "CryptoKeyPai
 const-oid = { version = "0.9", features = ["db"] }
 
 [dev-dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "0.19.0", features = ["test_suite"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.20.0", features = ["test_suite"] }
 wasm-bindgen-test = { version = "0.3.26", default-features = false }
 futures-test = "0.3.25"
 serde_json = "^1.0"

--- a/mls-rs-ffi/Cargo.toml
+++ b/mls-rs-ffi/Cargo.toml
@@ -19,9 +19,9 @@ std = ["mls-rs/std", "safer-ffi-gen/std"]
 x509 = ["mls-rs-identity-x509"]
 
 [dependencies]
-mls-rs = { path = "../mls-rs", version = "0.42.0", features = ["ffi"] }
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.10.0", optional = true }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.12.0", optional = true }
+mls-rs = { path = "../mls-rs", version = "0.43.0", features = ["ffi"] }
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.11.0", optional = true }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.13.0", optional = true }
 mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.13.1", default-features = false, optional = true }
 safer-ffi = { version = "0.1.7", default-features = false }
 safer-ffi-gen = { version = "0.9.2", default-features = false }

--- a/mls-rs-identity-x509/Cargo.toml
+++ b/mls-rs-identity-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-identity-x509"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "X509 Identity utilities for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -13,7 +13,7 @@ default = ["std"]
 std = ["mls-rs-core/std", "dep:thiserror"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["x509"], version = "0.19.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["x509"], version = "0.20.0" }
 maybe-async = "0.2.10"
 thiserror = { version = "1.0.40", optional = true }
 

--- a/mls-rs-identity-x509/src/provider.rs
+++ b/mls-rs-identity-x509/src/provider.rs
@@ -9,7 +9,7 @@ use mls_rs_core::{
     crypto::SignaturePublicKey,
     error::IntoAnyError,
     extension::ExtensionList,
-    identity::{CredentialType, IdentityProvider},
+    identity::{CredentialType, CurrentEpochInfo, IdentityProvider},
     time::MlsTime,
 };
 
@@ -147,7 +147,8 @@ where
         &self,
         signing_identity: &mls_rs_core::identity::SigningIdentity,
         timestamp: Option<MlsTime>,
-        _extensions: Option<&ExtensionList>,
+        _: Option<CurrentEpochInfo>,
+        _: Option<&ExtensionList>,
     ) -> Result<(), Self::Error> {
         self.validate(signing_identity, timestamp)
     }

--- a/mls-rs-identity-x509/src/provider.rs
+++ b/mls-rs-identity-x509/src/provider.rs
@@ -147,7 +147,7 @@ where
         &self,
         signing_identity: &mls_rs_core::identity::SigningIdentity,
         timestamp: Option<MlsTime>,
-        _: Option<CurrentEpochInfo>,
+        _: Option<CurrentEpochInfo<'_>>,
         _: Option<&ExtensionList>,
     ) -> Result<(), Self::Error> {
         self.validate(signing_identity, timestamp)

--- a/mls-rs-identity-x509/src/provider.rs
+++ b/mls-rs-identity-x509/src/provider.rs
@@ -6,11 +6,10 @@ use crate::{util::credential_to_chain, CertificateChain, X509IdentityError};
 use alloc::vec;
 use alloc::vec::Vec;
 use mls_rs_core::{
-    context::GroupContext,
     crypto::SignaturePublicKey,
     error::IntoAnyError,
     extension::ExtensionList,
-    identity::{CredentialType, IdentityProvider},
+    identity::{CredentialType, IdentityProvider, MemberValidationContext},
     time::MlsTime,
 };
 
@@ -148,8 +147,7 @@ where
         &self,
         signing_identity: &mls_rs_core::identity::SigningIdentity,
         timestamp: Option<MlsTime>,
-        _: Option<&GroupContext>,
-        _: Option<&ExtensionList>,
+        _: MemberValidationContext<'_>,
     ) -> Result<(), Self::Error> {
         self.validate(signing_identity, timestamp)
     }

--- a/mls-rs-identity-x509/src/provider.rs
+++ b/mls-rs-identity-x509/src/provider.rs
@@ -6,10 +6,11 @@ use crate::{util::credential_to_chain, CertificateChain, X509IdentityError};
 use alloc::vec;
 use alloc::vec::Vec;
 use mls_rs_core::{
+    context::GroupContext,
     crypto::SignaturePublicKey,
     error::IntoAnyError,
     extension::ExtensionList,
-    identity::{CredentialType, CurrentEpochInfo, IdentityProvider},
+    identity::{CredentialType, IdentityProvider},
     time::MlsTime,
 };
 
@@ -147,7 +148,7 @@ where
         &self,
         signing_identity: &mls_rs_core::identity::SigningIdentity,
         timestamp: Option<MlsTime>,
-        _: Option<CurrentEpochInfo<'_>>,
+        _: Option<&GroupContext>,
         _: Option<&ExtensionList>,
     ) -> Result<(), Self::Error> {
         self.validate(signing_identity, timestamp)

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["mls", "mls-rs"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "0.19.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.20.0" }
 thiserror = "1.0.40"
 wasm-bindgen = { version = "0.2", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }

--- a/mls-rs-uniffi/Cargo.toml
+++ b/mls-rs-uniffi/Cargo.toml
@@ -17,9 +17,9 @@ name = "mls_rs_uniffi"
 [dependencies]
 async-trait = "0.1.77"
 maybe-async = "0.2.10"
-mls-rs = { version = "0.42.0", path = "../mls-rs" }
-mls-rs-core = { version = "0.19.0", path = "../mls-rs-core" }
-mls-rs-crypto-openssl = { version = "0.10.0", path = "../mls-rs-crypto-openssl" }
+mls-rs = { version = "0.43.0", path = "../mls-rs" }
+mls-rs-core = { version = "0.20.0", path = "../mls-rs-core" }
+mls-rs-crypto-openssl = { version = "0.11.0", path = "../mls-rs-crypto-openssl" }
 thiserror = "1.0.57"
 uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "eeb785c", version = "0.27.0" }
 

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.42.3"
+version = "0.43.0"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -51,8 +51,8 @@ benchmark_util = ["test_util", "default", "dep:mls-rs-crypto-openssl"]
 fuzz_util = ["test_util", "default", "dep:once_cell", "dep:mls-rs-crypto-openssl"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.19.1" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", default-features = false, version = "0.12.0", optional = true }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.20.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", default-features = false, version = "0.13.0", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 mls-rs-codec = { version = "0.5.2", path = "../mls-rs-codec", default-features = false}
 thiserror = { version = "1.0.40", optional = true }
@@ -64,7 +64,7 @@ maybe-async = { version = "0.2.10" }
 
 # Optional dependencies
 mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.13.0", default-features = false, optional = true }
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", optional = true, version = "0.10.0" }
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", optional = true, version = "0.11.0" }
 # TODO: https://github.com/GoogleChromeLabs/wasm-bindgen-rayon
 rayon = { version = "1", optional = true }
 arbitrary = { version = "1", features = ["derive"], optional = true }
@@ -106,7 +106,7 @@ mls-rs-crypto-webcrypto = { path = "../mls-rs-crypto-webcrypto", version = "0.5.
 criterion = { version = "0.5.1", default-features = false, features = ["plotters", "cargo_bench_support", "async_futures", "html_reports"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.10.0"}
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.11.0"}
 criterion = { version = "0.5.1", features = ["async_futures", "html_reports"] }
 
 [[example]]

--- a/mls-rs/examples/custom.rs
+++ b/mls-rs/examples/custom.rs
@@ -44,10 +44,7 @@ use mls_rs_core::{
     error::IntoAnyError,
     extension::{ExtensionError, ExtensionType, MlsCodecExtension},
     group::ProposalType,
-    identity::{
-        Credential, CredentialType, CurrentEpochInfo, CustomCredential, MlsCredential,
-        SigningIdentity,
-    },
+    identity::{Credential, CredentialType, CustomCredential, MlsCredential, SigningIdentity},
     time::MlsTime,
 };
 
@@ -209,7 +206,7 @@ impl IdentityProvider for CustomIdentityProvider {
         &self,
         signing_identity: &SigningIdentity,
         _: Option<MlsTime>,
-        _: Option<CurrentEpochInfo<'_>>,
+        _: Option<&GroupContext>,
         new_extensions: Option<&ExtensionList>,
     ) -> Result<(), Self::Error> {
         let Some(extensions) = new_extensions else {

--- a/mls-rs/examples/custom.rs
+++ b/mls-rs/examples/custom.rs
@@ -209,7 +209,7 @@ impl IdentityProvider for CustomIdentityProvider {
         &self,
         signing_identity: &SigningIdentity,
         _: Option<MlsTime>,
-        _: Option<CurrentEpochInfo>,
+        _: Option<CurrentEpochInfo<'_>>,
         new_extensions: Option<&ExtensionList>,
     ) -> Result<(), Self::Error> {
         let Some(extensions) = new_extensions else {

--- a/mls-rs/examples/custom.rs
+++ b/mls-rs/examples/custom.rs
@@ -29,7 +29,7 @@ use mls_rs::{
     error::MlsError,
     group::{
         proposal::{MlsCustomProposal, Proposal},
-        Roster, Sender,
+        GroupContext, Roster, Sender,
     },
     mls_rules::{
         CommitDirection, CommitOptions, CommitSource, EncryptionOptions, ProposalBundle,
@@ -44,7 +44,10 @@ use mls_rs_core::{
     error::IntoAnyError,
     extension::{ExtensionError, ExtensionType, MlsCodecExtension},
     group::ProposalType,
-    identity::{Credential, CredentialType, CustomCredential, MlsCredential, SigningIdentity},
+    identity::{
+        Credential, CredentialType, CurrentEpochInfo, CustomCredential, MlsCredential,
+        SigningIdentity,
+    },
     time::MlsTime,
 };
 
@@ -128,12 +131,16 @@ impl MlsRules for CustomMlsRules {
         _: CommitDirection,
         _: CommitSource,
         _: &Roster,
-        extension_list: &ExtensionList,
+        context: &GroupContext,
         mut proposals: ProposalBundle,
     ) -> Result<ProposalBundle, Self::Error> {
         // Find our extension
-        let mut roster: RosterExtension =
-            extension_list.get_as().ok().flatten().ok_or(CustomError)?;
+        let mut roster: RosterExtension = context
+            .extensions
+            .get_as()
+            .ok()
+            .flatten()
+            .ok_or(CustomError)?;
 
         // Find AddUser proposals
         let add_user_proposals = proposals
@@ -149,7 +156,7 @@ impl MlsRules for CustomMlsRules {
         }
 
         // Issue GroupContextExtensions proposal to modify our roster (eventually we don't have to do this if there were no AddUser proposals)
-        let mut new_extensions = extension_list.clone();
+        let mut new_extensions = context.extensions.clone();
         new_extensions.set_from(roster)?;
         let gce_proposal = Proposal::GroupContextExtensions(new_extensions);
         proposals.add(gce_proposal, Sender::Member(0), ProposalSource::Local);
@@ -160,7 +167,7 @@ impl MlsRules for CustomMlsRules {
     fn commit_options(
         &self,
         _: &Roster,
-        _: &ExtensionList,
+        _: &GroupContext,
         _: &ProposalBundle,
     ) -> Result<CommitOptions, Self::Error> {
         Ok(CommitOptions::new())
@@ -169,7 +176,7 @@ impl MlsRules for CustomMlsRules {
     fn encryption_options(
         &self,
         _: &Roster,
-        _: &ExtensionList,
+        _: &GroupContext,
     ) -> Result<EncryptionOptions, Self::Error> {
         Ok(EncryptionOptions::new(false, PaddingMode::None))
     }
@@ -202,9 +209,10 @@ impl IdentityProvider for CustomIdentityProvider {
         &self,
         signing_identity: &SigningIdentity,
         _: Option<MlsTime>,
-        extensions: Option<&ExtensionList>,
+        _: Option<CurrentEpochInfo>,
+        new_extensions: Option<&ExtensionList>,
     ) -> Result<(), Self::Error> {
-        let Some(extensions) = extensions else {
+        let Some(extensions) = new_extensions else {
             return Ok(());
         };
 

--- a/mls-rs/examples/custom.rs
+++ b/mls-rs/examples/custom.rs
@@ -44,7 +44,10 @@ use mls_rs_core::{
     error::IntoAnyError,
     extension::{ExtensionError, ExtensionType, MlsCodecExtension},
     group::ProposalType,
-    identity::{Credential, CredentialType, CustomCredential, MlsCredential, SigningIdentity},
+    identity::{
+        Credential, CredentialType, CustomCredential, MemberValidationContext, MlsCredential,
+        SigningIdentity,
+    },
     time::MlsTime,
 };
 
@@ -206,10 +209,9 @@ impl IdentityProvider for CustomIdentityProvider {
         &self,
         signing_identity: &SigningIdentity,
         _: Option<MlsTime>,
-        _: Option<&GroupContext>,
-        new_extensions: Option<&ExtensionList>,
+        context: MemberValidationContext<'_>,
     ) -> Result<(), Self::Error> {
-        let Some(extensions) = new_extensions else {
+        let Some(extensions) = context.new_extensions() else {
             return Ok(());
         };
 

--- a/mls-rs/fuzz/Cargo.toml
+++ b/mls-rs/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-mls-rs = { version = "0.42.0", path = "..", features = ["arbitrary", "fuzz_util"] }
+mls-rs = { version = "0.43.0", path = "..", features = ["arbitrary", "fuzz_util"] }
 futures = "0.3.25"
 libfuzzer-sys = "0.4"
 once_cell = "1.13.0"

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -27,7 +27,7 @@ use mls_rs_core::crypto::{CryptoProvider, SignatureSecretKey};
 use mls_rs_core::error::{AnyError, IntoAnyError};
 use mls_rs_core::extension::{ExtensionError, ExtensionList, ExtensionType};
 use mls_rs_core::group::{GroupStateStorage, ProposalType};
-use mls_rs_core::identity::{CredentialType, IdentityProvider};
+use mls_rs_core::identity::{CredentialType, IdentityProvider, MemberValidationContext};
 use mls_rs_core::key_package::KeyPackageStorage;
 
 use crate::group::external_commit::ExternalCommitBuilder;
@@ -597,7 +597,11 @@ where
         validate_group_info_joiner(group_info_message.version, group_info, signer, &id, &cs)
             .await?;
 
-        id.validate_member(signer, None, Some(&group_info.group_context), None)
+        let context = MemberValidationContext::ForNewGroup {
+            current_context: &group_info.group_context,
+        };
+
+        id.validate_member(signer, None, context)
             .await
             .map_err(|e| MlsError::IdentityProviderError(e.into_any_error()))?;
 

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -597,7 +597,7 @@ where
         validate_group_info_joiner(group_info_message.version, group_info, signer, &id, &cs)
             .await?;
 
-        id.validate_member(signer, None, Some((&group_info.group_context).into()), None)
+        id.validate_member(signer, None, Some(&group_info.group_context), None)
             .await
             .map_err(|e| MlsError::IdentityProviderError(e.into_any_error()))?;
 

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -597,7 +597,7 @@ where
         validate_group_info_joiner(group_info_message.version, group_info, signer, &id, &cs)
             .await?;
 
-        id.validate_member(signer, None, Some(&group_info.group_context.extensions))
+        id.validate_member(signer, None, Some((&group_info.group_context).into()), None)
             .await
             .map_err(|e| MlsError::IdentityProviderError(e.into_any_error()))?;
 

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -910,7 +910,7 @@ mod tests {
     use mls_rs_core::{
         error::IntoAnyError,
         extension::ExtensionType,
-        identity::{CredentialType, IdentityProvider},
+        identity::{CredentialType, CurrentEpochInfo, IdentityProvider},
         time::MlsTime,
     };
 
@@ -1586,9 +1586,10 @@ mod tests {
             &self,
             identity: &SigningIdentity,
             timestamp: Option<MlsTime>,
-            extensions: Option<&ExtensionList>,
+            _: Option<CurrentEpochInfo>,
+            new_extensions: Option<&ExtensionList>,
         ) -> Result<(), Self::Error> {
-            self.starts_with_foo(identity, timestamp, extensions)
+            self.starts_with_foo(identity, timestamp, new_extensions)
                 .await
                 .then_some(())
                 .ok_or(IdentityProviderWithExtensionError {})

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -553,7 +553,7 @@ where
         let commit_options = mls_rules
             .commit_options(
                 &provisional_state.public_tree.roster(),
-                &provisional_group_context.extensions,
+                &provisional_group_context,
                 &provisional_state.applied_proposals,
             )
             .map_err(|e| MlsError::MlsRulesError(e.into_any_error()))?;

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -1586,7 +1586,7 @@ mod tests {
             &self,
             identity: &SigningIdentity,
             timestamp: Option<MlsTime>,
-            _: Option<CurrentEpochInfo>,
+            _: Option<CurrentEpochInfo<'_>>,
             new_extensions: Option<&ExtensionList>,
         ) -> Result<(), Self::Error> {
             self.starts_with_foo(identity, timestamp, new_extensions)

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -46,8 +46,7 @@ use super::{
     message_signature::AuthenticatedContent,
     mls_rules::CommitDirection,
     proposal::{Proposal, ProposalOrRef},
-    ConfirmedTranscriptHash, EncryptedGroupSecrets, ExportedTree, Group, GroupContext, GroupInfo,
-    Welcome,
+    EncryptedGroupSecrets, ExportedTree, Group, GroupContext, GroupInfo, Welcome,
 };
 
 #[cfg(not(feature = "by_ref_proposal"))]
@@ -653,7 +652,7 @@ where
 
         // Use the signature, the commit_secret and the psk_secret to advance the key schedule and
         // compute the confirmation_tag value in the MlsPlaintext.
-        let confirmed_transcript_hash = ConfirmedTranscriptHash::create(
+        let confirmed_transcript_hash = super::transcript_hash::create(
             self.cipher_suite_provider(),
             &self.state.interim_transcript_hash,
             &auth_content,
@@ -910,7 +909,7 @@ mod tests {
     use mls_rs_core::{
         error::IntoAnyError,
         extension::ExtensionType,
-        identity::{CredentialType, CurrentEpochInfo, IdentityProvider},
+        identity::{CredentialType, IdentityProvider},
         time::MlsTime,
     };
 
@@ -1586,7 +1585,7 @@ mod tests {
             &self,
             identity: &SigningIdentity,
             timestamp: Option<MlsTime>,
-            _: Option<CurrentEpochInfo<'_>>,
+            _: Option<&GroupContext>,
             new_extensions: Option<&ExtensionList>,
         ) -> Result<(), Self::Error> {
             self.starts_with_foo(identity, timestamp, new_extensions)

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -909,7 +909,7 @@ mod tests {
     use mls_rs_core::{
         error::IntoAnyError,
         extension::ExtensionType,
-        identity::{CredentialType, IdentityProvider},
+        identity::{CredentialType, IdentityProvider, MemberValidationContext},
         time::MlsTime,
     };
 
@@ -1585,10 +1585,9 @@ mod tests {
             &self,
             identity: &SigningIdentity,
             timestamp: Option<MlsTime>,
-            _: Option<&GroupContext>,
-            new_extensions: Option<&ExtensionList>,
+            context: MemberValidationContext<'_>,
         ) -> Result<(), Self::Error> {
-            self.starts_with_foo(identity, timestamp, new_extensions)
+            self.starts_with_foo(identity, timestamp, context.new_extensions())
                 .await
                 .then_some(())
                 .ok_or(IdentityProviderWithExtensionError {})

--- a/mls-rs/src/group/confirmation_tag.rs
+++ b/mls-rs/src/group/confirmation_tag.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 use crate::CipherSuiteProvider;
-use crate::{client::MlsError, group::transcript_hash::ConfirmedTranscriptHash};
+use crate::{client::MlsError, group::ConfirmedTranscriptHash};
 use alloc::vec::Vec;
 use core::{
     fmt::{self, Debug},

--- a/mls-rs/src/group/context.rs
+++ b/mls-rs/src/group/context.rs
@@ -6,6 +6,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
+use mls_rs_core::identity::CurrentEpochInfo;
 
 use crate::{cipher_suite::CipherSuite, protocol_version::ProtocolVersion, ExtensionList};
 
@@ -49,6 +50,16 @@ impl Debug for GroupContext {
             .field("confirmed_transcript_hash", &self.confirmed_transcript_hash)
             .field("extensions", &self.extensions)
             .finish()
+    }
+}
+
+impl<'a> From<&'a GroupContext> for CurrentEpochInfo<'a> {
+    fn from(value: &'a GroupContext) -> Self {
+        Self {
+            group_id: &value.group_id,
+            epoch: value.epoch,
+            extensions: &value.extensions,
+        }
     }
 }
 

--- a/mls-rs/src/group/group_info.rs
+++ b/mls-rs/src/group/group_info.rs
@@ -41,7 +41,6 @@ impl Debug for GroupInfo {
     }
 }
 
-#[cfg_attr(all(feature = "ffi", not(test)), ::safer_ffi_gen::safer_ffi_gen)]
 impl GroupInfo {
     /// Group context.
     pub fn group_context(&self) -> &GroupContext {

--- a/mls-rs/src/group/message_processor.rs
+++ b/mls-rs/src/group/message_processor.rs
@@ -903,7 +903,7 @@ pub(crate) async fn validate_key_package<C: CipherSuiteProvider, I: IdentityProv
     cs: &C,
     id: &I,
 ) -> Result<(), MlsError> {
-    let validator = LeafNodeValidator::new_with_context(cs, id, MemberValidationContext::None);
+    let validator = LeafNodeValidator::new(cs, id, MemberValidationContext::None);
 
     #[cfg(feature = "std")]
     let context = Some(MlsTime::now());

--- a/mls-rs/src/group/message_processor.rs
+++ b/mls-rs/src/group/message_processor.rs
@@ -35,7 +35,9 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 use mls_rs_core::{
-    identity::IdentityProvider, protocol_version::ProtocolVersion, psk::PreSharedKeyStorage,
+    identity::{IdentityProvider, MemberValidationContext},
+    protocol_version::ProtocolVersion,
+    psk::PreSharedKeyStorage,
 };
 
 #[cfg(feature = "by_ref_proposal")]
@@ -668,6 +670,22 @@ pub(crate) trait MessageProcessor: Send + Sync {
             });
         }
 
+        let update_path = match commit.path {
+            Some(update_path) => Some(
+                validate_update_path(
+                    &self.identity_provider(),
+                    self.cipher_suite_provider(),
+                    update_path,
+                    &provisional_state,
+                    sender,
+                    time_sent,
+                    &group_state.context,
+                )
+                .await?,
+            ),
+            None => None,
+        };
+
         let commit_effect =
             if let Some(reinit) = provisional_state.applied_proposals.reinitializations.pop() {
                 self.group_state_mut().pending_reinit = Some(reinit.proposal.clone());
@@ -678,21 +696,6 @@ pub(crate) trait MessageProcessor: Send + Sync {
                     &provisional_state,
                 )))
             };
-
-        let update_path = match commit.path {
-            Some(update_path) => Some(
-                validate_update_path(
-                    &self.identity_provider(),
-                    self.cipher_suite_provider(),
-                    update_path,
-                    &provisional_state,
-                    sender,
-                    time_sent,
-                )
-                .await?,
-            ),
-            None => None,
-        };
 
         let new_secrets = match update_path {
             Some(update_path) => {
@@ -900,7 +903,7 @@ pub(crate) async fn validate_key_package<C: CipherSuiteProvider, I: IdentityProv
     cs: &C,
     id: &I,
 ) -> Result<(), MlsError> {
-    let validator = LeafNodeValidator::new(cs, id, None);
+    let validator = LeafNodeValidator::new_with_context(cs, id, MemberValidationContext::None);
 
     #[cfg(feature = "std")]
     let context = Some(MlsTime::now());

--- a/mls-rs/src/group/mls_rules.rs
+++ b/mls-rs/src/group/mls_rules.rs
@@ -143,7 +143,7 @@ pub trait MlsRules: Send + Sync {
         direction: CommitDirection,
         source: CommitSource,
         current_roster: &Roster,
-        context: &GroupContext,
+        current_context: &GroupContext,
         proposals: ProposalBundle,
     ) -> Result<ProposalBundle, Self::Error>;
 

--- a/mls-rs/src/group/mls_rules.rs
+++ b/mls-rs/src/group/mls_rules.rs
@@ -12,9 +12,9 @@ use crate::{
 
 use alloc::boxed::Box;
 use core::convert::Infallible;
-use mls_rs_core::{
-    error::IntoAnyError, extension::ExtensionList, group::Member, identity::SigningIdentity,
-};
+use mls_rs_core::{error::IntoAnyError, group::Member, identity::SigningIdentity};
+
+use super::GroupContext;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CommitDirection {
@@ -143,7 +143,7 @@ pub trait MlsRules: Send + Sync {
         direction: CommitDirection,
         source: CommitSource,
         current_roster: &Roster,
-        extension_list: &ExtensionList,
+        context: &GroupContext,
         proposals: ProposalBundle,
     ) -> Result<ProposalBundle, Self::Error>;
 
@@ -156,7 +156,7 @@ pub trait MlsRules: Send + Sync {
     fn commit_options(
         &self,
         new_roster: &Roster,
-        new_extension_list: &ExtensionList,
+        new_context: &GroupContext,
         proposals: &ProposalBundle,
     ) -> Result<CommitOptions, Self::Error>;
 
@@ -168,7 +168,7 @@ pub trait MlsRules: Send + Sync {
     fn encryption_options(
         &self,
         current_roster: &Roster,
-        current_extension_list: &ExtensionList,
+        current_context: &GroupContext,
     ) -> Result<EncryptionOptions, Self::Error>;
 }
 
@@ -185,29 +185,29 @@ macro_rules! delegate_mls_rules {
                 direction: CommitDirection,
                 source: CommitSource,
                 current_roster: &Roster,
-                extension_list: &ExtensionList,
+                context: &GroupContext,
                 proposals: ProposalBundle,
             ) -> Result<ProposalBundle, Self::Error> {
                 (**self)
-                    .filter_proposals(direction, source, current_roster, extension_list, proposals)
+                    .filter_proposals(direction, source, current_roster, context, proposals)
                     .await
             }
 
             fn commit_options(
                 &self,
                 roster: &Roster,
-                extension_list: &ExtensionList,
+                context: &GroupContext,
                 proposals: &ProposalBundle,
             ) -> Result<CommitOptions, Self::Error> {
-                (**self).commit_options(roster, extension_list, proposals)
+                (**self).commit_options(roster, context, proposals)
             }
 
             fn encryption_options(
                 &self,
                 roster: &Roster,
-                extension_list: &ExtensionList,
+                context: &GroupContext,
             ) -> Result<EncryptionOptions, Self::Error> {
-                (**self).encryption_options(roster, extension_list)
+                (**self).encryption_options(roster, context)
             }
         }
     };
@@ -258,7 +258,7 @@ impl MlsRules for DefaultMlsRules {
         _direction: CommitDirection,
         _source: CommitSource,
         _current_roster: &Roster,
-        _extension_list: &ExtensionList,
+        _: &GroupContext,
         proposals: ProposalBundle,
     ) -> Result<ProposalBundle, Self::Error> {
         Ok(proposals)
@@ -267,7 +267,7 @@ impl MlsRules for DefaultMlsRules {
     fn commit_options(
         &self,
         _: &Roster,
-        _: &ExtensionList,
+        _: &GroupContext,
         _: &ProposalBundle,
     ) -> Result<CommitOptions, Self::Error> {
         Ok(self.commit_options)
@@ -276,7 +276,7 @@ impl MlsRules for DefaultMlsRules {
     fn encryption_options(
         &self,
         _: &Roster,
-        _: &ExtensionList,
+        _: &GroupContext,
     ) -> Result<EncryptionOptions, Self::Error> {
         Ok(self.encryption_options)
     }

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1511,7 +1511,7 @@ where
     pub(crate) fn encryption_options(&self) -> Result<EncryptionOptions, MlsError> {
         self.config
             .mls_rules()
-            .encryption_options(&self.roster(), self.group_context().extensions())
+            .encryption_options(&self.roster(), self.group_context())
             .map_err(|e| MlsError::MlsRulesError(e.into_any_error()))
     }
 

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -9,6 +9,7 @@ use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 #[cfg(feature = "last_resort_key_package_ext")]
 use mls_rs_core::extension::MlsExtension;
+use mls_rs_core::identity::MemberValidationContext;
 use mls_rs_core::secret::Secret;
 use mls_rs_core::time::MlsTime;
 
@@ -336,11 +337,14 @@ where
 
         let identity_provider = config.identity_provider();
 
-        let leaf_node_validator = LeafNodeValidator::new_for_commit_validation(
+        let member_validation_context = MemberValidationContext::ForNewGroup {
+            current_context: &context,
+        };
+
+        let leaf_node_validator = LeafNodeValidator::new_with_context(
             &cipher_suite_provider,
             &identity_provider,
-            Some(&context),
-            &context.extensions,
+            member_validation_context,
         );
 
         leaf_node_validator

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -341,7 +341,7 @@ where
             current_context: &context,
         };
 
-        let leaf_node_validator = LeafNodeValidator::new_with_context(
+        let leaf_node_validator = LeafNodeValidator::new(
             &cipher_suite_provider,
             &identity_provider,
             member_validation_context,

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -27,13 +27,11 @@ use crate::psk::PreSharedKeyID;
 use crate::signer::Signable;
 use crate::tree_kem::hpke_encryption::HpkeEncryptable;
 use crate::tree_kem::kem::TreeKem;
+use crate::tree_kem::leaf_node::LeafNode;
+use crate::tree_kem::leaf_node_validator::{LeafNodeValidator, ValidationContext};
 use crate::tree_kem::node::LeafIndex;
 use crate::tree_kem::path_secret::PathSecret;
 pub use crate::tree_kem::Capabilities;
-use crate::tree_kem::{
-    leaf_node::LeafNode,
-    leaf_node_validator::{LeafNodeValidator, ValidationContext},
-};
 use crate::tree_kem::{math as tree_math, ValidatedUpdatePath};
 use crate::tree_kem::{TreeKemPrivate, TreeKemPublic};
 use crate::{CipherSuiteProvider, CryptoProvider};
@@ -313,10 +311,11 @@ where
 
         let identity_provider = config.identity_provider();
 
-        let leaf_node_validator = LeafNodeValidator::new(
+        let leaf_node_validator = LeafNodeValidator::new_for_commit_validation(
             &cipher_suite_provider,
             &identity_provider,
-            Some(&group_context_extensions),
+            None,
+            &group_context_extensions,
         );
 
         leaf_node_validator
@@ -4216,7 +4215,7 @@ mod tests {
         fn commit_options(
             &self,
             _: &Roster,
-            _: &ExtensionList,
+            _: &GroupContext,
             proposals: &ProposalBundle,
         ) -> Result<CommitOptions, MlsError> {
             Ok(CommitOptions::default().with_path_required(
@@ -4227,7 +4226,7 @@ mod tests {
         fn encryption_options(
             &self,
             _: &Roster,
-            _: &ExtensionList,
+            _: &GroupContext,
         ) -> Result<crate::mls_rules::EncryptionOptions, MlsError> {
             Ok(Default::default())
         }
@@ -4237,7 +4236,7 @@ mod tests {
             _: CommitDirection,
             sender: CommitSource,
             _: &Roster,
-            _: &ExtensionList,
+            _: &GroupContext,
             proposals: ProposalBundle,
         ) -> Result<ProposalBundle, MlsError> {
             let is_external = matches!(sender, CommitSource::NewMember(_));

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -96,10 +96,10 @@ pub use group_info::GroupInfo;
 
 pub use self::framing::{ContentType, Sender};
 pub use commit::*;
-pub use context::GroupContext;
+pub use mls_rs_core::context::GroupContext;
 pub use roster::*;
 
-pub(crate) use transcript_hash::ConfirmedTranscriptHash;
+pub(crate) use mls_rs_core::context::ConfirmedTranscriptHash;
 pub(crate) use util::*;
 
 #[cfg(all(feature = "by_ref_proposal", feature = "external_client"))]
@@ -110,7 +110,6 @@ mod ciphertext_processor;
 
 mod commit;
 pub(crate) mod confirmation_tag;
-mod context;
 pub(crate) mod epoch;
 pub(crate) mod framing;
 mod group_info;
@@ -338,13 +337,15 @@ where
                 .map_err(|e| MlsError::CryptoProviderError(e.into_any_error()))
         })?;
 
-        let context = GroupContext::new_group(
+        let context = GroupContext {
             protocol_version,
             cipher_suite,
             group_id,
+            epoch: 0,
             tree_hash,
-            group_context_extensions,
-        );
+            confirmed_transcript_hash: vec![].into(),
+            extensions: group_context_extensions,
+        };
 
         let state_repo = GroupStateRepository::new(
             #[cfg(feature = "prior_epoch")]

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -97,10 +97,10 @@ pub use group_info::GroupInfo;
 
 pub use self::framing::{ContentType, Sender};
 pub use commit::*;
-pub use mls_rs_core::context::GroupContext;
+pub use mls_rs_core::group::GroupContext;
 pub use roster::*;
 
-pub(crate) use mls_rs_core::context::ConfirmedTranscriptHash;
+pub(crate) use mls_rs_core::group::ConfirmedTranscriptHash;
 pub(crate) use util::*;
 
 #[cfg(all(feature = "by_ref_proposal", feature = "external_client"))]
@@ -325,15 +325,13 @@ where
                 .map_err(|e| MlsError::CryptoProviderError(e.into_any_error()))
         })?;
 
-        let context = GroupContext {
+        let context = GroupContext::new(
             protocol_version,
             cipher_suite,
             group_id,
-            epoch: 0,
             tree_hash,
-            confirmed_transcript_hash: vec![].into(),
-            extensions: group_context_extensions,
-        };
+            group_context_extensions,
+        );
 
         let identity_provider = config.identity_provider();
 

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -287,7 +287,7 @@ impl GroupState {
         prepare_proposals_for_mls_rules(&mut proposals, direction, &self.public_tree)?;
 
         proposals = user_rules
-            .filter_proposals(direction, origin, &roster, group_extensions, proposals)
+            .filter_proposals(direction, origin, &roster, &self.context, proposals)
             .await
             .map_err(|e| MlsError::MlsRulesError(e.into_any_error()))?;
 

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -264,7 +264,6 @@ impl GroupState {
         CSP: CipherSuiteProvider,
     {
         let roster = self.public_tree.roster();
-        let group_extensions = &self.context.extensions;
 
         #[cfg(feature = "by_ref_proposal")]
         let all_proposals = proposals.clone();
@@ -293,14 +292,11 @@ impl GroupState {
 
         let applier = ProposalApplier::new(
             &self.public_tree,
-            self.context.protocol_version,
             cipher_suite_provider,
-            group_extensions,
+            &self.context,
             external_leaf,
             identity_provider,
             psk_storage,
-            #[cfg(feature = "by_ref_proposal")]
-            &self.context.group_id,
         );
 
         #[cfg(feature = "by_ref_proposal")]
@@ -665,8 +661,8 @@ mod tests {
     use crate::group::proposal_ref::test_utils::auth_content_from_proposal;
     use crate::group::proposal_ref::ProposalRef;
     use crate::group::{
-        AddProposal, AuthenticatedContent, Content, ExternalInit, Proposal, ProposalOrRef,
-        ReInitProposal, RemoveProposal, Roster, Sender, UpdateProposal,
+        AddProposal, AuthenticatedContent, Content, ExternalInit, GroupContext, Proposal,
+        ProposalOrRef, ReInitProposal, RemoveProposal, Roster, Sender, UpdateProposal,
     };
     use crate::key_package::test_utils::test_key_package_with_signer;
     use crate::signer::Signable;
@@ -3885,7 +3881,7 @@ mod tests {
                 _: CommitDirection,
                 _: CommitSource,
                 _: &Roster,
-                _: &ExtensionList,
+                _: &GroupContext,
                 mut proposals: ProposalBundle,
             ) -> Result<ProposalBundle, Self::Error> {
                 proposals.group_context_extensions.clear();
@@ -3896,7 +3892,7 @@ mod tests {
             fn commit_options(
                 &self,
                 _: &Roster,
-                _: &ExtensionList,
+                _: &GroupContext,
                 _: &ProposalBundle,
             ) -> Result<CommitOptions, Self::Error> {
                 Ok(Default::default())
@@ -3906,7 +3902,7 @@ mod tests {
             fn encryption_options(
                 &self,
                 _: &Roster,
-                _: &ExtensionList,
+                _: &GroupContext,
             ) -> Result<EncryptionOptions, Self::Error> {
                 Ok(Default::default())
             }
@@ -3937,7 +3933,7 @@ mod tests {
             _: CommitDirection,
             _: CommitSource,
             _: &Roster,
-            _: &ExtensionList,
+            _: &GroupContext,
             _: ProposalBundle,
         ) -> Result<ProposalBundle, Self::Error> {
             Err(MlsError::InvalidSignature)
@@ -3947,7 +3943,7 @@ mod tests {
         fn commit_options(
             &self,
             _: &Roster,
-            _: &ExtensionList,
+            _: &GroupContext,
             _: &ProposalBundle,
         ) -> Result<CommitOptions, Self::Error> {
             Ok(Default::default())
@@ -3957,7 +3953,7 @@ mod tests {
         fn encryption_options(
             &self,
             _: &Roster,
-            _: &ExtensionList,
+            _: &GroupContext,
         ) -> Result<EncryptionOptions, Self::Error> {
             Ok(Default::default())
         }
@@ -3978,7 +3974,7 @@ mod tests {
             _: CommitDirection,
             _: CommitSource,
             _: &Roster,
-            _: &ExtensionList,
+            _: &GroupContext,
             mut proposals: ProposalBundle,
         ) -> Result<ProposalBundle, Self::Error> {
             for proposal in self.to_inject.iter().cloned() {
@@ -3992,7 +3988,7 @@ mod tests {
         fn commit_options(
             &self,
             _: &Roster,
-            _: &ExtensionList,
+            _: &GroupContext,
             _: &ProposalBundle,
         ) -> Result<CommitOptions, Self::Error> {
             Ok(Default::default())
@@ -4002,7 +3998,7 @@ mod tests {
         fn encryption_options(
             &self,
             _: &Roster,
-            _: &ExtensionList,
+            _: &GroupContext,
         ) -> Result<EncryptionOptions, Self::Error> {
             Ok(Default::default())
         }

--- a/mls-rs/src/group/proposal_filter/filtering.rs
+++ b/mls-rs/src/group/proposal_filter/filtering.rs
@@ -181,10 +181,10 @@ where
     ) -> Result<ProposalBundle, MlsError> {
         let member_validation_context = MemberValidationContext::ForCommit {
             current_context: self.original_context,
-            new_extensions: &group_extensions_in_use,
+            new_extensions: group_extensions_in_use,
         };
 
-        let leaf_node_validator = &LeafNodeValidator::new_with_context(
+        let leaf_node_validator = &LeafNodeValidator::new(
             self.cipher_suite_provider,
             self.identity_provider,
             member_validation_context,

--- a/mls-rs/src/group/proposal_filter/filtering.rs
+++ b/mls-rs/src/group/proposal_filter/filtering.rs
@@ -139,11 +139,11 @@ where
         &self,
         strategy: FilterStrategy,
         proposals: ProposalBundle,
-        group_extensions_in_use: &ExtensionList,
+        new_extensions: &ExtensionList,
         commit_time: Option<MlsTime>,
     ) -> Result<ApplyProposalsOutput, MlsError> {
         let mut applied_proposals = self
-            .validate_new_nodes(strategy, proposals, group_extensions_in_use, commit_time)
+            .validate_new_nodes(strategy, proposals, new_extensions, commit_time)
             .await?;
 
         let mut new_tree = self.original_tree.clone();
@@ -151,7 +151,7 @@ where
         let added = new_tree
             .batch_edit(
                 &mut applied_proposals,
-                group_extensions_in_use,
+                new_extensions,
                 self.identity_provider,
                 self.cipher_suite_provider,
                 strategy.is_ignore(),
@@ -176,12 +176,12 @@ where
         &self,
         strategy: FilterStrategy,
         mut proposals: ProposalBundle,
-        group_extensions_in_use: &ExtensionList,
+        new_extensions: &ExtensionList,
         commit_time: Option<MlsTime>,
     ) -> Result<ProposalBundle, MlsError> {
         let member_validation_context = MemberValidationContext::ForCommit {
             current_context: self.original_context,
-            new_extensions: group_extensions_in_use,
+            new_extensions,
         };
 
         let leaf_node_validator = &LeafNodeValidator::new(
@@ -218,7 +218,7 @@ where
                         .valid_successor(
                             &old_leaf.signing_identity,
                             &leaf.signing_identity,
-                            group_extensions_in_use,
+                            new_extensions,
                         )
                         .await
                         .map_err(|e| MlsError::IdentityProviderError(e.into_any_error()))

--- a/mls-rs/src/group/proposal_filter/filtering_common.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_common.rs
@@ -25,7 +25,7 @@ use crate::extension::{MlsExtension, RequiredCapabilitiesExt};
 #[cfg(feature = "by_ref_proposal")]
 use crate::extension::ExternalSendersExt;
 
-use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::{error::IntoAnyError, identity::MemberValidationContext};
 
 use alloc::vec::Vec;
 use mls_rs_core::{identity::IdentityProvider, psk::PreSharedKeyStorage};
@@ -229,11 +229,15 @@ where
                 .has_extension(ExternalSendersExt::extension_type());
 
         let new_capabilities_supported = if must_check {
-            let leaf_validator = LeafNodeValidator::new_for_commit_validation(
+            let member_validation_context = MemberValidationContext::ForCommit {
+                current_context: self.original_context,
+                new_extensions: &group_context_extensions_proposal.proposal,
+            };
+
+            let leaf_validator = LeafNodeValidator::new_with_context(
                 self.cipher_suite_provider,
                 self.identity_provider,
-                Some(self.original_context),
-                &group_context_extensions_proposal.proposal,
+                member_validation_context,
             );
 
             output

--- a/mls-rs/src/group/proposal_filter/filtering_common.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_common.rs
@@ -234,7 +234,7 @@ where
                 new_extensions: &group_context_extensions_proposal.proposal,
             };
 
-            let leaf_validator = LeafNodeValidator::new_with_context(
+            let leaf_validator = LeafNodeValidator::new(
                 self.cipher_suite_provider,
                 self.identity_provider,
                 member_validation_context,

--- a/mls-rs/src/group/proposal_filter/filtering_common.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_common.rs
@@ -308,7 +308,7 @@ where
 
         validate_key_package_properties(
             key_package,
-            self.protocol_version,
+            self.original_context.protocol_version,
             self.cipher_suite_provider,
         )
         .await

--- a/mls-rs/src/group/proposal_filter/filtering_lite.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_lite.rs
@@ -59,7 +59,7 @@ where
         filter_out_invalid_group_extensions(proposals, self.identity_provider, commit_time).await?;
 
         filter_out_extra_group_context_extensions(proposals)?;
-        filter_out_invalid_reinit(proposals, self.protocol_version)?;
+        filter_out_invalid_reinit(proposals, self.original_context.protocol_version)?;
         filter_out_reinit_if_other_proposals(proposals)?;
 
         self.apply_proposal_changes(proposals, commit_time).await
@@ -77,7 +77,7 @@ where
                     .await
             }
             None => {
-                self.apply_tree_changes(proposals, self.original_group_extensions, commit_time)
+                self.apply_tree_changes(proposals, &self.original_context.extensions, commit_time)
                     .await
             }
         }
@@ -124,10 +124,11 @@ where
         group_extensions_in_use: &ExtensionList,
         commit_time: Option<MlsTime>,
     ) -> Result<(), MlsError> {
-        let leaf_node_validator = &LeafNodeValidator::new(
+        let leaf_node_validator = &LeafNodeValidator::new_for_commit_validation(
             self.cipher_suite_provider,
             self.identity_provider,
-            Some(group_extensions_in_use),
+            Some(self.original_context),
+            group_extensions_in_use,
         );
 
         let adds = wrap_iter(proposals.add_proposals());

--- a/mls-rs/src/group/proposal_filter/filtering_lite.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_lite.rs
@@ -90,10 +90,10 @@ where
     pub(super) async fn apply_tree_changes(
         &self,
         proposals: &ProposalBundle,
-        group_extensions_in_use: &ExtensionList,
+        new_extensions: &ExtensionList,
         commit_time: Option<MlsTime>,
     ) -> Result<ApplyProposalsOutput, MlsError> {
-        self.validate_new_nodes(proposals, group_extensions_in_use, commit_time)
+        self.validate_new_nodes(proposals, new_extensions, commit_time)
             .await?;
 
         let mut new_tree = self.original_tree.clone();
@@ -101,7 +101,7 @@ where
         let added = new_tree
             .batch_edit_lite(
                 proposals,
-                group_extensions_in_use,
+                new_extensions,
                 self.identity_provider,
                 self.cipher_suite_provider,
             )
@@ -124,12 +124,12 @@ where
     async fn validate_new_nodes(
         &self,
         proposals: &ProposalBundle,
-        group_extensions_in_use: &ExtensionList,
+        new_extensions: &ExtensionList,
         commit_time: Option<MlsTime>,
     ) -> Result<(), MlsError> {
         let member_validation_context = MemberValidationContext::ForCommit {
             current_context: self.original_context,
-            new_extensions: group_extensions_in_use,
+            new_extensions,
         };
 
         let leaf_node_validator = &LeafNodeValidator::new(

--- a/mls-rs/src/group/state.rs
+++ b/mls-rs/src/group/state.rs
@@ -30,7 +30,6 @@ pub struct GroupState {
 }
 
 #[cfg(all(feature = "ffi", not(test)))]
-#[safer_ffi_gen::safer_ffi_gen]
 impl GroupState {
     pub fn context(&self) -> &GroupContext {
         &self.context

--- a/mls-rs/src/group/transcript_hash.rs
+++ b/mls-rs/src/group/transcript_hash.rs
@@ -10,7 +10,7 @@ use core::{
 
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::{
-    context::ConfirmedTranscriptHash, crypto::CipherSuiteProvider, error::IntoAnyError,
+    crypto::CipherSuiteProvider, error::IntoAnyError, group::ConfirmedTranscriptHash,
 };
 
 use crate::{

--- a/mls-rs/src/group/transcript_hash.rs
+++ b/mls-rs/src/group/transcript_hash.rs
@@ -9,7 +9,9 @@ use core::{
 };
 
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
-use mls_rs_core::{crypto::CipherSuiteProvider, error::IntoAnyError};
+use mls_rs_core::{
+    context::ConfirmedTranscriptHash, crypto::CipherSuiteProvider, error::IntoAnyError,
+};
 
 use crate::{
     client::MlsError,
@@ -19,69 +21,36 @@ use crate::{
 
 use super::{AuthenticatedContent, ConfirmationTag};
 
-#[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ConfirmedTranscriptHash(
-    #[mls_codec(with = "mls_rs_codec::byte_vec")]
-    #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
-    Vec<u8>,
-);
-
-impl Debug for ConfirmedTranscriptHash {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        mls_rs_core::debug::pretty_bytes(&self.0)
-            .named("ConfirmedTranscriptHash")
-            .fmt(f)
+#[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+pub(crate) async fn create<P: CipherSuiteProvider>(
+    cipher_suite_provider: &P,
+    interim_transcript_hash: &InterimTranscriptHash,
+    content: &AuthenticatedContent,
+) -> Result<ConfirmedTranscriptHash, MlsError> {
+    #[derive(Debug, MlsSize, MlsEncode)]
+    struct ConfirmedTranscriptHashInput<'a> {
+        wire_format: WireFormat,
+        content: &'a FramedContent,
+        signature: &'a MessageSignature,
     }
-}
 
-impl Deref for ConfirmedTranscriptHash {
-    type Target = Vec<u8>;
+    let input = ConfirmedTranscriptHashInput {
+        wire_format: content.wire_format,
+        content: &content.content,
+        signature: &content.auth.signature,
+    };
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+    let hash_input = [
+        interim_transcript_hash.deref(),
+        input.mls_encode_to_vec()?.deref(),
+    ]
+    .concat();
 
-impl From<Vec<u8>> for ConfirmedTranscriptHash {
-    fn from(value: Vec<u8>) -> Self {
-        Self(value)
-    }
-}
-
-impl ConfirmedTranscriptHash {
-    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
-    pub(crate) async fn create<P: CipherSuiteProvider>(
-        cipher_suite_provider: &P,
-        interim_transcript_hash: &InterimTranscriptHash,
-        content: &AuthenticatedContent,
-    ) -> Result<Self, MlsError> {
-        #[derive(Debug, MlsSize, MlsEncode)]
-        struct ConfirmedTranscriptHashInput<'a> {
-            wire_format: WireFormat,
-            content: &'a FramedContent,
-            signature: &'a MessageSignature,
-        }
-
-        let input = ConfirmedTranscriptHashInput {
-            wire_format: content.wire_format,
-            content: &content.content,
-            signature: &content.auth.signature,
-        };
-
-        let hash_input = [
-            interim_transcript_hash.deref(),
-            input.mls_encode_to_vec()?.deref(),
-        ]
-        .concat();
-
-        cipher_suite_provider
-            .hash(&hash_input)
-            .await
-            .map(Into::into)
-            .map_err(|e| MlsError::CryptoProviderError(e.into_any_error()))
-    }
+    cipher_suite_provider
+        .hash(&hash_input)
+        .await
+        .map(Into::into)
+        .map_err(|e| MlsError::CryptoProviderError(e.into_any_error()))
 }
 
 #[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
@@ -129,7 +98,7 @@ impl InterimTranscriptHash {
         let input = InterimTranscriptHashInput { confirmation_tag }.mls_encode_to_vec()?;
 
         cipher_suite_provider
-            .hash(&[confirmed.0.deref(), &input].concat())
+            .hash(&[&confirmed[..], &input].concat())
             .await
             .map(Into::into)
             .map_err(|e| MlsError::CryptoProviderError(e.into_any_error()))
@@ -167,7 +136,7 @@ mod tests {
     };
 
     #[cfg(not(mls_build_async))]
-    use super::{ConfirmedTranscriptHash, InterimTranscriptHash};
+    use super::InterimTranscriptHash;
 
     #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
     struct TestCase {
@@ -258,9 +227,7 @@ mod tests {
             .unwrap();
 
             let interim_hash_before = cs.random_bytes_vec(cs.kdf_extract_size()).unwrap().into();
-
-            let conf_hash_after =
-                ConfirmedTranscriptHash::create(&cs, &interim_hash_before, &auth_content).unwrap();
+            let conf_hash_after = super::create(&cs, &interim_hash_before, &auth_content).unwrap();
 
             let conf_key = cs.random_bytes_vec(cs.kdf_extract_size()).unwrap();
             let conf_tag = ConfirmationTag::create(&conf_key, &conf_hash_after, &cs).unwrap();
@@ -277,8 +244,8 @@ mod tests {
                 authenticated_content: auth_content.mls_encode_to_vec().unwrap(),
                 interim_transcript_hash_before: interim_hash_before.0,
 
-                confirmed_transcript_hash_after: conf_hash_after.0,
-                interim_transcript_hash_after: interim_hash_after.0,
+                confirmed_transcript_hash_after: conf_hash_after.to_vec(),
+                interim_transcript_hash_after: interim_hash_after.to_vec(),
             };
 
             test_cases.push(test_case);

--- a/mls-rs/src/group/util.rs
+++ b/mls-rs/src/group/util.rs
@@ -168,7 +168,7 @@ pub(super) async fn transcript_hashes<P: CipherSuiteProvider>(
     prev_interim_transcript_hash: &InterimTranscriptHash,
     content: &AuthenticatedContent,
 ) -> Result<(InterimTranscriptHash, ConfirmedTranscriptHash), MlsError> {
-    let confirmed_transcript_hash = ConfirmedTranscriptHash::create(
+    let confirmed_transcript_hash = super::transcript_hash::create(
         cipher_suite_provider,
         prev_interim_transcript_hash,
         content,

--- a/mls-rs/src/identity.rs
+++ b/mls-rs/src/identity.rs
@@ -22,11 +22,12 @@ pub(crate) mod test_utils {
     use alloc::vec;
     use alloc::vec::Vec;
     use mls_rs_core::{
-        context::GroupContext,
         crypto::{CipherSuite, CipherSuiteProvider, SignatureSecretKey},
         error::IntoAnyError,
         extension::ExtensionList,
-        identity::{Credential, CredentialType, IdentityProvider, SigningIdentity},
+        identity::{
+            Credential, CredentialType, IdentityProvider, MemberValidationContext, SigningIdentity,
+        },
         time::MlsTime,
     };
 
@@ -120,8 +121,7 @@ pub(crate) mod test_utils {
             &self,
             _signing_identity: &SigningIdentity,
             _timestamp: Option<MlsTime>,
-            _current_epoch: Option<&GroupContext>,
-            _new_extensions: Option<&ExtensionList>,
+            _context: MemberValidationContext<'_>,
         ) -> Result<(), Self::Error> {
             //TODO: Is it actually beneficial to check the key, or does that already happen elsewhere before
             //this point?

--- a/mls-rs/src/identity.rs
+++ b/mls-rs/src/identity.rs
@@ -22,12 +22,11 @@ pub(crate) mod test_utils {
     use alloc::vec;
     use alloc::vec::Vec;
     use mls_rs_core::{
+        context::GroupContext,
         crypto::{CipherSuite, CipherSuiteProvider, SignatureSecretKey},
         error::IntoAnyError,
         extension::ExtensionList,
-        identity::{
-            Credential, CredentialType, CurrentEpochInfo, IdentityProvider, SigningIdentity,
-        },
+        identity::{Credential, CredentialType, IdentityProvider, SigningIdentity},
         time::MlsTime,
     };
 
@@ -121,7 +120,7 @@ pub(crate) mod test_utils {
             &self,
             _signing_identity: &SigningIdentity,
             _timestamp: Option<MlsTime>,
-            _current_epoch: Option<CurrentEpochInfo<'_>>,
+            _current_epoch: Option<&GroupContext>,
             _new_extensions: Option<&ExtensionList>,
         ) -> Result<(), Self::Error> {
             //TODO: Is it actually beneficial to check the key, or does that already happen elsewhere before

--- a/mls-rs/src/identity.rs
+++ b/mls-rs/src/identity.rs
@@ -25,7 +25,9 @@ pub(crate) mod test_utils {
         crypto::{CipherSuite, CipherSuiteProvider, SignatureSecretKey},
         error::IntoAnyError,
         extension::ExtensionList,
-        identity::{Credential, CredentialType, IdentityProvider, SigningIdentity},
+        identity::{
+            Credential, CredentialType, CurrentEpochInfo, IdentityProvider, SigningIdentity,
+        },
         time::MlsTime,
     };
 
@@ -119,7 +121,8 @@ pub(crate) mod test_utils {
             &self,
             _signing_identity: &SigningIdentity,
             _timestamp: Option<MlsTime>,
-            _extensions: Option<&ExtensionList>,
+            _current_epoch: Option<CurrentEpochInfo>,
+            _new_extensions: Option<&ExtensionList>,
         ) -> Result<(), Self::Error> {
             //TODO: Is it actually beneficial to check the key, or does that already happen elsewhere before
             //this point?

--- a/mls-rs/src/identity.rs
+++ b/mls-rs/src/identity.rs
@@ -121,7 +121,7 @@ pub(crate) mod test_utils {
             &self,
             _signing_identity: &SigningIdentity,
             _timestamp: Option<MlsTime>,
-            _current_epoch: Option<CurrentEpochInfo>,
+            _current_epoch: Option<CurrentEpochInfo<'_>>,
             _new_extensions: Option<&ExtensionList>,
         ) -> Result<(), Self::Error> {
             //TODO: Is it actually beneficial to check the key, or does that already happen elsewhere before

--- a/mls-rs/src/identity/basic.rs
+++ b/mls-rs/src/identity/basic.rs
@@ -7,8 +7,9 @@ use alloc::vec;
 use alloc::vec::Vec;
 pub use mls_rs_core::identity::BasicCredential;
 use mls_rs_core::{
-    context::GroupContext, error::IntoAnyError, extension::ExtensionList,
-    identity::IdentityProvider,
+    error::IntoAnyError,
+    extension::ExtensionList,
+    identity::{IdentityProvider, MemberValidationContext},
 };
 
 #[derive(Debug)]
@@ -65,8 +66,7 @@ impl IdentityProvider for BasicIdentityProvider {
         &self,
         signing_identity: &SigningIdentity,
         _timestamp: Option<MlsTime>,
-        _current_epoch: Option<&GroupContext>,
-        _extensions: Option<&ExtensionList>,
+        _context: MemberValidationContext<'_>,
     ) -> Result<(), Self::Error> {
         resolve_basic_identity(signing_identity).map(|_| ())
     }

--- a/mls-rs/src/identity/basic.rs
+++ b/mls-rs/src/identity/basic.rs
@@ -66,7 +66,7 @@ impl IdentityProvider for BasicIdentityProvider {
         &self,
         signing_identity: &SigningIdentity,
         _timestamp: Option<MlsTime>,
-        _current_epoch: Option<CurrentEpochInfo>,
+        _current_epoch: Option<CurrentEpochInfo<'_>>,
         _extensions: Option<&ExtensionList>,
     ) -> Result<(), Self::Error> {
         resolve_basic_identity(signing_identity).map(|_| ())

--- a/mls-rs/src/identity/basic.rs
+++ b/mls-rs/src/identity/basic.rs
@@ -7,9 +7,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 pub use mls_rs_core::identity::BasicCredential;
 use mls_rs_core::{
-    error::IntoAnyError,
-    extension::ExtensionList,
-    identity::{CurrentEpochInfo, IdentityProvider},
+    context::GroupContext, error::IntoAnyError, extension::ExtensionList,
+    identity::IdentityProvider,
 };
 
 #[derive(Debug)]
@@ -66,7 +65,7 @@ impl IdentityProvider for BasicIdentityProvider {
         &self,
         signing_identity: &SigningIdentity,
         _timestamp: Option<MlsTime>,
-        _current_epoch: Option<CurrentEpochInfo<'_>>,
+        _current_epoch: Option<&GroupContext>,
         _extensions: Option<&ExtensionList>,
     ) -> Result<(), Self::Error> {
         resolve_basic_identity(signing_identity).map(|_| ())

--- a/mls-rs/src/identity/basic.rs
+++ b/mls-rs/src/identity/basic.rs
@@ -6,7 +6,11 @@ use crate::{identity::CredentialType, identity::SigningIdentity, time::MlsTime};
 use alloc::vec;
 use alloc::vec::Vec;
 pub use mls_rs_core::identity::BasicCredential;
-use mls_rs_core::{error::IntoAnyError, extension::ExtensionList, identity::IdentityProvider};
+use mls_rs_core::{
+    error::IntoAnyError,
+    extension::ExtensionList,
+    identity::{CurrentEpochInfo, IdentityProvider},
+};
 
 #[derive(Debug)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
@@ -62,6 +66,7 @@ impl IdentityProvider for BasicIdentityProvider {
         &self,
         signing_identity: &SigningIdentity,
         _timestamp: Option<MlsTime>,
+        _current_epoch: Option<CurrentEpochInfo>,
         _extensions: Option<&ExtensionList>,
     ) -> Result<(), Self::Error> {
         resolve_basic_identity(signing_identity).map(|_| ())

--- a/mls-rs/src/key_package/generator.rs
+++ b/mls-rs/src/key_package/generator.rs
@@ -261,7 +261,7 @@ mod tests {
             assert_eq!(opened, test_data);
 
             let validator =
-                LeafNodeValidator::new(&cipher_suite_provider, &BasicIdentityProvider, None);
+                LeafNodeValidator::new_for_test(&cipher_suite_provider, &BasicIdentityProvider);
 
             validator
                 .check_if_valid(

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -241,8 +241,8 @@ mod tests {
     use assert_matches::assert_matches;
     #[cfg(feature = "std")]
     use core::time::Duration;
-    use mls_rs_core::context::GroupContext;
     use mls_rs_core::crypto::CipherSuite;
+    use mls_rs_core::group::GroupContext;
     use mls_rs_core::group::ProposalType;
 
     use super::*;

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -200,7 +200,7 @@ impl<'a, C: IdentityProvider, CP: CipherSuiteProvider> LeafNodeValidator<'a, C, 
             .validate_member(
                 &leaf_node.signing_identity,
                 context.generation_time(),
-                self.context.map(Into::into),
+                self.context,
                 self.new_extensions,
             )
             .await
@@ -655,9 +655,10 @@ pub(crate) mod test_utils {
     use alloc::vec::Vec;
     use mls_rs_codec::MlsEncode;
     use mls_rs_core::{
+        context::GroupContext,
         error::IntoAnyError,
         extension::ExtensionList,
-        identity::{BasicCredential, CurrentEpochInfo, IdentityProvider},
+        identity::{BasicCredential, IdentityProvider},
     };
 
     use crate::{identity::SigningIdentity, time::MlsTime};
@@ -693,7 +694,7 @@ pub(crate) mod test_utils {
             &self,
             _signing_identity: &SigningIdentity,
             _timestamp: Option<MlsTime>,
-            _current_epoch: Option<CurrentEpochInfo<'_>>,
+            _current_epoch: Option<&GroupContext>,
             _new_extensions: Option<&ExtensionList>,
         ) -> Result<(), Self::Error> {
             Err(TestFailureError)

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -50,7 +50,7 @@ where
 }
 
 impl<'a, C: IdentityProvider, CP: CipherSuiteProvider> LeafNodeValidator<'a, C, CP> {
-    pub fn new_with_context(
+    pub fn new(
         cipher_suite_provider: &'a CP,
         identity_provider: &'a C,
         context: MemberValidationContext<'a>,
@@ -539,11 +539,8 @@ mod tests {
             new_extensions: &group_context_extensions,
         };
 
-        let test_validator = LeafNodeValidator::new_with_context(
-            &cipher_suite_provider,
-            &BasicIdentityProvider,
-            context,
-        );
+        let test_validator =
+            LeafNodeValidator::new(&cipher_suite_provider, &BasicIdentityProvider, context);
 
         let res = test_validator
             .check_if_valid(&leaf_node, ValidationContext::Add(None))
@@ -574,11 +571,8 @@ mod tests {
             new_extensions: &group_context_extensions,
         };
 
-        let test_validator = LeafNodeValidator::new_with_context(
-            &cipher_suite_provider,
-            &BasicIdentityProvider,
-            context,
-        );
+        let test_validator =
+            LeafNodeValidator::new(&cipher_suite_provider, &BasicIdentityProvider, context);
 
         let res = test_validator
             .check_if_valid(&leaf_node, ValidationContext::Add(None))
@@ -621,11 +615,8 @@ mod tests {
             new_extensions: &group_context_extensions,
         };
 
-        let test_validator = LeafNodeValidator::new_with_context(
-            &cipher_suite_provider,
-            &BasicIdentityProvider,
-            context,
-        );
+        let test_validator =
+            LeafNodeValidator::new(&cipher_suite_provider, &BasicIdentityProvider, context);
 
         let res = test_validator
             .check_if_valid(&leaf_node, ValidationContext::Add(None))

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -693,7 +693,7 @@ pub(crate) mod test_utils {
             &self,
             _signing_identity: &SigningIdentity,
             _timestamp: Option<MlsTime>,
-            _current_epoch: Option<CurrentEpochInfo>,
+            _current_epoch: Option<CurrentEpochInfo<'_>>,
             _new_extensions: Option<&ExtensionList>,
         ) -> Result<(), Self::Error> {
             Err(TestFailureError)

--- a/mls-rs/src/tree_kem/tree_validator.rs
+++ b/mls-rs/src/tree_kem/tree_validator.rs
@@ -46,7 +46,7 @@ impl<'a, C: IdentityProvider, CSP: CipherSuiteProvider> TreeValidator<'a, C, CSP
             leaf_node_validator: LeafNodeValidator::new(
                 cipher_suite_provider,
                 identity_provider,
-                Some(&context.extensions),
+                Some(context),
             ),
             group_id: &context.group_id,
             cipher_suite_provider,

--- a/mls-rs/src/tree_kem/tree_validator.rs
+++ b/mls-rs/src/tree_kem/tree_validator.rs
@@ -16,7 +16,7 @@ use crate::group::GroupContext;
 use crate::iter::wrap_impl_iter;
 use crate::tree_kem::math as tree_math;
 use crate::tree_kem::{leaf_node_validator::LeafNodeValidator, TreeKemPublic};
-use mls_rs_core::identity::IdentityProvider;
+use mls_rs_core::identity::{IdentityProvider, MemberValidationContext};
 
 #[cfg(all(not(mls_build_async), feature = "rayon"))]
 use rayon::prelude::*;
@@ -41,12 +41,16 @@ impl<'a, C: IdentityProvider, CSP: CipherSuiteProvider> TreeValidator<'a, C, CSP
         context: &'a GroupContext,
         identity_provider: &'a C,
     ) -> Self {
+        let member_validation_context = MemberValidationContext::ForNewGroup {
+            current_context: context,
+        };
+
         TreeValidator {
             expected_tree_hash: &context.tree_hash,
-            leaf_node_validator: LeafNodeValidator::new(
+            leaf_node_validator: LeafNodeValidator::new_with_context(
                 cipher_suite_provider,
                 identity_provider,
-                Some(context),
+                member_validation_context,
             ),
             group_id: &context.group_id,
             cipher_suite_provider,

--- a/mls-rs/src/tree_kem/tree_validator.rs
+++ b/mls-rs/src/tree_kem/tree_validator.rs
@@ -47,7 +47,7 @@ impl<'a, C: IdentityProvider, CSP: CipherSuiteProvider> TreeValidator<'a, C, CSP
 
         TreeValidator {
             expected_tree_hash: &context.tree_hash,
-            leaf_node_validator: LeafNodeValidator::new_with_context(
+            leaf_node_validator: LeafNodeValidator::new(
                 cipher_suite_provider,
                 identity_provider,
                 member_validation_context,

--- a/mls-rs/src/tree_kem/update_path.rs
+++ b/mls-rs/src/tree_kem/update_path.rs
@@ -54,11 +54,11 @@ pub(crate) async fn validate_update_path<C: IdentityProvider, CSP: CipherSuitePr
     current_context: &GroupContext,
 ) -> Result<ValidatedUpdatePath, MlsError> {
     let member_validation_context = MemberValidationContext::ForCommit {
-        current_context: current_context,
+        current_context,
         new_extensions: &state.group_context.extensions,
     };
 
-    let leaf_validator = LeafNodeValidator::new_with_context(
+    let leaf_validator = LeafNodeValidator::new(
         cipher_suite_provider,
         identity_provider,
         member_validation_context,

--- a/mls-rs/src/tree_kem/update_path.rs
+++ b/mls-rs/src/tree_kem/update_path.rs
@@ -50,10 +50,11 @@ pub(crate) async fn validate_update_path<C: IdentityProvider, CSP: CipherSuitePr
 ) -> Result<ValidatedUpdatePath, MlsError> {
     let group_context_extensions = &state.group_context.extensions;
 
-    let leaf_validator = LeafNodeValidator::new(
+    let leaf_validator = LeafNodeValidator::new_for_commit_validation(
         cipher_suite_provider,
         identity_provider,
-        Some(group_context_extensions),
+        Some(&state.group_context),
+        &state.group_context.extensions,
     );
 
     leaf_validator

--- a/mls-rs/src/tree_kem/update_path.rs
+++ b/mls-rs/src/tree_kem/update_path.rs
@@ -5,8 +5,8 @@
 use alloc::{vec, vec::Vec};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::{
-    context::GroupContext,
     error::IntoAnyError,
+    group::GroupContext,
     identity::{IdentityProvider, MemberValidationContext},
 };
 

--- a/mls-rs/src/tree_kem/update_path.rs
+++ b/mls-rs/src/tree_kem/update_path.rs
@@ -4,7 +4,11 @@
 
 use alloc::{vec, vec::Vec};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
-use mls_rs_core::{error::IntoAnyError, identity::IdentityProvider};
+use mls_rs_core::{
+    context::GroupContext,
+    error::IntoAnyError,
+    identity::{IdentityProvider, MemberValidationContext},
+};
 
 use super::{
     leaf_node::LeafNode,
@@ -47,14 +51,17 @@ pub(crate) async fn validate_update_path<C: IdentityProvider, CSP: CipherSuitePr
     state: &ProvisionalState,
     sender: LeafIndex,
     commit_time: Option<MlsTime>,
+    current_context: &GroupContext,
 ) -> Result<ValidatedUpdatePath, MlsError> {
-    let group_context_extensions = &state.group_context.extensions;
+    let member_validation_context = MemberValidationContext::ForCommit {
+        current_context: current_context,
+        new_extensions: &state.group_context.extensions,
+    };
 
-    let leaf_validator = LeafNodeValidator::new_for_commit_validation(
+    let leaf_validator = LeafNodeValidator::new_with_context(
         cipher_suite_provider,
         identity_provider,
-        Some(&state.group_context),
-        &state.group_context.extensions,
+        member_validation_context,
     );
 
     leaf_validator
@@ -74,7 +81,7 @@ pub(crate) async fn validate_update_path<C: IdentityProvider, CSP: CipherSuitePr
             .valid_successor(
                 &original_leaf_node.signing_identity,
                 &path.leaf_node.signing_identity,
-                group_context_extensions,
+                &state.group_context.extensions,
             )
             .await
             .map_err(|e| MlsError::IdentityProviderError(e.into_any_error()))?
@@ -190,14 +197,16 @@ mod tests {
     async fn test_valid_leaf_node() {
         let cipher_suite_provider = test_cipher_suite_provider(TEST_CIPHER_SUITE);
         let update_path = test_update_path(TEST_CIPHER_SUITE, "creator").await;
+        let state = test_provisional_state(TEST_CIPHER_SUITE).await;
 
         let validated = validate_update_path(
             &BasicIdentityProvider,
             &cipher_suite_provider,
             update_path.clone(),
-            &test_provisional_state(TEST_CIPHER_SUITE).await,
+            &state,
             LeafIndex(0),
             None,
+            &state.group_context,
         )
         .await
         .unwrap();
@@ -213,14 +222,16 @@ mod tests {
         let cipher_suite_provider = test_cipher_suite_provider(TEST_CIPHER_SUITE);
         let mut update_path = test_update_path(TEST_CIPHER_SUITE, "creator").await;
         update_path.leaf_node.signature = random_bytes(32);
+        let state = test_provisional_state(TEST_CIPHER_SUITE).await;
 
         let validated = validate_update_path(
             &BasicIdentityProvider,
             &cipher_suite_provider,
             update_path,
-            &test_provisional_state(TEST_CIPHER_SUITE).await,
+            &state,
             LeafIndex(0),
             None,
+            &state.group_context,
         )
         .await;
 
@@ -232,14 +243,16 @@ mod tests {
         let cipher_suite_provider = test_cipher_suite_provider(TEST_CIPHER_SUITE);
         let cipher_suite = TEST_CIPHER_SUITE;
         let update_path = test_update_path(cipher_suite, "foobar").await;
+        let state = test_provisional_state(TEST_CIPHER_SUITE).await;
 
         let validated = validate_update_path(
             &BasicIdentityProvider,
             &cipher_suite_provider,
             update_path,
-            &test_provisional_state(cipher_suite).await,
+            &state,
             LeafIndex(0),
             None,
+            &state.group_context,
         )
         .await;
 
@@ -266,6 +279,7 @@ mod tests {
             &state,
             LeafIndex(0),
             None,
+            &state.group_context,
         )
         .await;
 

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mls-rs = { version = "0.42.0", path = "..", default-features = false, features = ["std", "external_client"]}
+mls-rs = { version = "0.43.0", path = "..", default-features = false, features = ["std", "external_client"]}
 tonic = "0.10.2"
 prost = "0.12.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
@@ -25,10 +25,10 @@ by_ref_proposal = [ "mls-rs/by_ref_proposal" ]
 default = ["tree_index", "private_message", "prior_epoch", "out_of_order", "psk", "custom_proposal", "by_ref_proposal"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features = ["browser"], version = "0.11.0" }
+mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features = ["browser"], version = "0.12.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-mls-rs-crypto-openssl = { path = "../../mls-rs-crypto-openssl", version = "0.10.0"}
+mls-rs-crypto-openssl = { path = "../../mls-rs-crypto-openssl", version = "0.11.0"}
 
 [build-dependencies]
 tonic-build = "0.10.2"

--- a/mls-rs/test_harness_integration/src/main.rs
+++ b/mls-rs/test_harness_integration/src/main.rs
@@ -18,7 +18,7 @@ use mls_rs::{
     },
     crypto::SignatureSecretKey,
     external_client::ExternalClient,
-    group::{CommitEffect, ExportedTree, Member, ReceivedMessage, Roster},
+    group::{CommitEffect, ExportedTree, GroupContext, Member, ReceivedMessage, Roster},
     identity::{
         basic::{BasicCredential, BasicIdentityProvider},
         Credential, SigningIdentity,
@@ -161,7 +161,7 @@ impl MlsRules for TestMlsRules {
         _: CommitDirection,
         _: CommitSource,
         _: &Roster,
-        _: &ExtensionList,
+        _: &GroupContext,
         proposals: ProposalBundle,
     ) -> Result<ProposalBundle, Self::Error> {
         Ok(proposals)
@@ -170,7 +170,7 @@ impl MlsRules for TestMlsRules {
     fn commit_options(
         &self,
         _: &Roster,
-        _: &ExtensionList,
+        _: &GroupContext,
         _: &ProposalBundle,
     ) -> Result<CommitOptions, Self::Error> {
         Ok(*self.commit_options.lock().unwrap())
@@ -179,7 +179,7 @@ impl MlsRules for TestMlsRules {
     fn encryption_options(
         &self,
         _: &Roster,
-        _: &ExtensionList,
+        _: &GroupContext,
     ) -> Result<EncryptionOptions, Self::Error> {
         Ok(*self.encryption_options.lock().unwrap())
     }


### PR DESCRIPTION
Maybe useful to know more context

### Call-outs

Moving GroupContext to core means making `tree_hash` and `confirmed_transcript_hash` public (there's currently a function on ExternalGroup that returns `confirmed_transcript_hash` anyway).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
