### PR TITLE
Add impl From<Vec<u8>> for SignaturePublicKey

### DIFF
--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-core"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 description = "Core components and traits for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs-core/src/crypto.rs
+++ b/mls-rs-core/src/crypto.rs
@@ -229,6 +229,12 @@ impl From<Vec<u8>> for SignaturePublicKey {
     }
 }
 
+impl From<SignaturePublicKey> for Vec<u8> {
+    fn from(value: SignaturePublicKey) -> Self {
+        value.0
+    }
+}
+
 /// Byte representation of a signature key.
 #[cfg_attr(
     all(feature = "ffi", not(test)),


### PR DESCRIPTION
It's implemented for other keys including SignatureSecretKey

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
