### PR TITLE
Bump version of webcrypto

### DIFF
--- a/mls-rs-crypto-webcrypto/Cargo.toml
+++ b/mls-rs-crypto-webcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-webcrypto"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "SubtleCrypto based CryptoProvider for supporting mls-rs in a browser"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -102,7 +102,7 @@ rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3.26", default-features = false }
-mls-rs-crypto-webcrypto = { path = "../mls-rs-crypto-webcrypto", version = "0.5.0" }
+mls-rs-crypto-webcrypto = { path = "../mls-rs-crypto-webcrypto", version = "0.6.0" }
 criterion = { version = "0.5.1", default-features = false, features = ["plotters", "cargo_bench_support", "async_futures", "html_reports"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]


### PR DESCRIPTION
Forgotten after version of mls-rs-core was bumped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
