### PR TITLE
Fix bug where double-hitting a ciphertext deleted the whole ratchet

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.43.1"
+version = "0.43.2"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"


### PR DESCRIPTION
Problem in an application
* Receive a ciphertext from leaf 2, generation 0
* Receive that ciphertext again
  * ratchet is deleted
  * message_key_generation throws an error
  * we exit, ratchet is gone
* We can't receive from leaf 2, generation 1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
