### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: nanasess/setup-chromedriver@v2
     - uses: jetli/wasm-pack-action@v0.3.0
       with:
-        version: 'v0.10.3'
+        version: 'v0.13.0'
     - name: WASM mls-rs-crypto-rustcrypto
       working-directory: mls-rs-crypto-rustcrypto
       run: wasm-pack test --headless --chrome --release --features browser

--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: nanasess/setup-chromedriver@v2
     - uses: jetli/wasm-pack-action@v0.3.0
       with:
-        version: 'v0.13.0'
+        version: 'v0.10.3'
     - name: WASM mls-rs-crypto-rustcrypto
       working-directory: mls-rs-crypto-rustcrypto
       run: wasm-pack test --headless --chrome --release --features browser

--- a/mls-rs-codec/Cargo.toml
+++ b/mls-rs-codec/Cargo.toml
@@ -21,7 +21,7 @@ thiserror = { version = "1.0.40", optional = true }
 assert_matches = "1.5.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2.79" }

--- a/mls-rs-codec/Cargo.toml
+++ b/mls-rs-codec/Cargo.toml
@@ -24,7 +24,7 @@ assert_matches = "1.5.0"
 wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2.79" }
+wasm-bindgen = { version = "=0.2.87" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-codec/src/cow.rs
+++ b/mls-rs-codec/src/cow.rs
@@ -5,7 +5,7 @@ use alloc::{
 
 use crate::{Error, MlsDecode, MlsEncode, MlsSize};
 
-impl<'a, T> MlsSize for Cow<'a, T>
+impl<T> MlsSize for Cow<'_, T>
 where
     T: MlsSize + ToOwned,
 {
@@ -14,7 +14,7 @@ where
     }
 }
 
-impl<'a, T> MlsEncode for Cow<'a, T>
+impl<T> MlsEncode for Cow<'_, T>
 where
     T: MlsEncode + ToOwned,
 {
@@ -24,7 +24,7 @@ where
     }
 }
 
-impl<'a, T> MlsDecode for Cow<'a, T>
+impl<T> MlsDecode for Cow<'_, T>
 where
     T: ToOwned,
     <T as ToOwned>::Owned: MlsDecode,

--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -44,10 +44,10 @@ async-trait = "0.1.74"
 assert_matches = "1.5.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "^0.2.79" }
+wasm-bindgen = { version = "0.2.79" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)', 'cfg(coverage_nightly)'] }

--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -47,7 +47,7 @@ assert_matches = "1.5.0"
 wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2.79" }
+wasm-bindgen = { version = "=0.2.87" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)', 'cfg(coverage_nightly)'] }

--- a/mls-rs-core/src/identity/provider.rs
+++ b/mls-rs-core/src/identity/provider.rs
@@ -23,7 +23,7 @@ pub enum MemberValidationContext<'a> {
     None,
 }
 
