### PR TITLE
Add API for deleting exporters

### DIFF
--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -338,6 +338,8 @@ pub enum MlsError {
     InvalidGroupInfo,
     #[cfg_attr(feature = "std", error("Invalid welcome message"))]
     InvalidWelcomeMessage,
+    #[cfg_attr(feature = "std", error("Exporter deleted"))]
+    ExporterDeleted,
 }
 
 impl IntoAnyError for MlsError {

--- a/mls-rs/src/group/key_schedule.rs
+++ b/mls-rs/src/group/key_schedule.rs
@@ -83,6 +83,10 @@ impl KeySchedule {
         }
     }
 
+    pub fn delete_exporter(&mut self) {
+        self.exporter_secret = Default::default();
+    }
+
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn derive_for_external<P: CipherSuiteProvider>(
         &self,
@@ -234,6 +238,10 @@ impl KeySchedule {
         len: usize,
         cipher_suite: &P,
     ) -> Result<Zeroizing<Vec<u8>>, MlsError> {
+        if self.exporter_secret.is_empty() {
+            return Err(MlsError::ExporterDeleted);
+        }
+
         let secret = kdf_derive_secret(cipher_suite, &self.exporter_secret, label).await?;
 
         let context_hash = cipher_suite

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1442,7 +1442,7 @@ where
     /// combination has a unique and independent secret. Secrets for all
     /// epochs, labels and contexts can be derived until either the epoch
     /// changes, i.e. a commit is received (or own commit is applied), or
-    /// (Group::delete_exporter) is called.
+    /// [Group::delete_exporter] is called.
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn export_secret(
         &self,
@@ -1457,10 +1457,10 @@ where
     }
 
     /// Delete the exporter secret. Afterwards the state contains no information
-    /// aboud any secrets outputted by (Group::export_secret) (for the current or
-    /// past epochs). This means that after calling this function (Group::export_secret)
+    /// about any secrets outputted by [Group::export_secret] (for the current or
+    /// past epochs). This means that after calling this function, [Group::export_secret]
     /// can no longer be used and we get forward secrecy for all secrets derived using
-    /// (Group::export_secret).
+    /// [Group::export_secret].
     pub fn delete_exporter(&mut self) {
         self.key_schedule.delete_exporter();
     }

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1438,6 +1438,11 @@ where
         Ok(self.key_schedule.authentication_secret.clone().into())
     }
 
+    /// Export a secret for use outside of MLS. Each epoch, label, context
+    /// combination has a unique and independent secret. Secrets for all
+    /// epochs, labels and contexts can be derived until either the epoch
+    /// changes, i.e. a commit is received (or own commit is applied), or
+    /// (Group::delete_exporter) is called.
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn export_secret(
         &self,
@@ -1449,6 +1454,15 @@ where
             .export_secret(label, context, len, &self.cipher_suite_provider)
             .await
             .map(Into::into)
+    }
+
+    /// Delete the exporter secret. Afterwards the state contains no information
+    /// aboud any secrets outputted by (Group::export_secret) (for the current or
+    /// past epochs). This means that after calling this function (Group::export_secret)
+    /// can no longer be used and we get forward secrecy for all secrets derived using
+    /// (Group::export_secret).
+    pub fn delete_exporter(&mut self) {
+        self.key_schedule.delete_exporter();
     }
 
     /// Export the current epoch's ratchet tree in serialized format.
@@ -4411,5 +4425,20 @@ mod tests {
             .unwrap();
 
         assert_eq!(restored.group_state(), group.group_state());
+    }
+
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn delete_exporter() {
+        let mut group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
+
+        group.export_secret(b"123", b"", 15).await.unwrap();
+
+        group.delete_exporter();
+        let res = group.export_secret(b"123", b"", 15).await;
+        assert_matches!(res, Err(MlsError::ExporterDeleted));
+
+        group.commit(vec![]).await.unwrap();
+        group.apply_pending_commit().await.unwrap();
+        group.export_secret(b"123", b"", 15).await.unwrap();
     }
 }


### PR DESCRIPTION
Deleting the exporter enables forward secrecy of derived values within an epoch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
