### PR TITLE
Bump version of mls-rs-crypto-traits after breaking change

### DIFF
--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -20,7 +20,7 @@ aws-lc-sys = { version = "=0.24.1", optional = true }
 aws-lc-fips-sys = { version = "=0.13.0", optional = true }
 mls-rs-core = { path = "../mls-rs-core", version = "0.20.0" }
 mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.12.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.12.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.13.0" }
 mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.14.0" }
 thiserror = "1.0.40"
 zeroize = { version = "1", features = ["zeroize_derive"] }

--- a/mls-rs-crypto-cryptokit/Cargo.toml
+++ b/mls-rs-crypto-cryptokit/Cargo.toml
@@ -25,7 +25,7 @@ mls-rs-core = { path = "../mls-rs-core", version = "0.20.0", features = ["test_s
 [dependencies]
 maybe-async = "0.2.10"
 mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.20.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.12.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.13.0" }
 thiserror = { version = "1.0.63", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 

--- a/mls-rs-crypto-hpke/Cargo.toml
+++ b/mls-rs-crypto-hpke/Cargo.toml
@@ -16,7 +16,7 @@ test_utils = ["mls-rs-core/test_suite"]
 
 [dependencies]
 mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.20.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.12.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.13.0" }
 thiserror = { version = "1.0.40", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 cfg-if = "^1"
@@ -28,7 +28,7 @@ serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
 mockall = "0.12"
 hex = { version = "^0.4.3", features = ["serde"] }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.12.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.13.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "=0.3.26", default-features = false }

--- a/mls-rs-crypto-openssl/Cargo.toml
+++ b/mls-rs-crypto-openssl/Cargo.toml
@@ -17,7 +17,7 @@ openssl = { version = "0.10.40" }
 mls-rs-core = { path = "../mls-rs-core", version = "0.20.0" }
 mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.14.0" }
 mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.12.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.12.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.13.0" }
 thiserror = "1.0.40"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.10"

--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -31,7 +31,7 @@ std = [
 [dependencies]
 mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.20.0" }
 mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.12.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.12.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.13.0" }
 
 thiserror = { version = "1.0.40", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }

--- a/mls-rs-crypto-traits/Cargo.toml
+++ b/mls-rs-crypto-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-traits"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Crypto traits required to create a CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs-crypto-webcrypto/Cargo.toml
+++ b/mls-rs-crypto-webcrypto/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["std"], version = "0.20.0" }
 mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, features = ["std"], version = "0.12.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, features = ["std"], version = "0.12.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, features = ["std"], version = "0.13.0" }
 thiserror = "1.0.40"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.10"


### PR DESCRIPTION
Versions of dependent packages are already higher than on crates io.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
