### PR TITLE
Key Package Generation / Join API 1.x

### DIFF
--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -43,7 +43,9 @@ jobs:
         run: cargo test --no-default-features --features std,test_util,non-fips  --verbose --workspace
       - name: Examples
         working-directory: mls-rs
-        run: cargo run --example basic_usage
+        run: |
+          cargo run --example basic_usage
+          cargo run --example api_1x
   AsyncBuildAndTest:
     strategy:
       matrix:

--- a/mls-rs-codec/Cargo.toml
+++ b/mls-rs-codec/Cargo.toml
@@ -21,10 +21,10 @@ thiserror = { version = "1.0.40", optional = true }
 assert_matches = "1.5.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2.79" }
+wasm-bindgen = { version = "=0.2.87" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-codec/src/cow.rs
+++ b/mls-rs-codec/src/cow.rs
@@ -5,7 +5,7 @@ use alloc::{
 
 use crate::{Error, MlsDecode, MlsEncode, MlsSize};
 
-impl<'a, T> MlsSize for Cow<'a, T>
+impl<T> MlsSize for Cow<'_, T>
 where
     T: MlsSize + ToOwned,
 {
@@ -14,7 +14,7 @@ where
     }
 }
 
-impl<'a, T> MlsEncode for Cow<'a, T>
+impl<T> MlsEncode for Cow<'_, T>
 where
     T: MlsEncode + ToOwned,
 {
@@ -24,7 +24,7 @@ where
     }
 }
 
-impl<'a, T> MlsDecode for Cow<'a, T>
+impl<T> MlsDecode for Cow<'_, T>
 where
     T: ToOwned,
     <T as ToOwned>::Owned: MlsDecode,

--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -44,10 +44,10 @@ async-trait = "0.1.74"
 assert_matches = "1.5.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "^0.2.79" }
+wasm-bindgen = { version = "=0.2.87" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)', 'cfg(coverage_nightly)'] }

--- a/mls-rs-core/src/identity.rs
+++ b/mls-rs-core/src/identity.rs
@@ -12,8 +12,17 @@ mod x509;
 
 pub use basic::*;
 pub use credential::*;
+use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 pub use provider::*;
 pub use signing_identity::*;
 
 #[cfg(feature = "x509")]
 pub use x509::*;
+
+use crate::crypto::SignatureSecretKey;
+
+#[derive(Clone, Debug, MlsEncode, MlsSize, MlsDecode, PartialEq)]
+pub struct SigningData {
+    pub signing_identity: SigningIdentity,
+    pub signing_key: SignatureSecretKey,
+}

--- a/mls-rs-core/src/identity/provider.rs
+++ b/mls-rs-core/src/identity/provider.rs
@@ -23,7 +23,7 @@ pub enum MemberValidationContext<'a> {
     None,
 }
 
