### PR TITLE
Work around rust < 1.78 crash

### DIFF
--- a/mls-rs/src/tree_kem/parent_hash.rs
+++ b/mls-rs/src/tree_kem/parent_hash.rs
@@ -135,7 +135,7 @@ impl TreeKemPublic {
             )
             .await?;
 
-            (parent.parent_hash, hash) = (hash, calculated);
+            parent.parent_hash = core::mem::replace(&mut hash, calculated);
         }
 
         Ok(hash)


### PR DESCRIPTION
Somehow the DWARF info generated by the compiler for the `hash`-replacement assignment is confusing to LLVM, which crashes.

By using a different form for the same operation, the compiler is happy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