-impl<'a> MemberValidationContext<'a> {
+impl MemberValidationContext<'_> {
     pub fn new_extensions(&self) -> Option<&ExtensionList> {
         match self {
             Self::ForCommit { new_extensions, .. } => Some(*new_extensions),

--- a/mls-rs-crypto-awslc/src/x509/component.rs
+++ b/mls-rs-crypto-awslc/src/x509/component.rs
@@ -374,7 +374,7 @@ pub struct X509ExtensionContext<'a> {
     pub(crate) phantom: PhantomData<&'a Certificate>,
 }
 
-impl<'a> X509ExtensionContext<'a> {
+impl X509ExtensionContext<'_> {
     pub fn as_mut_ptr(&mut self) -> *mut X509V3_CTX {
         &mut self.inner
     }

--- a/mls-rs-crypto-hpke/Cargo.toml
+++ b/mls-rs-crypto-hpke/Cargo.toml
@@ -31,7 +31,7 @@ hex = { version = "^0.4.3", features = ["serde"] }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.12.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(mls_build_async)'.dependencies]

--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -77,7 +77,7 @@ mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false,
 async-trait = "0.1.74"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-crypto-webcrypto/Cargo.toml
+++ b/mls-rs-crypto-webcrypto/Cargo.toml
@@ -17,7 +17,7 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.10"
 async-trait = "0.1.74"
 js-sys = "0.3.64"
-wasm-bindgen = "0.2.87"
+wasm-bindgen = "=0.2.87"
 wasm-bindgen-futures = "0.4.37"
 serde-wasm-bindgen = "0.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/mls-rs-crypto-webcrypto/Cargo.toml
+++ b/mls-rs-crypto-webcrypto/Cargo.toml
@@ -27,7 +27,7 @@ const-oid = { version = "0.9", features = ["db"] }
 
 [dev-dependencies]
 mls-rs-core = { path = "../mls-rs-core", version = "0.20.0", features = ["test_suite"] }
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 futures-test = "0.3.25"
 serde_json = "^1.0"
 hex = { version = "^0.4.3", features = ["serde"] }

--- a/mls-rs-crypto-webcrypto/src/aead.rs
+++ b/mls-rs-crypto-webcrypto/src/aead.rs
@@ -83,9 +83,9 @@ impl Aead {
             .then_some(())
             .ok_or(CryptoError::WrongKeyLength)?;
 
-        let params = AesGcmParams::new(key_type.algorithm(), &Uint8Array::from(nonce));
+        let mut params = AesGcmParams::new(key_type.algorithm(), &Uint8Array::from(nonce));
         let aad = Uint8Array::from(aad.unwrap_or_default());
-        params.set_additional_data(&aad);
+        params.additional_data(&aad);
         let key = key_type.import(&crypto, key).await?;
 
         let out = match key_type {

--- a/mls-rs-crypto-webcrypto/src/key_type.rs
+++ b/mls-rs-crypto-webcrypto/src/key_type.rs
@@ -86,8 +86,8 @@ impl KeyType {
             | KeyType::EcdhSecret(curve)
             | KeyType::EcdsaPublic(curve)
             | KeyType::EcdsaSecret(curve) => {
-                let params = EcKeyImportParams::new(self.algorithm());
-                params.set_named_curve(curve);
+                let mut params = EcKeyImportParams::new(self.algorithm());
+                params.named_curve(curve);
 
                 crypto.import_key_with_object(self.format(), &key, &params, true, &key_usages)?
             }

--- a/mls-rs-identity-x509/Cargo.toml
+++ b/mls-rs-identity-x509/Cargo.toml
@@ -27,12 +27,12 @@ assert_matches = "1"
 rand = "0.8"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "^0.2.79" }
+wasm-bindgen = { version = "0.2.79" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-identity-x509/Cargo.toml
+++ b/mls-rs-identity-x509/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = { version = "0.2", features = ["js"] }
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2.79" }
+wasm-bindgen = { version = "=0.2.87" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 mls-rs-core = { path = "../mls-rs-core", version = "0.20.0" }
 thiserror = "1.0.40"
-wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen = { version = "=0.2.87", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 rusqlite = { version = "0.31", default-features = false }
 rand = "0.8"

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -96,12 +96,12 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 hex = { version = "^0.4.3", default-features = false, features = ["serde", "alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "^0.2.79" }
+wasm-bindgen = { version = "0.2.79" }
 getrandom = { version = "0.2", features = ["js", "custom"], default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 mls-rs-crypto-webcrypto = { path = "../mls-rs-crypto-webcrypto", version = "0.6.0" }
 criterion = { version = "0.5.1", default-features = false, features = ["plotters", "cargo_bench_support", "async_futures", "html_reports"] }
 

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -96,7 +96,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 hex = { version = "^0.4.3", default-features = false, features = ["serde", "alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2.79" }
+wasm-bindgen = { version = "=0.2.87" }
 getrandom = { version = "0.2", features = ["js", "custom"], default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 

--- a/mls-rs/src/group/group_info.rs
+++ b/mls-rs/src/group/group_info.rs
@@ -67,7 +67,7 @@ struct SignableGroupInfo<'a> {
     signer: LeafIndex,
 }
 
-impl<'a> Signable<'a> for GroupInfo {
+impl Signable<'_> for GroupInfo {
     const SIGN_LABEL: &'static str = "GroupInfoTBS";
     type SigningContext = ();
 

--- a/mls-rs/src/group/message_processor.rs
+++ b/mls-rs/src/group/message_processor.rs
@@ -73,7 +73,7 @@ pub(crate) struct ProvisionalState {
 // psk
 // reinit
 pub(crate) fn path_update_required(proposals: &ProposalBundle) -> bool {
-    let res = proposals.external_init_proposals().first().is_some();
+    let res = !proposals.external_init_proposals().is_empty();
 
     #[cfg(feature = "by_ref_proposal")]
     let res = res || !proposals.update_proposals().is_empty();

--- a/mls-rs/src/group/message_signature.rs
+++ b/mls-rs/src/group/message_signature.rs
@@ -159,7 +159,7 @@ pub(crate) struct AuthenticatedContentTBS<'a> {
     pub(crate) context: Option<&'a GroupContext>,
 }
 
-impl<'a> MlsSize for AuthenticatedContentTBS<'a> {
+impl MlsSize for AuthenticatedContentTBS<'_> {
     fn mls_encoded_len(&self) -> usize {
         self.protocol_version.mls_encoded_len()
             + self.wire_format.mls_encoded_len()
@@ -168,7 +168,7 @@ impl<'a> MlsSize for AuthenticatedContentTBS<'a> {
     }
 }
 
-impl<'a> MlsEncode for AuthenticatedContentTBS<'a> {
+impl MlsEncode for AuthenticatedContentTBS<'_> {
     fn mls_encode(&self, writer: &mut Vec<u8>) -> Result<(), mls_rs_codec::Error> {
         self.protocol_version.mls_encode(writer)?;
         self.wire_format.mls_encode(writer)?;

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2318,7 +2318,7 @@ mod tests {
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
-    async fn test_reused_key_package() -> Result<(), MlsError> {
+    async fn test_reused_key_package() {
         let mut alice_group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
         let (bob_client, bob_key_package) =
             test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "bob").await;
@@ -2328,24 +2328,29 @@ mod tests {
         let commit_output = alice_group
             .group
             .commit_builder()
-            .add_member(bob_key_package.clone())?
+            .add_member(bob_key_package.clone())
+            .unwrap()
             .build()
-            .await?;
+            .await
+            .unwrap();
 
         // Bob joins group.
         let (mut bob_group, _) = bob_client
             .join_group(None, &commit_output.welcome_messages[0])
-            .await?;
+            .await
+            .unwrap();
         // This deletes the key package used to join the group.
-        bob_group.write_to_storage().await?;
+        bob_group.write_to_storage().await.unwrap();
 
         // Carla adds Bob, reusing the same key package.
         let commit_output = carla_group
             .group
             .commit_builder()
-            .add_member(bob_key_package.clone())?
+            .add_member(bob_key_package.clone())
+            .unwrap()
             .build()
-            .await?;
+            .await
+            .unwrap();
 
         // Bob cannot join Carla's group.
         let bob_group = bob_client
@@ -2353,8 +2358,6 @@ mod tests {
             .await
             .map(|_| ());
         assert_matches!(bob_group, Err(MlsError::WelcomeKeyPackageNotFound));
-
-        Ok(())
     }
 
     #[cfg(feature = "last_resort_key_package_ext")]

--- a/mls-rs/src/group/proposal_filter/filtering.rs
+++ b/mls-rs/src/group/proposal_filter/filtering.rs
@@ -53,7 +53,7 @@ use {crate::iter::ParallelIteratorExt, rayon::prelude::*};
 #[cfg(mls_build_async)]
 use futures::{StreamExt, TryStreamExt};
 
-impl<'a, C, P, CSP> ProposalApplier<'a, C, P, CSP>
+impl<C, P, CSP> ProposalApplier<'_, C, P, CSP>
 where
     C: IdentityProvider,
     P: PreSharedKeyStorage,

--- a/mls-rs/src/group/proposal_filter/filtering_lite.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_lite.rs
@@ -42,7 +42,7 @@ use crate::group::{
 #[cfg(all(feature = "std", feature = "psk"))]
 use std::collections::HashSet;
 
-impl<'a, C, P, CSP> ProposalApplier<'a, C, P, CSP>
+impl<C, P, CSP> ProposalApplier<'_, C, P, CSP>
 where
     C: IdentityProvider,
     P: PreSharedKeyStorage,

--- a/mls-rs/src/key_package/generator.rs
+++ b/mls-rs/src/key_package/generator.rs
@@ -73,7 +73,7 @@ impl KeyPackageGeneration {
     }
 }
 
-impl<'a, CP> KeyPackageGenerator<'a, CP>
+impl<CP> KeyPackageGenerator<'_, CP>
 where
     CP: CipherSuiteProvider,
 {

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -139,7 +139,7 @@ impl KeyPackage {
     }
 }
 
-impl<'a> Signable<'a> for KeyPackage {
+impl Signable<'_> for KeyPackage {
     const SIGN_LABEL: &'static str = "KeyPackageTBS";
 
     type SigningContext = ();

--- a/mls-rs/src/signer.rs
+++ b/mls-rs/src/signer.rs
@@ -139,7 +139,7 @@ pub(crate) mod test_utils {
         pub signature: Vec<u8>,
     }
 
-    impl<'a> Signable<'a> for TestSignable {
+    impl Signable<'_> for TestSignable {
         const SIGN_LABEL: &'static str = "SignWithLabel";
 
         type SigningContext = Vec<u8>;

--- a/mls-rs/src/tree_kem/leaf_node.rs
+++ b/mls-rs/src/tree_kem/leaf_node.rs
@@ -186,7 +186,7 @@ struct LeafNodeTBS<'a> {
     leaf_index: Option<u32>,
 }
 
-impl<'a> MlsSize for LeafNodeTBS<'a> {
+impl MlsSize for LeafNodeTBS<'_> {
     fn mls_encoded_len(&self) -> usize {
         self.public_key.mls_encoded_len()
             + self.signing_identity.mls_encoded_len()
@@ -201,7 +201,7 @@ impl<'a> MlsSize for LeafNodeTBS<'a> {
     }
 }
 
-impl<'a> MlsEncode for LeafNodeTBS<'a> {
+impl MlsEncode for LeafNodeTBS<'_> {
     fn mls_encode(&self, writer: &mut Vec<u8>) -> Result<(), mls_rs_codec::Error> {
         self.public_key.mls_encode(writer)?;
         self.signing_identity.mls_encode(writer)?;

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -20,7 +20,7 @@ pub enum ValidationContext<'a> {
     Commit((&'a [u8], u32, Option<MlsTime>)),
 }
 
-impl<'a> ValidationContext<'a> {
+impl ValidationContext<'_> {
     fn signing_context(&self) -> LeafNodeSigningContext {
         match *self {
             ValidationContext::Add(_) => Default::default(),


### PR DESCRIPTION
* Fix warnings clippy found after it updated
* Fix version of wasm-bindgen-test and wasm-bindgen -- it seems that the newest minor versions of these [are incompatible](https://github.com/awslabs/mls-rs/actions/runs/12184270164/job/33987746575#step:6:105); we can investigate in another issue or wait for it to fix itself
* For some reason that version of wasm-bindgen-test freaks out if a test returns Result

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