-impl<'a> MemberValidationContext<'a> {
+impl MemberValidationContext<'_> {
     pub fn new_extensions(&self) -> Option<&ExtensionList> {
         match self {
             Self::ForCommit { new_extensions, .. } => Some(*new_extensions),

--- a/mls-rs-crypto-awslc/src/x509/component.rs
+++ b/mls-rs-crypto-awslc/src/x509/component.rs
@@ -374,7 +374,7 @@ pub struct X509ExtensionContext<'a> {
     pub(crate) phantom: PhantomData<&'a Certificate>,
 }
 
-impl<'a> X509ExtensionContext<'a> {
+impl X509ExtensionContext<'_> {
     pub fn as_mut_ptr(&mut self) -> *mut X509V3_CTX {
         &mut self.inner
     }

--- a/mls-rs-crypto-hpke/Cargo.toml
+++ b/mls-rs-crypto-hpke/Cargo.toml
@@ -31,7 +31,7 @@ hex = { version = "^0.4.3", features = ["serde"] }
 mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.12.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(mls_build_async)'.dependencies]

--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -77,7 +77,7 @@ mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false,
 async-trait = "0.1.74"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-crypto-webcrypto/Cargo.toml
+++ b/mls-rs-crypto-webcrypto/Cargo.toml
@@ -17,7 +17,7 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.10"
 async-trait = "0.1.74"
 js-sys = "0.3.64"
-wasm-bindgen = "0.2.87"
+wasm-bindgen = "=0.2.87"
 wasm-bindgen-futures = "0.4.37"
 serde-wasm-bindgen = "0.6"
 serde = { version = "1.0", features = ["derive"] }
@@ -27,7 +27,7 @@ const-oid = { version = "0.9", features = ["db"] }
 
 [dev-dependencies]
 mls-rs-core = { path = "../mls-rs-core", version = "0.20.0", features = ["test_suite"] }
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 futures-test = "0.3.25"
 serde_json = "^1.0"
 hex = { version = "^0.4.3", features = ["serde"] }

--- a/mls-rs-crypto-webcrypto/src/aead.rs
+++ b/mls-rs-crypto-webcrypto/src/aead.rs
@@ -83,9 +83,9 @@ impl Aead {
             .then_some(())
             .ok_or(CryptoError::WrongKeyLength)?;
 
-        let params = AesGcmParams::new(key_type.algorithm(), &Uint8Array::from(nonce));
+        let mut params = AesGcmParams::new(key_type.algorithm(), &Uint8Array::from(nonce));
         let aad = Uint8Array::from(aad.unwrap_or_default());
-        params.set_additional_data(&aad);
+        params.additional_data(&aad);
         let key = key_type.import(&crypto, key).await?;
 
         let out = match key_type {

--- a/mls-rs-crypto-webcrypto/src/key_type.rs
+++ b/mls-rs-crypto-webcrypto/src/key_type.rs
@@ -86,8 +86,8 @@ impl KeyType {
             | KeyType::EcdhSecret(curve)
             | KeyType::EcdsaPublic(curve)
             | KeyType::EcdsaSecret(curve) => {
-                let params = EcKeyImportParams::new(self.algorithm());
-                params.set_named_curve(curve);
+                let mut params = EcKeyImportParams::new(self.algorithm());
+                params.named_curve(curve);
 
                 crypto.import_key_with_object(self.format(), &key, &params, true, &key_usages)?
             }

--- a/mls-rs-identity-x509/Cargo.toml
+++ b/mls-rs-identity-x509/Cargo.toml
@@ -27,12 +27,12 @@ assert_matches = "1"
 rand = "0.8"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "^0.2.79" }
+wasm-bindgen = { version = "=0.2.87" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(mls_build_async)'] }

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 mls-rs-core = { path = "../mls-rs-core", version = "0.20.0" }
 thiserror = "1.0.40"
-wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen = { version = "=0.2.87", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 rusqlite = { version = "0.31", default-features = false }
 rand = "0.8"

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -96,12 +96,12 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 hex = { version = "^0.4.3", default-features = false, features = ["serde", "alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "^0.2.79" }
+wasm-bindgen = { version = "=0.2.87" }
 getrandom = { version = "0.2", features = ["js", "custom"], default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { version = "0.3.26", default-features = false }
+wasm-bindgen-test = { version = "=0.3.26", default-features = false }
 mls-rs-crypto-webcrypto = { path = "../mls-rs-crypto-webcrypto", version = "0.6.0" }
 criterion = { version = "0.5.1", default-features = false, features = ["plotters", "cargo_bench_support", "async_futures", "html_reports"] }
 

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -114,6 +114,10 @@ name = "basic_usage"
 required-features = []
 
 [[example]]
+name = "api_1x"
+required-features = []
+
+[[example]]
 name = "x509"
 required-features = ["x509"]
 

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.43.1"
+version = "0.43.2"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/examples/api_1x.rs
+++ b/mls-rs/examples/api_1x.rs
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright by contributors to this project.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+use std::convert::Infallible;
+
+use mls_rs::{
+    client_builder::MlsConfig,
+    error::MlsError,
+    identity::{
+        basic::{BasicCredential, BasicIdentityProvider},
+        SigningIdentity,
+    },
+    CipherSuite, CipherSuiteProvider, Client, CryptoProvider, ExtensionList, KeyPackageStorage,
+};
+use mls_rs_core::key_package::KeyPackageData;
+
+const CIPHERSUITE: CipherSuite = CipherSuite::CURVE25519_AES128;
+
+fn main() -> Result<(), MlsError> {
+    let crypto_provider = mls_rs_crypto_openssl::OpensslCryptoProvider::default();
+
+    // Create clients for Alice and Bob
+    let alice = make_client(crypto_provider.clone(), "alice")?;
+    let bob = make_client(crypto_provider.clone(), "bob")?;
+
+    // Bob generates key package. We store secrets in memory, no need for any storage.
+    let key_package_generation = bob
+        .key_package_builder(CIPHERSUITE)?
+        .valid_for_sec(123)
+        .build()?;
+
+    let stored_secrets = key_package_generation.key_package_data;
+
+    // Alice creates a group with Bob.
+    let mut alice_group = alice.create_group(ExtensionList::default(), Default::default())?;
+
+    let welcomes = alice_group
+        .commit_builder()
+        .add_member(key_package_generation.key_package_message)?
+        .build()?
+        .welcome_messages;
+
+    alice_group.apply_pending_commit()?;
+
+    // Bob joins
+    let mut bob_group = bob.group_joiner(&welcomes[0], stored_secrets)?.join()?.0;
+
+    // Alice and bob can chat
+    let msg = alice_group.encrypt_application_message(b"hello world", Default::default())?;
+    let msg = bob_group.process_incoming_message(msg)?;
+
+    println!("Received message: {:?}", msg);
+
+    Ok(())
+}
+
+#[derive(Clone)]
+struct NoOpKeyPackageStorage;
+
+impl KeyPackageStorage for NoOpKeyPackageStorage {
+    type Error = Infallible;
+
+    fn delete(&mut self, _: &[u8]) -> Result<(), Infallible> {
+        Ok(())
+    }
+
+    fn get(&self, _: &[u8]) -> Result<Option<KeyPackageData>, Infallible> {
+        Ok(None)
+    }
+
+    fn insert(&mut self, _: Vec<u8>, _: KeyPackageData) -> Result<(), Infallible> {
+        Ok(())
+    }
+}
+
+fn make_client<P: CryptoProvider + Clone>(
+    crypto_provider: P,
+    name: &str,
+) -> Result<Client<impl MlsConfig>, MlsError> {
+    let cipher_suite = crypto_provider.cipher_suite_provider(CIPHERSUITE).unwrap();
+    let (secret, public) = cipher_suite.signature_key_generate().unwrap();
+    let basic_identity = BasicCredential::new(name.as_bytes().to_vec());
+    let signing_identity = SigningIdentity::new(basic_identity.into_credential(), public);
+
+    Ok(Client::builder()
+        .identity_provider(BasicIdentityProvider)
+        .crypto_provider(crypto_provider)
+        .signing_identity(signing_identity, secret, CIPHERSUITE)
+        .key_package_repo(NoOpKeyPackageStorage)
+        .build())
+}

--- a/mls-rs/examples/api_1x.rs
+++ b/mls-rs/examples/api_1x.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), MlsError> {
 
     // Bob generates key package. We store secrets in memory, no need for any storage.
     let key_package_generation = bob
-        .key_package_builder(CIPHERSUITE)?
+        .key_package_builder(CIPHERSUITE, None)?
         .valid_for_sec(123)
         .build()?;
 

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -31,7 +31,9 @@ use mls_rs_core::crypto::{CryptoProvider, SignatureSecretKey};
 use mls_rs_core::error::{AnyError, IntoAnyError};
 use mls_rs_core::extension::{ExtensionError, ExtensionList, ExtensionType};
 use mls_rs_core::group::{GroupStateStorage, ProposalType};
-use mls_rs_core::identity::{CredentialType, IdentityProvider, MemberValidationContext};
+use mls_rs_core::identity::{
+    CredentialType, IdentityProvider, MemberValidationContext, SigningData,
+};
 use mls_rs_core::key_package::{KeyPackageData, KeyPackageStorage};
 
 use crate::group::external_commit::ExternalCommitBuilder;
@@ -491,8 +493,9 @@ where
     pub fn key_package_builder(
         &self,
         cipher_suite: CipherSuite,
+        signing_data: Option<SigningData>,
     ) -> Result<
-        KeyPackageBuilder<'_, <C::CryptoProvider as CryptoProvider>::CipherSuiteProvider>,
+        KeyPackageBuilder<<C::CryptoProvider as CryptoProvider>::CipherSuiteProvider>,
         MlsError,
     > {
         let cipher_suite_provider = self
@@ -501,7 +504,11 @@ where
             .cipher_suite_provider(cipher_suite)
             .ok_or(MlsError::UnsupportedCipherSuite(cipher_suite))?;
 
-        Ok(KeyPackageBuilder::new(self, cipher_suite_provider))
+        Ok(KeyPackageBuilder::new(
+            self,
+            cipher_suite_provider,
+            signing_data,
+        )?)
     }
 
     /// Create a group with a specific group_id.

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -5,9 +5,11 @@
 use crate::cipher_suite::CipherSuite;
 use crate::client_builder::{recreate_config, BaseConfig, ClientBuilder, MakeConfig};
 use crate::client_config::ClientConfig;
-use crate::group::framing::MlsMessage;
+use crate::group::framing::{MlsMessage, MlsMessageDescription};
 
-use crate::group::{cipher_suite_provider, validate_group_info_joiner, GroupInfo};
+use crate::group::{
+    cipher_suite_provider, find_key_package_generation, validate_group_info_joiner, GroupInfo,
+};
 use crate::group::{
     framing::MlsMessagePayload, snapshot::Snapshot, ExportedTree, Group, NewMemberInfo,
 };
@@ -17,6 +19,7 @@ use crate::group::{
     message_signature::AuthenticatedContent,
     proposal::{AddProposal, Proposal},
 };
+use crate::group_joiner::GroupJoiner;
 use crate::identity::SigningIdentity;
 use crate::key_package::builder::KeyPackageBuilder;
 use crate::key_package::{KeyPackageGeneration, KeyPackageGenerator};
@@ -29,7 +32,7 @@ use mls_rs_core::error::{AnyError, IntoAnyError};
 use mls_rs_core::extension::{ExtensionError, ExtensionList, ExtensionType};
 use mls_rs_core::group::{GroupStateStorage, ProposalType};
 use mls_rs_core::identity::{CredentialType, IdentityProvider, MemberValidationContext};
-use mls_rs_core::key_package::KeyPackageStorage;
+use mls_rs_core::key_package::{KeyPackageData, KeyPackageStorage};
 
 use crate::group::external_commit::ExternalCommitBuilder;
 
@@ -575,13 +578,36 @@ where
         tree_data: Option<ExportedTree<'_>>,
         welcome_message: &MlsMessage,
     ) -> Result<(Group<C>, NewMemberInfo), MlsError> {
-        Group::join(
-            welcome_message,
-            tree_data,
-            self.config.clone(),
-            self.signer()?.clone(),
-        )
-        .await
+        let MlsMessageDescription::Welcome {
+            key_package_refs, ..
+        } = welcome_message.description()
+        else {
+            return Err(MlsError::UnexpectedMessageType);
+        };
+
+        let key_package_data =
+            find_key_package_generation(&self.config.key_package_repo(), &key_package_refs).await?;
+
+        let mut joiner = self
+            .group_joiner(welcome_message, key_package_data)
+            .await?
+            .signature_secret_key(self.signer()?.clone());
+
+        if let Some(tree) = tree_data {
+            joiner = joiner.ratchet_tree(tree);
+        }
+
+        joiner.join().await
+    }
+
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub async fn group_joiner<'a, 'b>(
+        &self,
+        welcome_message: &'a MlsMessage,
+        key_package_data: KeyPackageData,
+    ) -> Result<GroupJoiner<'a, 'b, C>, MlsError> {
+        GroupJoiner::new(self.config.clone(), welcome_message, key_package_data).await
     }
 
     /// Decrypt GroupInfo encrypted in the Welcome message without actually joining

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -504,11 +504,7 @@ where
             .cipher_suite_provider(cipher_suite)
             .ok_or(MlsError::UnsupportedCipherSuite(cipher_suite))?;
 
-        Ok(KeyPackageBuilder::new(
-            self,
-            cipher_suite_provider,
-            signing_data,
-        )?)
+        KeyPackageBuilder::new(self, cipher_suite_provider, signing_data)
     }
 
     /// Create a group with a specific group_id.

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -18,6 +18,7 @@ use crate::group::{
     proposal::{AddProposal, Proposal},
 };
 use crate::identity::SigningIdentity;
+use crate::key_package::builder::KeyPackageBuilder;
 use crate::key_package::{KeyPackageGeneration, KeyPackageGenerator};
 use crate::protocol_version::ProtocolVersion;
 use crate::tree_kem::node::NodeIndex;
@@ -481,6 +482,23 @@ where
             .map_err(|e| MlsError::KeyPackageRepoError(e.into_any_error()))?;
 
         Ok(key_pkg_gen)
+    }
+
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
+    pub fn key_package_builder(
+        &self,
+        cipher_suite: CipherSuite,
+    ) -> Result<
+        KeyPackageBuilder<'_, <C::CryptoProvider as CryptoProvider>::CipherSuiteProvider>,
+        MlsError,
+    > {
+        let cipher_suite_provider = self
+            .config
+            .crypto_provider()
+            .cipher_suite_provider(cipher_suite)
+            .ok_or(MlsError::UnsupportedCipherSuite(cipher_suite))?;
+
+        Ok(KeyPackageBuilder::new(self, cipher_suite_provider))
     }
 
     /// Create a group with a specific group_id.

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -338,6 +338,8 @@ pub enum MlsError {
     InvalidGroupInfo,
     #[cfg_attr(feature = "std", error("Invalid welcome message"))]
     InvalidWelcomeMessage,
+    #[cfg_attr(feature = "std", error("Exporter deleted"))]
+    ExporterDeleted,
 }
 
 impl IntoAnyError for MlsError {

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -607,7 +607,13 @@ where
         welcome_message: &'a MlsMessage,
         key_package_data: KeyPackageData,
     ) -> Result<GroupJoiner<'a, 'b, C>, MlsError> {
-        GroupJoiner::new(self.config.clone(), welcome_message, key_package_data).await
+        GroupJoiner::new(
+            self.config.clone(),
+            welcome_message,
+            key_package_data,
+            self.signer.clone(),
+        )
+        .await
     }
 
     /// Decrypt GroupInfo encrypted in the Welcome message without actually joining

--- a/mls-rs/src/extension.rs
+++ b/mls-rs/src/extension.rs
@@ -5,8 +5,6 @@
 pub use mls_rs_core::extension::{ExtensionType, MlsCodecExtension, MlsExtension};
 
 pub(crate) use built_in::*;
-#[cfg(feature = "last_resort_key_package_ext")]
-pub(crate) use recommended::*;
 
 /// Default extension types required by the MLS RFC.
 pub mod built_in;

--- a/mls-rs/src/external_client.rs
+++ b/mls-rs/src/external_client.rs
@@ -13,10 +13,7 @@ mod config;
 mod group;
 
 pub(crate) use config::ExternalClientConfig;
-use mls_rs_core::{
-    crypto::{CryptoProvider, SignatureSecretKey},
-    identity::SigningIdentity,
-};
+use mls_rs_core::{crypto::CryptoProvider, identity::SigningData};
 
 use builder::{ExternalBaseConfig, ExternalClientBuilder};
 
@@ -39,7 +36,7 @@ pub use group::{ExternalGroup, ExternalReceivedMessage, ExternalSnapshot};
 /// the resulting group state.
 pub struct ExternalClient<C> {
     config: C,
-    signing_data: Option<(SignatureSecretKey, SigningIdentity)>,
+    signing_data: Option<SigningData>,
 }
 
 impl ExternalClient<()> {
@@ -52,10 +49,7 @@ impl<C> ExternalClient<C>
 where
     C: ExternalClientConfig + Clone,
 {
-    pub(crate) fn new(
-        config: C,
-        signing_data: Option<(SignatureSecretKey, SigningIdentity)>,
-    ) -> Self {
+    pub(crate) fn new(config: C, signing_data: Option<SigningData>) -> Self {
         Self {
             config,
             signing_data,

--- a/mls-rs/src/external_client/builder.rs
+++ b/mls-rs/src/external_client/builder.rs
@@ -276,7 +276,10 @@ impl<C: IntoConfig> ExternalClientBuilder<C> {
         signing_identity: SigningIdentity,
     ) -> ExternalClientBuilder<IntoConfigOutput<C>> {
         let mut c = self.0.into_config();
-        c.0.signing_data = Some((signer, signing_identity));
+        c.0.signing_data = Some(SigningData {
+            signing_identity,
+            signing_key: signer,
+        });
         ExternalClientBuilder(c)
     }
 }
@@ -520,7 +523,7 @@ impl Default for Settings {
 /// Definitions meant to be private that are inaccessible outside this crate. They need to be marked
 /// `pub` because they appear in public definitions.
 mod private {
-    use mls_rs_core::{crypto::SignatureSecretKey, identity::SigningIdentity};
+    use mls_rs_core::identity::SigningData;
 
     use super::{IntoConfigOutput, Settings};
 
@@ -533,7 +536,7 @@ mod private {
         pub(crate) identity_provider: Ip,
         pub(crate) mls_rules: Mpf,
         pub(crate) crypto_provider: Cp,
-        pub(crate) signing_data: Option<(SignatureSecretKey, SigningIdentity)>,
+        pub(crate) signing_data: Option<SigningData>,
     }
 
     pub trait IntoConfig {
@@ -557,7 +560,7 @@ mod private {
 
 use mls_rs_core::{
     crypto::SignatureSecretKey,
-    identity::{IdentityProvider, SigningIdentity},
+    identity::{IdentityProvider, SigningData, SigningIdentity},
 };
 use private::{Config, ConfigInner, IntoConfig};
 

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -243,11 +243,24 @@ where
     /// [`PreSharedKeyProposal`](crate::group::proposal::PreSharedKeyProposal) with
     /// a resumption PSK into the current commit that is being built.
     #[cfg(feature = "psk")]
-    pub fn add_resumption_psk(mut self, psk_epoch: u64) -> Result<Self, MlsError> {
+    pub fn add_resumption_psk(self, psk_epoch: u64) -> Result<Self, MlsError> {
+        let group_id = self.group.group_id().to_vec();
+        self.add_resumption_psk_for_group(psk_epoch, group_id)
+    }
+
+    /// Insert a
+    /// [`PreSharedKeyProposal`](crate::group::proposal::PreSharedKeyProposal) with
+    /// a resumption PSK into the current commit that is being built.
+    #[cfg(feature = "psk")]
+    pub fn add_resumption_psk_for_group(
+        mut self,
+        psk_epoch: u64,
+        group_id: Vec<u8>,
+    ) -> Result<Self, MlsError> {
         let psk_id = ResumptionPsk {
             psk_epoch,
             usage: ResumptionPSKUsage::Application,
-            psk_group_id: PskGroupId(self.group.group_id().to_vec()),
+            psk_group_id: PskGroupId(group_id),
         };
 
         let key_id = JustPreSharedKeyID::Resumption(psk_id);

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -211,7 +211,6 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             KeySchedule::new(init_secret),
             epoch_secrets,
             TreeKemPrivate::new_for_external(),
-            None,
             self.signer,
         )
         .await?;

--- a/mls-rs/src/group/framing.rs
+++ b/mls-rs/src/group/framing.rs
@@ -793,7 +793,7 @@ mod tests {
     async fn message_description() {
         let mut group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
 
-        let message = group.commit(vec![]).unwrap();
+        let message = group.commit(vec![]).await.unwrap();
 
         let expected = MlsMessageDescription::ProtocolMessage {
             group_id: group.group_id(),

--- a/mls-rs/src/group/framing.rs
+++ b/mls-rs/src/group/framing.rs
@@ -715,6 +715,7 @@ pub(crate) mod test_utils {
 #[cfg(feature = "private_message")]
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
     use assert_matches::assert_matches;
 
     use crate::{

--- a/mls-rs/src/group/group_info.rs
+++ b/mls-rs/src/group/group_info.rs
@@ -67,7 +67,7 @@ struct SignableGroupInfo<'a> {
     signer: LeafIndex,
 }
 
-impl<'a> Signable<'a> for GroupInfo {
+impl Signable<'_> for GroupInfo {
     const SIGN_LABEL: &'static str = "GroupInfoTBS";
     type SigningContext = ();
 

--- a/mls-rs/src/group/key_schedule.rs
+++ b/mls-rs/src/group/key_schedule.rs
@@ -83,6 +83,10 @@ impl KeySchedule {
         }
     }
 
+    pub fn delete_exporter(&mut self) {
+        self.exporter_secret = Default::default();
+    }
+
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn derive_for_external<P: CipherSuiteProvider>(
         &self,
@@ -234,6 +238,10 @@ impl KeySchedule {
         len: usize,
         cipher_suite: &P,
     ) -> Result<Zeroizing<Vec<u8>>, MlsError> {
+        if self.exporter_secret.is_empty() {
+            return Err(MlsError::ExporterDeleted);
+        }
+
         let secret = kdf_derive_secret(cipher_suite, &self.exporter_secret, label).await?;
 
         let context_hash = cipher_suite

--- a/mls-rs/src/group/message_processor.rs
+++ b/mls-rs/src/group/message_processor.rs
@@ -73,7 +73,7 @@ pub(crate) struct ProvisionalState {
 // psk
 // reinit
 pub(crate) fn path_update_required(proposals: &ProposalBundle) -> bool {
-    let res = proposals.external_init_proposals().first().is_some();
+    let res = !proposals.external_init_proposals().is_empty();
 
     #[cfg(feature = "by_ref_proposal")]
     let res = res || !proposals.update_proposals().is_empty();

--- a/mls-rs/src/group/message_signature.rs
+++ b/mls-rs/src/group/message_signature.rs
@@ -159,7 +159,7 @@ pub(crate) struct AuthenticatedContentTBS<'a> {
     pub(crate) context: Option<&'a GroupContext>,
 }
 
-impl<'a> MlsSize for AuthenticatedContentTBS<'a> {
+impl MlsSize for AuthenticatedContentTBS<'_> {
     fn mls_encoded_len(&self) -> usize {
         self.protocol_version.mls_encoded_len()
             + self.wire_format.mls_encoded_len()
@@ -168,7 +168,7 @@ impl<'a> MlsSize for AuthenticatedContentTBS<'a> {
     }
 }
 
-impl<'a> MlsEncode for AuthenticatedContentTBS<'a> {
+impl MlsEncode for AuthenticatedContentTBS<'_> {
     fn mls_encode(&self, writer: &mut Vec<u8>) -> Result<(), mls_rs_codec::Error> {
         self.protocol_version.mls_encode(writer)?;
         self.wire_format.mls_encode(writer)?;

--- a/mls-rs/src/group/message_verifier.rs
+++ b/mls-rs/src/group/message_verifier.rs
@@ -300,14 +300,10 @@ mod tests {
 
             alice.apply_pending_commit().await.unwrap();
 
-            let (bob, _) = Group::join(
-                &commit_output.welcome_messages[0],
-                None,
-                bob_client.config,
-                bob_client.signer.unwrap(),
-            )
-            .await
-            .unwrap();
+            let (bob, _) = bob_client
+                .join_group(None, &commit_output.welcome_messages[0])
+                .await
+                .unwrap();
 
             TestEnv {
                 alice,

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2318,7 +2318,7 @@ mod tests {
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
-    async fn test_reused_key_package() -> Result<(), MlsError> {
+    async fn test_reused_key_package() {
         let mut alice_group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
         let (bob_client, bob_key_package) =
             test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "bob").await;
@@ -2328,24 +2328,29 @@ mod tests {
         let commit_output = alice_group
             .group
             .commit_builder()
-            .add_member(bob_key_package.clone())?
+            .add_member(bob_key_package.clone())
+            .unwrap()
             .build()
-            .await?;
+            .await
+            .unwrap();
 
         // Bob joins group.
         let (mut bob_group, _) = bob_client
             .join_group(None, &commit_output.welcome_messages[0])
-            .await?;
+            .await
+            .unwrap();
         // This deletes the key package used to join the group.
-        bob_group.write_to_storage().await?;
+        bob_group.write_to_storage().await.unwrap();
 
         // Carla adds Bob, reusing the same key package.
         let commit_output = carla_group
             .group
             .commit_builder()
-            .add_member(bob_key_package.clone())?
+            .add_member(bob_key_package.clone())
+            .unwrap()
             .build()
-            .await?;
+            .await
+            .unwrap();
 
         // Bob cannot join Carla's group.
         let bob_group = bob_client
@@ -2353,8 +2358,6 @@ mod tests {
             .await
             .map(|_| ());
         assert_matches!(bob_group, Err(MlsError::WelcomeKeyPackageNotFound));
-
-        Ok(())
     }
 
     #[cfg(feature = "last_resort_key_package_ext")]

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1504,7 +1504,7 @@ impl<C: ClientConfig> Group<C> {
         let key_package_data =
             find_key_package_generation(&config.key_package_repo(), &key_package_refs).await?;
 
-        let (group_info, _, _) = GroupJoiner::new(config.clone(), welcome, key_package_data)
+        let (group_info, _, _) = GroupJoiner::new(config.clone(), welcome, key_package_data, None)
             .await?
             .decrypt_group_info()
             .await?;
@@ -1513,7 +1513,6 @@ impl<C: ClientConfig> Group<C> {
     }
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
-
     pub(crate) async fn decrypt_group_secrets<'a>(
         welcome: &'a MlsMessage,
         config: &C,

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1504,10 +1504,11 @@ impl<C: ClientConfig> Group<C> {
         let key_package_data =
             find_key_package_generation(&config.key_package_repo(), &key_package_refs).await?;
 
-        let (group_info, _, _) = GroupJoiner::new(config.clone(), welcome, key_package_data, None)
+        let group_info = GroupJoiner::new(config.clone(), welcome, key_package_data, None)
             .await?
             .decrypt_group_info()
-            .await?;
+            .await?
+            .group_info;
 
         Ok(group_info)
     }

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1438,6 +1438,11 @@ where
         Ok(self.key_schedule.authentication_secret.clone().into())
     }
 
+    /// Export a secret for use outside of MLS. Each epoch, label, context
+    /// combination has a unique and independent secret. Secrets for all
+    /// epochs, labels and contexts can be derived until either the epoch
+    /// changes, i.e. a commit is received (or own commit is applied), or
+    /// [Group::delete_exporter] is called.
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn export_secret(
         &self,
@@ -1449,6 +1454,15 @@ where
             .export_secret(label, context, len, &self.cipher_suite_provider)
             .await
             .map(Into::into)
+    }
+
+    /// Delete the exporter secret. Afterwards the state contains no information
+    /// about any secrets outputted by [Group::export_secret] (for the current or
+    /// past epochs). This means that after calling this function, [Group::export_secret]
+    /// can no longer be used and we get forward secrecy for all secrets derived using
+    /// [Group::export_secret].
+    pub fn delete_exporter(&mut self) {
+        self.key_schedule.delete_exporter();
     }
 
     /// Export the current epoch's ratchet tree in serialized format.
@@ -4411,5 +4425,20 @@ mod tests {
             .unwrap();
 
         assert_eq!(restored.group_state(), group.group_state());
+    }
+
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn delete_exporter() {
+        let mut group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
+
+        group.export_secret(b"123", b"", 15).await.unwrap();
+
+        group.delete_exporter();
+        let res = group.export_secret(b"123", b"", 15).await;
+        assert_matches!(res, Err(MlsError::ExporterDeleted));
+
+        group.commit(vec![]).await.unwrap();
+        group.apply_pending_commit().await.unwrap();
+        group.export_secret(b"123", b"", 15).await.unwrap();
     }
 }

--- a/mls-rs/src/group/proposal_filter/filtering.rs
+++ b/mls-rs/src/group/proposal_filter/filtering.rs
@@ -53,7 +53,7 @@ use {crate::iter::ParallelIteratorExt, rayon::prelude::*};
 #[cfg(mls_build_async)]
 use futures::{StreamExt, TryStreamExt};
 
-impl<'a, C, P, CSP> ProposalApplier<'a, C, P, CSP>
+impl<C, P, CSP> ProposalApplier<'_, C, P, CSP>
 where
     C: IdentityProvider,
     P: PreSharedKeyStorage,

--- a/mls-rs/src/group/proposal_filter/filtering_lite.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_lite.rs
@@ -42,7 +42,7 @@ use crate::group::{
 #[cfg(all(feature = "std", feature = "psk"))]
 use std::collections::HashSet;
 
-impl<'a, C, P, CSP> ProposalApplier<'a, C, P, CSP>
+impl<C, P, CSP> ProposalApplier<'_, C, P, CSP>
 where
     C: IdentityProvider,
     P: PreSharedKeyStorage,

--- a/mls-rs/src/group/resumption.rs
+++ b/mls-rs/src/group/resumption.rs
@@ -298,9 +298,8 @@ async fn resumption_join_group<C: ClientConfig + Clone>(
     let key_package_data =
         find_key_package_generation(&config.key_package_repo(), &key_package_refs).await?;
 
-    let mut joiner = GroupJoiner::new(config.clone(), welcome, key_package_data)
+    let mut joiner = GroupJoiner::new(config.clone(), welcome, key_package_data, Some(signer))
         .await?
-        .signature_secret_key(signer)
         .additional_psk(psk_input);
 
     if let Some(tree) = tree_data {

--- a/mls-rs/src/group/snapshot.rs
+++ b/mls-rs/src/group/snapshot.rs
@@ -194,7 +194,6 @@ where
             snapshot.state.context.group_id.clone(),
             config.group_state_storage(),
             config.key_package_repo(),
-            None,
         )?;
 
         Ok(Group {

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -108,13 +108,9 @@ impl TestGroup {
         config(&mut new_client.config);
 
         // Group from new member's perspective
-        let (new_group, _) = Group::join(
-            &welcome_messages[0],
-            ratchet_tree,
-            new_client.config.clone(),
-            new_client.signer.clone().unwrap(),
-        )
-        .await?;
+        let (new_group, _) = new_client
+            .join_group(ratchet_tree, &welcome_messages[0])
+            .await?;
 
         let new_test_group = TestGroup { group: new_group };
 

--- a/mls-rs/src/group_joiner.rs
+++ b/mls-rs/src/group_joiner.rs
@@ -261,6 +261,7 @@ pub(crate) struct DecryptedGroupInfo {
 #[cfg(feature = "psk")]
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use mls_rs_core::psk::{ExternalPskId, PreSharedKey};
 
     use crate::{

--- a/mls-rs/src/group_joiner.rs
+++ b/mls-rs/src/group_joiner.rs
@@ -1,0 +1,239 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright by contributors to this project.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+use mls_rs_codec::MlsDecode;
+use mls_rs_core::{
+    crypto::{CipherSuite, HpkeSecretKey, SignatureSecretKey},
+    key_package::KeyPackageData,
+    protocol_version::ProtocolVersion,
+    psk::ExternalPskId,
+};
+
+use crate::{
+    client_config::ClientConfig,
+    error::MlsError,
+    group::{
+        cipher_suite_provider,
+        key_schedule::{KeySchedule, WelcomeSecret},
+        validate_tree_and_info_joiner, ExportedTree, GroupInfo, GroupSecrets, NewMemberInfo,
+        Welcome,
+    },
+    psk::{secret::PskSecret, JustPreSharedKeyID, ResumptionPsk},
+    tree_kem::{TreeKemPrivate, TreeKemPublic},
+    Group, KeyPackage, MlsMessage,
+};
+
+pub struct GroupJoiner<'a, 'b, C> {
+    // Parsed data
+    group_secrets: GroupSecrets,
+    welcome: &'a Welcome,
+    version: ProtocolVersion,
+    key_package: KeyPackage,
+    leaf_secret: HpkeSecretKey,
+    config: C,
+
+    // Inputted by application
+    tree: Option<ExportedTree<'b>>,
+    signer: Option<SignatureSecretKey>,
+
+    // Needed for reinit
+    #[cfg(feature = "psk")]
+    additional_psk: Option<crate::psk::secret::PskSecretInput>,
+}
+
+impl<'a, 'b, C: ClientConfig> GroupJoiner<'a, 'b, C> {
+    // Info
+    pub fn required_external_psks(&self) -> impl Iterator<Item = &ExternalPskId> {
+        self.group_secrets
+            .psks
+            .iter()
+            .filter_map(|psk| match &psk.key_id {
+                JustPreSharedKeyID::External(psk) => Some(psk),
+                _ => None,
+            })
+    }
+
+    pub fn required_resumption_psks(&self) -> impl Iterator<Item = &ResumptionPsk> {
+        self.group_secrets
+            .psks
+            .iter()
+            .filter_map(|psk| match &psk.key_id {
+                JustPreSharedKeyID::Resumption(psk) => Some(psk),
+                _ => None,
+            })
+    }
+
+    pub fn cipher_suite(&self) -> CipherSuite {
+        self.welcome.cipher_suite
+    }
+
+    // Settings
+    pub fn ratchet_tree(self, tree: ExportedTree<'b>) -> Self {
+        Self {
+            tree: Some(tree),
+            ..self
+        }
+    }
+
+    pub fn signature_secret_key(self, signature_secret_key: SignatureSecretKey) -> Self {
+        Self {
+            signer: Some(signature_secret_key),
+            ..self
+        }
+    }
+
+    // TODO with_psks
+
+    // Reinit
+    #[cfg(feature = "psk")]
+    pub(crate) fn additional_psk(self, additional_psk: crate::psk::secret::PskSecretInput) -> Self {
+        Self {
+            additional_psk: Some(additional_psk),
+            ..self
+        }
+    }
+
+    // Joining
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub(crate) async fn new(
+        config: C,
+        welcome_msg: &'a MlsMessage,
+        key_package_data: KeyPackageData,
+    ) -> Result<Self, MlsError> {
+        let key_package = KeyPackage::mls_decode(&mut &*key_package_data.key_package_bytes)?;
+        let init_key = &key_package_data.init_key;
+
+        let (group_secrets, welcome) =
+            Group::decrypt_group_secrets(welcome_msg, &config, &key_package, init_key).await?;
+
+        Ok(Self {
+            group_secrets,
+            welcome,
+            tree: None,
+            config,
+            version: welcome_msg.version,
+            key_package,
+            leaf_secret: key_package_data.leaf_node_key,
+            signer: None,
+            #[cfg(feature = "psk")]
+            additional_psk: None,
+        })
+    }
+
+    /// Decrypt and validate the GroupInfo from this Welcome message. This requires
+    /// that the ratchet tree is a part of GroupInfo or has been provided with
+    /// [GroupJoiner::tree], and that all required PSKs have been provided [TODO].
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub(crate) async fn decrypt_group_info(
+        &mut self,
+    ) -> Result<(GroupInfo, TreeKemPublic, PskSecret), MlsError> {
+        let cipher_suite_provider =
+            cipher_suite_provider(self.config.crypto_provider(), self.welcome.cipher_suite)?;
+
+        let psk_secret = Group::psk_secret(
+            &self.config,
+            &cipher_suite_provider,
+            &self.group_secrets.psks,
+            #[cfg(feature = "psk")]
+            self.additional_psk.take(),
+        )
+        .await?;
+
+        // From the joiner_secret in the decrypted GroupSecrets object and the PSKs specified in
+        // the GroupSecrets, derive the welcome_secret and using that the welcome_key and
+        // welcome_nonce.
+        let welcome_secret = WelcomeSecret::from_joiner_secret(
+            &cipher_suite_provider,
+            &self.group_secrets.joiner_secret,
+            &psk_secret,
+        )
+        .await?;
+
+        // Use the key and nonce to decrypt the encrypted_group_info field.
+        let decrypted_group_info = welcome_secret
+            .decrypt(&self.welcome.encrypted_group_info)
+            .await?;
+
+        let decrypted_group_info = GroupInfo::mls_decode(&mut &**decrypted_group_info)?;
+
+        let id_provider = self.config.identity_provider();
+
+        let public_tree = validate_tree_and_info_joiner(
+            self.version,
+            &decrypted_group_info,
+            self.tree.take(),
+            &id_provider,
+            &cipher_suite_provider,
+        )
+        .await?;
+
+        Ok((decrypted_group_info, public_tree, psk_secret))
+    }
+
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub async fn join(mut self) -> Result<(Group<C>, NewMemberInfo), MlsError> {
+        let (group_info, public_tree, psk_secret) = self.decrypt_group_info().await?;
+
+        let cipher_suite_provider =
+            cipher_suite_provider(self.config.crypto_provider(), self.welcome.cipher_suite)?;
+
+        // [RFC] Identify a leaf whose LeafNode is identical to the one in the KeyPackage. If no
+        // such field exists, return an error.
+        let self_index = public_tree
+            .find_leaf_node(&self.key_package.leaf_node)
+            .ok_or(MlsError::WelcomeKeyPackageNotFound)?;
+
+        let mut private_tree = TreeKemPrivate::new_self_leaf(self_index, self.leaf_secret);
+
+        // If the path_secret value is set in the GroupSecrets object
+        if let Some(path_secret) = self.group_secrets.path_secret {
+            private_tree
+                .update_secrets(
+                    &cipher_suite_provider,
+                    group_info.signer,
+                    path_secret,
+                    &public_tree,
+                )
+                .await?;
+        }
+
+        // Use the joiner_secret from the GroupSecrets object to generate the epoch secret and
+        // other derived secrets for the current epoch.
+        let key_schedule_result = KeySchedule::from_joiner(
+            &cipher_suite_provider,
+            &self.group_secrets.joiner_secret,
+            &group_info.group_context,
+            #[cfg(any(feature = "secret_tree_access", feature = "private_message"))]
+            public_tree.total_leaf_count(),
+            &psk_secret,
+        )
+        .await?;
+
+        // Verify the confirmation tag in the GroupInfo using the derived confirmation key and the
+        // confirmed_transcript_hash from the GroupInfo.
+        if !group_info
+            .confirmation_tag
+            .matches(
+                &key_schedule_result.confirmation_key,
+                &group_info.group_context.confirmed_transcript_hash,
+                &cipher_suite_provider,
+            )
+            .await?
+        {
+            return Err(MlsError::InvalidConfirmationTag);
+        }
+
+        Group::join_with(
+            self.config,
+            group_info,
+            public_tree,
+            key_schedule_result.key_schedule,
+            key_schedule_result.epoch_secrets,
+            private_tree,
+            self.signer.ok_or(MlsError::SignerNotFound)?,
+        )
+        .await
+        .map_err(Into::into)
+    }
+}

--- a/mls-rs/src/group_joiner.rs
+++ b/mls-rs/src/group_joiner.rs
@@ -100,6 +100,7 @@ impl<'a, 'b, C: ClientConfig> GroupJoiner<'a, 'b, C> {
         config: C,
         welcome_msg: &'a MlsMessage,
         key_package_data: KeyPackageData,
+        signer: Option<SignatureSecretKey>,
     ) -> Result<Self, MlsError> {
         let key_package = KeyPackage::mls_decode(&mut &*key_package_data.key_package_bytes)?;
         let init_key = &key_package_data.init_key;
@@ -115,7 +116,7 @@ impl<'a, 'b, C: ClientConfig> GroupJoiner<'a, 'b, C> {
             version: welcome_msg.version,
             key_package,
             leaf_secret: key_package_data.leaf_node_key,
-            signer: None,
+            signer,
             #[cfg(feature = "psk")]
             additional_psk: None,
         })

--- a/mls-rs/src/group_joiner.rs
+++ b/mls-rs/src/group_joiner.rs
@@ -7,8 +7,10 @@ use mls_rs_core::{
     crypto::{CipherSuite, HpkeSecretKey, SignatureSecretKey},
     key_package::KeyPackageData,
     protocol_version::ProtocolVersion,
-    psk::ExternalPskId,
 };
+
+#[cfg(feature = "psk")]
+use mls_rs_core::psk::ExternalPskId;
 
 use crate::{
     client_config::ClientConfig,
@@ -19,10 +21,13 @@ use crate::{
         validate_tree_and_info_joiner, ExportedTree, GroupInfo, GroupSecrets, NewMemberInfo,
         Welcome,
     },
-    psk::{secret::PskSecret, JustPreSharedKeyID, ResumptionPsk},
+    psk::secret::PskSecret,
     tree_kem::{TreeKemPrivate, TreeKemPublic},
     Group, KeyPackage, MlsMessage,
 };
+
+#[cfg(feature = "psk")]
+use crate::psk::{JustPreSharedKeyID, ResumptionPsk};
 
 pub struct GroupJoiner<'a, 'b, C> {
     // Parsed data

--- a/mls-rs/src/key_package/builder.rs
+++ b/mls-rs/src/key_package/builder.rs
@@ -1,0 +1,303 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright by contributors to this project.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+use core::fmt::Debug;
+
+use alloc::vec;
+use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
+use mls_rs_core::error::IntoAnyError;
+use mls_rs_core::extension::MlsExtension;
+
+use crate::client::MlsError;
+use crate::client_config::ClientConfig;
+use crate::Client;
+use crate::{
+    crypto::{HpkeSecretKey, SignatureSecretKey},
+    group::framing::MlsMessagePayload,
+    identity::SigningIdentity,
+    protocol_version::ProtocolVersion,
+    signer::Signable,
+    tree_kem::{
+        leaf_node::{ConfigProperties, LeafNode},
+        Capabilities, Lifetime,
+    },
+    CipherSuiteProvider, ExtensionList, MlsMessage,
+};
+
+use super::{KeyPackage, KeyPackageRef};
+
+#[derive(Clone, Debug)]
+pub struct KeyPackageBuilder<'a, CP> {
+    protocol_version: ProtocolVersion,
+    cipher_suite_provider: CP,
+    signing_identity: Option<SigningIdentity>,
+    signing_key: Option<&'a SignatureSecretKey>,
+    key_package_extensions: ExtensionList,
+    leaf_node_extensions: ExtensionList,
+    validity_sec: u64,
+    // This I feel like can still be fixed for client as it rarely changes?
+    capabilities: Capabilities,
+}
+
+impl<'a, CP> KeyPackageBuilder<'a, CP> {
+    pub fn signing_data(
+        self,
+        signing_identity: SigningIdentity,
+        signing_key: &'a SignatureSecretKey,
+    ) -> Self {
+        Self {
+            signing_identity: Some(signing_identity),
+            signing_key: Some(signing_key),
+            ..self
+        }
+    }
+
+    pub fn with_key_package_extension<T: MlsExtension>(
+        mut self,
+        extension: T,
+    ) -> Result<Self, MlsError> {
+        self.key_package_extensions.set_from(extension)?;
+
+        Ok(self)
+    }
+
+    pub fn with_leaf_node_extension<T: MlsExtension>(
+        mut self,
+        extension: T,
+    ) -> Result<Self, MlsError> {
+        self.leaf_node_extensions.set_from(extension)?;
+
+        Ok(self)
+    }
+
+    pub fn valid_for_sec(self, validity_sec: u64) -> Self {
+        Self {
+            validity_sec,
+            ..self
+        }
+    }
+}
+
+impl<CP: CipherSuiteProvider> KeyPackageBuilder<'_, CP> {
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub async fn build(self) -> Result<KeyPackageGeneration, MlsError> {
+        let (signing_identity, signing_key) = self
+            .signing_identity
+            .zip(self.signing_key)
+            .ok_or(MlsError::SignerNotFound)?;
+
+        let (init_secret_key, public_init) = self
+            .cipher_suite_provider
+            .kem_generate()
+            .await
+            .map_err(|e| MlsError::CryptoProviderError(e.into_any_error()))?;
+
+        let properties = ConfigProperties {
+            capabilities: self.capabilities,
+            extensions: self.leaf_node_extensions,
+        };
+
+        let lifetime = Lifetime::seconds(self.validity_sec)?;
+
+        let (leaf_node, leaf_node_secret) = LeafNode::generate(
+            &self.cipher_suite_provider,
+            properties,
+            signing_identity,
+            signing_key,
+            lifetime,
+        )
+        .await?;
+
+        let mut package = KeyPackage {
+            version: self.protocol_version,
+            cipher_suite: self.cipher_suite_provider.cipher_suite(),
+            hpke_init_key: public_init,
+            leaf_node,
+            extensions: self.key_package_extensions,
+            signature: vec![],
+        };
+
+        package.grease(&self.cipher_suite_provider)?;
+
+        package
+            .sign(&self.cipher_suite_provider, signing_key, &())
+            .await?;
+
+        Ok(KeyPackageGeneration {
+            reference: package.to_reference(&self.cipher_suite_provider).await?,
+            key_package_message: MlsMessage::new(
+                self.protocol_version,
+                MlsMessagePayload::KeyPackage(package),
+            ),
+            secrets: KeyPackageSecrets {
+                init_secret_key,
+                leaf_node_secret,
+            },
+            not_after: lifetime.not_after,
+        })
+    }
+}
+
+#[derive(Clone, PartialEq, MlsEncode, MlsDecode, MlsSize, Debug)]
+#[non_exhaustive]
+pub struct KeyPackageSecrets {
+    pub init_secret_key: HpkeSecretKey,
+    pub leaf_node_secret: HpkeSecretKey,
+}
+
+#[derive(Clone, Debug)]
+pub struct KeyPackageGeneration {
+    pub reference: KeyPackageRef,
+    pub key_package_message: MlsMessage,
+    pub secrets: KeyPackageSecrets,
+    pub not_after: u64,
+}
+
+impl<'a, CP> KeyPackageBuilder<'a, CP> {
+    pub(crate) fn new<C: ClientConfig>(client: &'a Client<C>, cipher_suite_provider: CP) -> Self {
+        Self {
+            protocol_version: client.version,
+            cipher_suite_provider,
+            signing_identity: client.signing_identity.clone().map(|(id, _)| id),
+            signing_key: client.signer.as_ref(),
+            key_package_extensions: Default::default(),
+            leaf_node_extensions: Default::default(),
+            validity_sec: 86400 * 366,
+            capabilities: client.config.capabilities(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "std")]
+    use std::collections::HashSet;
+
+    #[cfg(not(feature = "std"))]
+    use alloc::collections::BTreeSet as HashSet;
+
+    use mls_rs_core::crypto::CipherSuiteProvider;
+
+    use crate::{
+        client::test_utils::{TestClientBuilder, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
+        crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider},
+        extension::test_utils::TestExtension,
+        group::test_utils::random_bytes,
+        identity::basic::BasicIdentityProvider,
+        key_package::validate_key_package_properties,
+        protocol_version::ProtocolVersion,
+        tree_kem::leaf_node_validator::{LeafNodeValidator, ValidationContext},
+    };
+
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn test_key_generation() {
+        for (protocol_version, cipher_suite) in ProtocolVersion::all().flat_map(|p| {
+            TestCryptoProvider::all_supported_cipher_suites()
+                .into_iter()
+                .map(move |cs| (p, cs))
+        }) {
+            let cipher_suite_provider = test_cipher_suite_provider(cipher_suite);
+
+            let client = TestClientBuilder::new_for_test()
+                .with_random_signing_identity("something", cipher_suite)
+                .await
+                .protocol_version(protocol_version)
+                .extension_types([42.into()].into_iter())
+                .build();
+
+            let generated = client
+                .key_package_builder(cipher_suite)
+                .unwrap()
+                .with_key_package_extension(TestExtension::from(32))
+                .unwrap()
+                .with_leaf_node_extension(TestExtension::from(42))
+                .unwrap()
+                .build()
+                .await
+                .unwrap();
+
+            let generated_kp = generated.key_package_message.into_key_package().unwrap();
+
+            assert_eq!(
+                TestExtension::from(32),
+                generated_kp.extensions.get_as().unwrap().unwrap()
+            );
+
+            assert_eq!(
+                TestExtension::from(32),
+                generated_kp.extensions.get_as().unwrap().unwrap()
+            );
+
+            assert_eq!(
+                TestExtension::from(42),
+                generated_kp.leaf_node.extensions.get_as().unwrap().unwrap()
+            );
+
+            assert_ne!(
+                generated_kp.hpke_init_key,
+                generated_kp.leaf_node.public_key
+            );
+
+            assert_eq!(generated_kp.cipher_suite, cipher_suite);
+            assert_eq!(generated_kp.version, protocol_version);
+
+            // Verify that the hpke key pair generated will work
+            let test_data = random_bytes(32);
+
+            let sealed = cipher_suite_provider
+                .hpke_seal(&generated_kp.hpke_init_key, &[], None, &test_data)
+                .await
+                .unwrap();
+
+            let opened = cipher_suite_provider
+                .hpke_open(
+                    &sealed,
+                    &generated.secrets.init_secret_key,
+                    &generated_kp.hpke_init_key,
+                    &[],
+                    None,
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(opened, test_data);
+
+            let validator =
+                LeafNodeValidator::new_for_test(&cipher_suite_provider, &BasicIdentityProvider);
+
+            validator
+                .check_if_valid(&generated_kp.leaf_node, ValidationContext::Add(None))
+                .await
+                .unwrap();
+
+            validate_key_package_properties(
+                &generated_kp,
+                protocol_version,
+                &cipher_suite_provider,
+            )
+            .await
+            .unwrap();
+        }
+    }
+
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn test_randomness() {
+        let client = TestClientBuilder::new_for_test()
+            .with_random_signing_identity("something", TEST_CIPHER_SUITE)
+            .await
+            .protocol_version(TEST_PROTOCOL_VERSION)
+            .extension_types([42.into()].into_iter())
+            .build();
+
+        let builder = client.key_package_builder(TEST_CIPHER_SUITE).unwrap();
+        let mut generated_keys = HashSet::new();
+
+        for _ in 0..100 {
+            let pkg = builder.clone().build().await.unwrap();
+            let pkg = pkg.key_package_message.into_key_package().unwrap();
+            assert!(generated_keys.insert(pkg.hpke_init_key));
+            assert!(generated_keys.insert(pkg.leaf_node.public_key));
+        }
+    }
+}

--- a/mls-rs/src/key_package/builder.rs
+++ b/mls-rs/src/key_package/builder.rs
@@ -203,7 +203,7 @@ mod tests {
                 .with_random_signing_identity("something", cipher_suite)
                 .await
                 .protocol_version(protocol_version)
-                .extension_types([42.into()].into_iter())
+                .extension_types([42.into()])
                 .build();
 
             let generated = client
@@ -287,7 +287,7 @@ mod tests {
             .with_random_signing_identity("something", TEST_CIPHER_SUITE)
             .await
             .protocol_version(TEST_PROTOCOL_VERSION)
-            .extension_types([42.into()].into_iter())
+            .extension_types([42.into()])
             .build();
 
         let builder = client.key_package_builder(TEST_CIPHER_SUITE).unwrap();

--- a/mls-rs/src/key_package/builder.rs
+++ b/mls-rs/src/key_package/builder.rs
@@ -161,7 +161,7 @@ impl<CP> KeyPackageBuilder<CP> {
                 signing_identity,
                 signing_key,
             })
-            .or_else(|| signing_data)
+            .or(signing_data)
             .ok_or(MlsError::SignerNotFound)?;
 
         Ok(Self {

--- a/mls-rs/src/key_package/builder.rs
+++ b/mls-rs/src/key_package/builder.rs
@@ -220,6 +220,7 @@ mod tests {
                 .unwrap()
                 .with_leaf_node_extension(TestExtension::from(42))
                 .unwrap()
+                .valid_for_sec(123456)
                 .build()
                 .await
                 .unwrap();

--- a/mls-rs/src/key_package/generator.rs
+++ b/mls-rs/src/key_package/generator.rs
@@ -4,7 +4,7 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
-use mls_rs_codec::{MlsDecode, MlsEncode};
+use mls_rs_codec::MlsEncode;
 use mls_rs_core::{error::IntoAnyError, key_package::KeyPackageData};
 
 use crate::client::MlsError;
@@ -54,15 +54,6 @@ impl KeyPackageGeneration {
         );
 
         Ok((id, data))
-    }
-
-    pub fn from_storage(id: Vec<u8>, data: KeyPackageData) -> Result<Self, MlsError> {
-        Ok(KeyPackageGeneration {
-            reference: KeyPackageRef::from(id),
-            key_package: KeyPackage::mls_decode(&mut &*data.key_package_bytes)?,
-            init_secret_key: data.init_key,
-            leaf_node_secret_key: data.leaf_node_key,
-        })
     }
 
     pub fn key_package_message(&self) -> MlsMessage {

--- a/mls-rs/src/key_package/generator.rs
+++ b/mls-rs/src/key_package/generator.rs
@@ -205,7 +205,7 @@ mod tests {
 
             let generated = test_generator
                 .generate(
-                    lifetime.clone(),
+                    lifetime,
                     capabilities.clone(),
                     key_package_ext.clone(),
                     leaf_node_ext.clone(),

--- a/mls-rs/src/key_package/generator.rs
+++ b/mls-rs/src/key_package/generator.rs
@@ -73,7 +73,7 @@ impl KeyPackageGeneration {
     }
 }
 
-impl<'a, CP> KeyPackageGenerator<'a, CP>
+impl<CP> KeyPackageGenerator<'_, CP>
 where
     CP: CipherSuiteProvider,
 {

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -139,7 +139,7 @@ impl KeyPackage {
     }
 }
 
-impl<'a> Signable<'a> for KeyPackage {
+impl Signable<'_> for KeyPackage {
     const SIGN_LABEL: &'static str = "KeyPackageTBS";
 
     type SigningContext = ();

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -87,7 +87,7 @@ impl From<Vec<u8>> for KeyPackageRef {
 }
 
 #[derive(MlsSize, MlsEncode)]
-struct KeyPackageData<'a> {
+struct KeyPackageTbs<'a> {
     pub version: ProtocolVersion,
     pub cipher_suite: CipherSuite,
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
@@ -154,7 +154,7 @@ impl Signable<'_> for KeyPackage {
         &self,
         _context: &Self::SigningContext,
     ) -> Result<Vec<u8>, mls_rs_codec::Error> {
-        KeyPackageData {
+        KeyPackageTbs {
             version: self.version,
             cipher_suite: self.cipher_suite,
             hpke_init_key: &self.hpke_init_key,

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -21,10 +21,12 @@ use mls_rs_codec::MlsEncode;
 use mls_rs_codec::MlsSize;
 use mls_rs_core::extension::ExtensionList;
 
+pub(crate) mod builder;
 mod validator;
 pub(crate) use validator::*;
 
 pub(crate) mod generator;
+//pub use builder::*;
 pub(crate) use generator::*;
 
 #[non_exhaustive]

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -26,7 +26,6 @@ mod validator;
 pub(crate) use validator::*;
 
 pub(crate) mod generator;
-//pub use builder::*;
 pub(crate) use generator::*;
 
 #[non_exhaustive]

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -143,6 +143,7 @@ pub mod external_client;
 mod grease;
 /// E2EE group created by a [`Client`].
 pub mod group;
+pub(crate) mod group_joiner;
 mod hash_reference;
 /// Identity providers to use with [`ClientBuilder`](client_builder::ClientBuilder).
 pub mod identity;

--- a/mls-rs/src/psk.rs
+++ b/mls-rs/src/psk.rs
@@ -62,7 +62,7 @@ pub(crate) enum JustPreSharedKeyID {
 #[derive(Clone, Eq, Hash, Ord, PartialOrd, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub(crate) struct PskGroupId(
+pub struct PskGroupId(
     #[mls_codec(with = "mls_rs_codec::byte_vec")]
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     pub Vec<u8>,
@@ -107,7 +107,7 @@ impl PskNonce {
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub(crate) struct ResumptionPsk {
+pub struct ResumptionPsk {
     pub usage: ResumptionPSKUsage,
     pub psk_group_id: PskGroupId,
     pub psk_epoch: u64,
@@ -117,7 +117,7 @@ pub(crate) struct ResumptionPsk {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
-pub(crate) enum ResumptionPSKUsage {
+pub enum ResumptionPSKUsage {
     Application = 1u8,
     Reinit = 2u8,
     Branch = 3u8,

--- a/mls-rs/src/signer.rs
+++ b/mls-rs/src/signer.rs
@@ -139,7 +139,7 @@ pub(crate) mod test_utils {
         pub signature: Vec<u8>,
     }
 
-    impl<'a> Signable<'a> for TestSignable {
+    impl Signable<'_> for TestSignable {
         const SIGN_LABEL: &'static str = "SignWithLabel";
 
         type SigningContext = Vec<u8>;

--- a/mls-rs/src/tree_kem/leaf_node.rs
+++ b/mls-rs/src/tree_kem/leaf_node.rs
@@ -432,7 +432,7 @@ mod tests {
                 &secret,
                 capabilities.clone(),
                 extensions.clone(),
-                lifetime.clone(),
+                lifetime,
             )
             .await;
 

--- a/mls-rs/src/tree_kem/leaf_node.rs
+++ b/mls-rs/src/tree_kem/leaf_node.rs
@@ -186,7 +186,7 @@ struct LeafNodeTBS<'a> {
     leaf_index: Option<u32>,
 }
 
-impl<'a> MlsSize for LeafNodeTBS<'a> {
+impl MlsSize for LeafNodeTBS<'_> {
     fn mls_encoded_len(&self) -> usize {
         self.public_key.mls_encoded_len()
             + self.signing_identity.mls_encoded_len()
@@ -201,7 +201,7 @@ impl<'a> MlsSize for LeafNodeTBS<'a> {
     }
 }
 
-impl<'a> MlsEncode for LeafNodeTBS<'a> {
+impl MlsEncode for LeafNodeTBS<'_> {
     fn mls_encode(&self, writer: &mut Vec<u8>) -> Result<(), mls_rs_codec::Error> {
         self.public_key.mls_encode(writer)?;
         self.signing_identity.mls_encode(writer)?;

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -20,7 +20,7 @@ pub enum ValidationContext<'a> {
     Commit((&'a [u8], u32, Option<MlsTime>)),
 }
 
-impl<'a> ValidationContext<'a> {
+impl ValidationContext<'_> {
     fn signing_context(&self) -> LeafNodeSigningContext {
         match *self {
             ValidationContext::Add(_) => Default::default(),

--- a/mls-rs/src/tree_kem/lifetime.rs
+++ b/mls-rs/src/tree_kem/lifetime.rs
@@ -5,7 +5,7 @@
 use crate::{client::MlsError, time::MlsTime};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
-#[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]

--- a/mls-rs/src/tree_kem/parent_hash.rs
+++ b/mls-rs/src/tree_kem/parent_hash.rs
@@ -135,7 +135,7 @@ impl TreeKemPublic {
             )
             .await?;
 
-            (parent.parent_hash, hash) = (hash, calculated);
+            parent.parent_hash = core::mem::replace(&mut hash, calculated);
         }
 
         Ok(hash)

--- a/mls-rs/src/tree_kem/tree_hash.rs
+++ b/mls-rs/src/tree_kem/tree_hash.rs
@@ -95,22 +95,23 @@ impl TreeKemPublic {
     ) -> Result<(), MlsError> {
         let num_leaves = self.total_leaf_count();
 
-        let trailing_blanks = (0..num_leaves)
-            .rev()
-            .map_while(|l| {
+        let leaves = updated_leaves
+            .iter()
+            .copied()
+            .chain((0..num_leaves).rev().map_while(|l| {
                 self.tree_hashes
                     .current
                     .get(2 * l as usize)
                     .is_none()
                     .then_some(LeafIndex(l))
-            })
+            }))
             .collect::<Vec<_>>();
 
         // Update the current hashes for direct paths of all modified leaves.
         tree_hash(
             &mut self.tree_hashes.current,
             &self.nodes,
-            Some([updated_leaves, &trailing_blanks].concat()),
+            Some(leaves),
             &[],
             num_leaves,
             cipher_suite_provider,


### PR DESCRIPTION
### Issues:

Resolves #216
Addresses #207 #215

### Description of changes:

- Includes the commit from main fixing CI (clippy, bindgen version)
- Addresses the key package storage aspect
- Logic was just moved between files, no functional changes
- Old API still exists in order to preserve tests and make review manageable
  - **follow up** remove old API, remove key package storage

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
