### PR TITLE
Improve custom proposal filtering

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.42.0"
+version = "0.42.1"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/src/group/proposal_filter.rs
+++ b/mls-rs/src/group/proposal_filter.rs
@@ -14,10 +14,7 @@ use filtering_lite as filtering;
 
 pub use bundle::{ProposalBundle, ProposalInfo, ProposalSource};
 
-#[cfg(feature = "by_ref_proposal")]
-pub(crate) use filtering::FilterStrategy;
-
-pub(crate) use filtering_common::ProposalApplier;
+pub(crate) use filtering_common::{prepare_proposals_for_mls_rules, ProposalApplier};
 
 #[cfg(all(feature = "by_ref_proposal", test))]
 pub(crate) use filtering::proposer_can_propose;

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -565,9 +565,16 @@ impl<T> ProposalInfo<T> {
         !self.is_by_reference()
     }
 
+    #[cfg(feature = "by_ref_proposal")]
     #[inline(always)]
     pub fn is_by_reference(&self) -> bool {
         matches!(self.source, ProposalSource::ByReference(_))
+    }
+
+    #[cfg(not(feature = "by_ref_proposal"))]
+    #[inline(always)]
+    pub fn is_by_reference(&self) -> bool {
+        false
     }
 
     /// The [`ProposalRef`] of this proposal if its source is [`ProposalSource::ByReference`]

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -562,12 +562,12 @@ impl<T> ProposalInfo<T> {
 
     #[inline(always)]
     pub fn is_by_value(&self) -> bool {
-        self.source == ProposalSource::ByValue
+        !self.is_by_reference()
     }
 
     #[inline(always)]
     pub fn is_by_reference(&self) -> bool {
-        !self.is_by_value()
+        matches!(self.source, ProposalSource::ByReference(_))
     }
 
     /// The [`ProposalRef`] of this proposal if its source is [`ProposalSource::ByReference`]

--- a/mls-rs/src/group/proposal_filter/filtering.rs
+++ b/mls-rs/src/group/proposal_filter/filtering.rs
@@ -10,6 +10,7 @@ use crate::{
         AddProposal, ProposalType, RemoveProposal, Sender, UpdateProposal,
     },
     iter::wrap_iter,
+    mls_rules::CommitDirection,
     protocol_version::ProtocolVersion,
     time::MlsTime,
     tree_kem::{
@@ -247,6 +248,15 @@ where
 pub enum FilterStrategy {
     IgnoreByRef,
     IgnoreNone,
+}
+
+impl From<CommitDirection> for FilterStrategy {
+    fn from(value: CommitDirection) -> Self {
+        match value {
+            CommitDirection::Send => FilterStrategy::IgnoreByRef,
+            CommitDirection::Receive => FilterStrategy::IgnoreNone,
+        }
+    }
 }
 
 impl FilterStrategy {

--- a/mls-rs/src/group/proposal_filter/filtering_common.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_common.rs
@@ -6,6 +6,7 @@ use crate::{
     client::MlsError,
     group::{proposal_filter::ProposalBundle, Sender},
     key_package::{validate_key_package_properties, KeyPackage},
+    mls_rules::CommitDirection,
     protocol_version::ProtocolVersion,
     time::MlsTime,
     tree_kem::{
@@ -44,7 +45,6 @@ use std::collections::HashSet;
 #[cfg(feature = "by_ref_proposal")]
 use super::filtering::{apply_strategy, filter_out_invalid_proposers, FilterStrategy};
 
-#[cfg(feature = "custom_proposal")]
 use super::filtering::filter_out_unsupported_custom_proposals;
 
 #[derive(Debug)]
@@ -129,19 +129,6 @@ where
             #[cfg(feature = "by_ref_proposal")]
             Sender::NewMemberProposal => Err(MlsError::ExternalSenderCannotCommit),
         }?;
-
-        #[cfg(all(feature = "by_ref_proposal", feature = "custom_proposal"))]
-        let mut output = output;
-
-        #[cfg(all(feature = "by_ref_proposal", feature = "custom_proposal"))]
-        filter_out_unsupported_custom_proposals(
-            &mut output.applied_proposals,
-            &output.new_tree,
-            strategy,
-        )?;
-
-        #[cfg(all(not(feature = "by_ref_proposal"), feature = "custom_proposal"))]
-        filter_out_unsupported_custom_proposals(proposals, &output.new_tree)?;
 
         Ok(output)
     }
@@ -357,6 +344,24 @@ where
         a?;
         b
     }
+}
+
+#[cfg(feature = "by_ref_proposal")]
+pub(crate) fn prepare_proposals_for_mls_rules(
+    proposals: &mut ProposalBundle,
+    direction: CommitDirection,
+    tree: &TreeKemPublic,
+) -> Result<(), MlsError> {
+    filter_out_unsupported_custom_proposals(proposals, tree, direction.into())
+}
+
+#[cfg(not(feature = "by_ref_proposal"))]
+pub(crate) fn prepare_proposals_for_mls_rules(
+    proposals: &mut ProposalBundle,
+    _direction: CommitDirection,
+    tree: &TreeKemPublic,
+) -> Result<(), MlsError> {
+    filter_out_unsupported_custom_proposals(&proposals, tree)
 }
 
 #[cfg(feature = "psk")]

--- a/mls-rs/src/group/proposal_filter/filtering_common.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_common.rs
@@ -45,6 +45,7 @@ use std::collections::HashSet;
 #[cfg(feature = "by_ref_proposal")]
 use super::filtering::{apply_strategy, filter_out_invalid_proposers, FilterStrategy};
 
+#[cfg(feature = "custom_proposal")]
 use super::filtering::filter_out_unsupported_custom_proposals;
 
 #[derive(Debug)]
@@ -346,7 +347,7 @@ where
     }
 }
 
-#[cfg(feature = "by_ref_proposal")]
+#[cfg(all(feature = "custom_proposal", feature = "by_ref_proposal"))]
 pub(crate) fn prepare_proposals_for_mls_rules(
     proposals: &mut ProposalBundle,
     direction: CommitDirection,
@@ -355,13 +356,22 @@ pub(crate) fn prepare_proposals_for_mls_rules(
     filter_out_unsupported_custom_proposals(proposals, tree, direction.into())
 }
 
-#[cfg(not(feature = "by_ref_proposal"))]
+#[cfg(all(feature = "custom_proposal", not(feature = "by_ref_proposal")))]
 pub(crate) fn prepare_proposals_for_mls_rules(
     proposals: &mut ProposalBundle,
     _direction: CommitDirection,
     tree: &TreeKemPublic,
 ) -> Result<(), MlsError> {
     filter_out_unsupported_custom_proposals(&proposals, tree)
+}
+
+#[cfg(not(feature = "custom_proposal"))]
+pub(crate) fn prepare_proposals_for_mls_rules(
+    _: &mut ProposalBundle,
+    _: CommitDirection,
+    _: &TreeKemPublic,
+) -> Result<(), MlsError> {
+    Ok(())
 }
 
 #[cfg(feature = "psk")]


### PR DESCRIPTION
* Basic validity checks of custom proposals must be done before they are passed to custom MlsRules - else it is too late, as they already took effect
* Local proposals are treated as by-value instead of by-reference by the proposal filter. Filtering out local proposals without filtering out their parents is error-prone.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
