### PR TITLE
Make CommitProcessor another variant of ReceivedMessage.

### DIFF
--- a/mls-rs/examples/api_1x.rs
+++ b/mls-rs/examples/api_1x.rs
@@ -42,7 +42,10 @@ fn main() -> Result<(), MlsError> {
 
     // Alice and bob can chat
     let msg = alice_group.encrypt_application_message(b"hello world", Default::default())?;
-    let msg = bob_group.process_incoming_message(msg)?;
+
+    let msg = bob_group
+        .process_incoming_message(msg)?
+        .into_received_message();
 
     println!("Received message: {:?}", msg);
 

--- a/mls-rs/examples/basic_server_usage.rs
+++ b/mls-rs/examples/basic_server_usage.rs
@@ -60,9 +60,12 @@ impl BasicServer {
         let mut group = server.load_group(group_state)?;
 
         let proposal_msg = MlsMessage::from_bytes(&proposal)?;
-        let res = group.process_incoming_message(proposal_msg)?;
 
-        let ExternalReceivedMessage::Proposal(proposal_desc) = res else {
+        let res = group
+            .process_incoming_message(proposal_msg)?
+            .into_received_message();
+
+        let Some(ExternalReceivedMessage::Proposal(proposal_desc)) = res else {
             panic!("expected proposal message!")
         };
 
@@ -86,9 +89,12 @@ impl BasicServer {
         }
 
         let commit_msg = MlsMessage::from_bytes(&commit)?;
-        let res = group.process_incoming_message(commit_msg)?;
 
-        let ExternalReceivedMessage::Commit(_commit_desc) = res else {
+        let res = group
+            .process_incoming_message(commit_msg)?
+            .into_received_message();
+
+        let Some(ExternalReceivedMessage::Commit(_commit_desc)) = res else {
             panic!("expected commit message!")
         };
 
@@ -184,7 +190,10 @@ fn main() -> Result<(), MlsError> {
     // Bob downloads the commit
     let message = server.download_messages(1).first().unwrap();
 
-    let res = bob_group.process_incoming_message(MlsMessage::from_bytes(message)?)?;
+    let res = bob_group
+        .process_incoming_message(MlsMessage::from_bytes(message)?)?
+        .into_received_message()
+        .unwrap();
 
     let ReceivedMessage::Commit(commit_desc) = res else {
         panic!("expected commit message")

--- a/mls-rs/examples/basic_usage.rs
+++ b/mls-rs/examples/basic_usage.rs
@@ -72,7 +72,9 @@ fn main() -> Result<(), MlsError> {
     let msg = alice_group.encrypt_application_message(b"hello world", Default::default())?;
 
     // Bob decrypts the application message from Alice.
-    let msg = bob_group.process_incoming_message(msg)?;
+    let msg = bob_group
+        .process_incoming_message(msg)?
+        .into_received_message();
 
     println!("Received message: {:?}", msg);
 

--- a/mls-rs/examples/custom.rs
+++ b/mls-rs/examples/custom.rs
@@ -29,7 +29,7 @@ use mls_rs::{
     error::MlsError,
     group::{
         proposal::{MlsCustomProposal, Proposal},
-        GroupContext, Sender,
+        GroupContext, ReceivedMessage, Sender,
     },
     mls_rules::{ProposalBundle, ProposalSource},
     CipherSuite, CipherSuiteProvider, Client, CryptoProvider, ExtensionList, IdentityProvider,
@@ -408,7 +408,12 @@ fn main() -> Result<(), CustomError> {
 
     alice_tablet_group.apply_pending_commit()?;
 
-    let mut processor = alice_pc_group.commit_processor(commit.commit_message)?;
+    let ReceivedMessage::CommitProcessor(mut processor) =
+        alice_pc_group.process_incoming_message(commit.commit_message)?
+    else {
+        return Err(CustomError);
+    };
+
     handle_custom_proposals(&processor.context().clone(), processor.proposals_mut())?;
     processor.process()?;
 

--- a/mls-rs/examples/custom.rs
+++ b/mls-rs/examples/custom.rs
@@ -29,7 +29,7 @@ use mls_rs::{
     error::MlsError,
     group::{
         proposal::{MlsCustomProposal, Proposal},
-        GroupContext, ReceivedMessage, Sender,
+        GroupContext, Sender,
     },
     mls_rules::{ProposalBundle, ProposalSource},
     CipherSuite, CipherSuiteProvider, Client, CryptoProvider, ExtensionList, IdentityProvider,
@@ -408,11 +408,10 @@ fn main() -> Result<(), CustomError> {
 
     alice_tablet_group.apply_pending_commit()?;
 
-    let ReceivedMessage::CommitProcessor(mut processor) =
-        alice_pc_group.process_incoming_message(commit.commit_message)?
-    else {
-        return Err(CustomError);
-    };
+    let mut processor = alice_pc_group
+        .process_incoming_message(commit.commit_message)?
+        .into_processor()
+        .ok_or(CustomError)?;
 
     handle_custom_proposals(&processor.context().clone(), processor.proposals_mut())?;
     processor.process()?;

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -1020,10 +1020,9 @@ mod tests {
 
         assert_eq!(new_group.roster().members_iter().count(), num_members);
 
-        let _ = alice_group
+        alice_group
             .commit_processor(external_commit.clone())
             .await
-            .unwrap()
             .with_external_psk(psk_id.clone(), psk.clone())
             .process()
             .await
@@ -1034,7 +1033,6 @@ mod tests {
         let message = bob_group
             .commit_processor(external_commit.clone())
             .await
-            .unwrap()
             .with_external_psk(psk_id, psk)
             .process()
             .await
@@ -1045,9 +1043,6 @@ mod tests {
         if !do_remove {
             assert!(bob_group.roster().members_iter().count() == num_members);
         } else {
-            // Bob was removed so his epoch must stay the same
-            assert_eq!(bob_group.current_epoch(), bob_current_epoch);
-
             assert_matches!(
                 message,
                 CommitMessageDescription {
@@ -1058,6 +1053,11 @@ mod tests {
                     ..
                 }
             );
+
+            core::mem::drop(message);
+
+            // Bob was removed so his epoch must stay the same
+            assert_eq!(bob_group.current_epoch(), bob_current_epoch);
         }
 
         // Comparing epoch authenticators is sufficient to check that members are in sync.

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -958,7 +958,7 @@ mod tests {
             .unwrap();
 
         assert_matches!(
-            message,
+            message.into_received_message().unwrap(),
             ReceivedMessage::Proposal(ProposalMessageDescription {
                 proposal: Proposal::Add(p), ..}
             ) if p.key_package.leaf_node.signing_identity == bob_identity

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -2,6 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+use core::fmt::{self, Debug};
+
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::{
     error::IntoAnyError,
@@ -24,7 +26,7 @@ use crate::{
             ApplicationMessageDescription, CommitMessageDescription, EventOrContent,
             MessageProcessor, ProposalMessageDescription, ProvisionalState,
         },
-        new_commit_processor, process_commit,
+        process_commit,
         proposal::RemoveProposal,
         proposal_filter::ProposalInfo,
         snapshot::RawGroupState,
@@ -83,12 +85,12 @@ use alloc::boxed::Box;
 
 /// The result of processing an [ExternalGroup](ExternalGroup) message using
 /// [process_incoming_message](ExternalGroup::process_incoming_message)
-#[derive(Clone, Debug)]
+#[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::ffi_type(opaque))]
 #[allow(clippy::large_enum_variant)]
-pub enum ExternalReceivedMessage {
-    /// State update as the result of a successful commit.
+pub enum ExternalReceivedMessage<'a, C: ExternalClientConfig> {
+    /// A new commit was processed creating a new group state.
     Commit(CommitMessageDescription),
-    /// Received proposal and its unique identifier.
+    /// A proposal was received.
     Proposal(ProposalMessageDescription),
     /// Encrypted message that can not be processed.
     Ciphertext(ContentType),
@@ -98,6 +100,30 @@ pub enum ExternalReceivedMessage {
     Welcome,
     /// Validated key package
     KeyPackage(KeyPackage),
+    /// A new commit can be processed to create a new group state.
+    CommitProcessor(ExternalCommitProcessor<'a, C>),
+}
+
+impl<C: ExternalClientConfig> Debug for ExternalReceivedMessage<'_, C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExternalReceivedMessage::Commit(value) => f.write_str(&format!("Commit({value:?})")),
+            ExternalReceivedMessage::Proposal(value) => {
+                f.write_str(&format!("Proposal({value:?})"))
+            }
+            ExternalReceivedMessage::Ciphertext(value) => {
+                f.write_str(&format!("Ciphertext({value:?})"))
+            }
+            ExternalReceivedMessage::GroupInfo(value) => {
+                f.write_str(&format!("GroupInfo({value:?})"))
+            }
+            ExternalReceivedMessage::KeyPackage(value) => {
+                f.write_str(&format!("KeyPackage({value:?})"))
+            }
+            ExternalReceivedMessage::Welcome => f.write_str("Welcome"),
+            ExternalReceivedMessage::CommitProcessor(_) => f.write_str("CommitProcessor"),
+        }
+    }
 }
 
 /// A handle to an observed group that can track plaintext control messages
@@ -188,7 +214,7 @@ impl<C: ExternalClientConfig + Clone> ExternalGroup<C> {
     pub async fn process_incoming_message(
         &mut self,
         message: MlsMessage,
-    ) -> Result<ExternalReceivedMessage, MlsError> {
+    ) -> Result<ExternalReceivedMessage<'_, C>, MlsError> {
         MessageProcessor::process_incoming_message(
             self,
             message,
@@ -196,6 +222,27 @@ impl<C: ExternalClientConfig + Clone> ExternalGroup<C> {
             self.config.cache_proposals(),
         )
         .await
+    }
+
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub async fn process_incoming_message_oneshot(
+        &mut self,
+        message: MlsMessage,
+    ) -> Result<ExternalReceivedMessage<'_, C>, MlsError> {
+        let received_message = MessageProcessor::process_incoming_message(
+            self,
+            message,
+            #[cfg(feature = "by_ref_proposal")]
+            self.config.cache_proposals(),
+        )
+        .await?;
+
+        match received_message {
+            ExternalReceivedMessage::CommitProcessor(p) => {
+                p.process().await.map(ExternalReceivedMessage::Commit)
+            }
+            other => Ok(other),
+        }
     }
 
     /// Replay a proposal message into the group skipping all validation steps.
@@ -577,13 +624,13 @@ impl<C: ExternalClientConfig + Clone> ExternalGroup<C> {
     all(not(target_arch = "wasm32"), mls_build_async),
     maybe_async::must_be_async
 )]
-impl<C> MessageProcessor for ExternalGroup<C>
+impl<'a, C> MessageProcessor<'a> for ExternalGroup<C>
 where
-    C: ExternalClientConfig + Clone,
+    C: 'a + ExternalClientConfig + Clone,
 {
     type MlsRules = C::MlsRules;
     type IdentityProvider = C::IdentityProvider;
-    type OutputType = ExternalReceivedMessage;
+    type OutputType = ExternalReceivedMessage<'a, C>;
     type CipherSuiteProvider = <C::CryptoProvider as CryptoProvider>::CipherSuiteProvider;
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
@@ -744,13 +791,9 @@ where
     }
 }
 
-impl From<CommitMessageDescription> for ExternalReceivedMessage {
-    fn from(value: CommitMessageDescription) -> Self {
-        ExternalReceivedMessage::Commit(value)
-    }
-}
-
-impl TryFrom<ApplicationMessageDescription> for ExternalReceivedMessage {
+impl<C: ExternalClientConfig> TryFrom<ApplicationMessageDescription>
+    for ExternalReceivedMessage<'_, C>
+{
     type Error = MlsError;
 
     fn try_from(_: ApplicationMessageDescription) -> Result<Self, Self::Error> {
@@ -758,25 +801,39 @@ impl TryFrom<ApplicationMessageDescription> for ExternalReceivedMessage {
     }
 }
 
-impl From<ProposalMessageDescription> for ExternalReceivedMessage {
+impl<'a, C: ExternalClientConfig> From<InternalCommitProcessor<'a, ExternalGroup<C>>>
+    for ExternalReceivedMessage<'a, C>
+{
+    fn from(value: InternalCommitProcessor<'a, ExternalGroup<C>>) -> Self {
+        ExternalReceivedMessage::CommitProcessor(ExternalCommitProcessor(value))
+    }
+}
+
+impl<C: ExternalClientConfig> From<CommitMessageDescription> for ExternalReceivedMessage<'_, C> {
+    fn from(value: CommitMessageDescription) -> Self {
+        ExternalReceivedMessage::Commit(value)
+    }
+}
+
+impl<C: ExternalClientConfig> From<ProposalMessageDescription> for ExternalReceivedMessage<'_, C> {
     fn from(value: ProposalMessageDescription) -> Self {
         ExternalReceivedMessage::Proposal(value)
     }
 }
 
-impl From<GroupInfo> for ExternalReceivedMessage {
+impl<C: ExternalClientConfig> From<GroupInfo> for ExternalReceivedMessage<'_, C> {
     fn from(value: GroupInfo) -> Self {
         ExternalReceivedMessage::GroupInfo(value)
     }
 }
 
-impl From<Welcome> for ExternalReceivedMessage {
+impl<C: ExternalClientConfig> From<Welcome> for ExternalReceivedMessage<'_, C> {
     fn from(_: Welcome) -> Self {
         ExternalReceivedMessage::Welcome
     }
 }
 
-impl From<KeyPackage> for ExternalReceivedMessage {
+impl<C: ExternalClientConfig> From<KeyPackage> for ExternalReceivedMessage<'_, C> {
     fn from(value: KeyPackage) -> Self {
         ExternalReceivedMessage::KeyPackage(value)
     }
@@ -819,17 +876,6 @@ impl<C: ExternalClientConfig> ExternalCommitProcessor<'_, C> {
 
     pub fn authenticated_data(&self) -> &[u8] {
         &self.0.authenticated_data
-    }
-}
-
-impl<C: ExternalClientConfig> ExternalGroup<C> {
-    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
-    pub async fn commit_processor(
-        &mut self,
-        commit_message: MlsMessage,
-    ) -> Result<ExternalCommitProcessor<'_, C>, MlsError> {
-        let p = new_commit_processor(self, commit_message).await?;
-        Ok(ExternalCommitProcessor(p))
     }
 }
 
@@ -965,7 +1011,7 @@ mod tests {
         alice.apply_pending_commit().await.unwrap();
 
         server
-            .process_incoming_message(commit_output.commit_message)
+            .process_incoming_message_oneshot(commit_output.commit_message)
             .await
             .unwrap();
 
@@ -986,7 +1032,10 @@ mod tests {
 
         let packet = alice.propose(add_proposal.clone()).await;
 
-        let proposal_process = server.process_incoming_message(packet).await.unwrap();
+        let proposal_process = server
+            .process_incoming_message_oneshot(packet)
+            .await
+            .unwrap();
 
         assert_matches!(
             proposal_process,
@@ -997,7 +1046,7 @@ mod tests {
         alice.apply_pending_commit().await.unwrap();
 
         let new_epoch = match server
-            .process_incoming_message(commit_output.commit_message)
+            .process_incoming_message_oneshot(commit_output.commit_message)
             .await
             .unwrap()
         {
@@ -1024,7 +1073,11 @@ mod tests {
         let mut server = make_external_group(&alice).await;
         let (_, commit) = alice.join("bob").await;
 
-        let new_epoch = match server.process_incoming_message(commit).await.unwrap() {
+        let new_epoch = match server
+            .process_incoming_message_oneshot(commit)
+            .await
+            .unwrap()
+        {
             ExternalReceivedMessage::Commit(CommitMessageDescription {
                 effect: CommitEffect::NewEpoch(new_epoch),
                 ..
@@ -1061,7 +1114,7 @@ mod tests {
         };
 
         let res = server
-            .process_incoming_message(commit_output.commit_message)
+            .process_incoming_message_oneshot(commit_output.commit_message)
             .await;
 
         assert_matches!(res, Err(MlsError::InvalidEpoch));
@@ -1085,7 +1138,7 @@ mod tests {
         };
 
         let res = server
-            .process_incoming_message(commit_output.commit_message)
+            .process_incoming_message_oneshot(commit_output.commit_message)
             .await;
 
         assert_matches!(res, Err(MlsError::InvalidSignature));
@@ -1100,7 +1153,7 @@ mod tests {
             .make_plaintext(Content::Application(b"hello".to_vec().into()))
             .await;
 
-        let res = server.process_incoming_message(plaintext).await;
+        let res = server.process_incoming_message_oneshot(plaintext).await;
 
         assert_matches!(res, Err(MlsError::UnencryptedApplicationMessage));
     }
@@ -1212,7 +1265,7 @@ mod tests {
         alice.process_pending_commit().await.unwrap();
 
         server
-            .process_incoming_message(commit_output.commit_message)
+            .process_incoming_message_oneshot(commit_output.commit_message)
             .await
             .unwrap();
 
@@ -1331,11 +1384,13 @@ mod tests {
         let commit_output = alice.commit(vec![]).await.unwrap();
 
         server
-            .process_incoming_message(commit_output.commit_message)
+            .process_incoming_message_oneshot(commit_output.commit_message)
             .await
             .unwrap();
 
-        let res = server.process_incoming_message(old_application_msg).await;
+        let res = server
+            .process_incoming_message_oneshot(old_application_msg)
+            .await;
 
         assert_matches!(res, Err(MlsError::InvalidEpoch));
     }
@@ -1357,14 +1412,14 @@ mod tests {
         let commit_output = alice.commit(vec![]).await.unwrap();
 
         server
-            .process_incoming_message(proposal.clone())
+            .process_incoming_message_oneshot(proposal.clone())
             .await
             .unwrap();
 
         server.insert_proposal_from_message(proposal).await.unwrap();
 
         server
-            .process_incoming_message(commit_output.commit_message)
+            .process_incoming_message_oneshot(commit_output.commit_message)
             .await
             .unwrap();
     }
@@ -1384,7 +1439,11 @@ mod tests {
         for _ in 0..2 {
             let commit = alice.commit(vec![]).await.unwrap().commit_message;
             alice.process_pending_commit().await.unwrap();
-            server.process_incoming_message(commit).await.unwrap();
+
+            server
+                .process_incoming_message_oneshot(commit)
+                .await
+                .unwrap();
         }
     }
 
@@ -1414,7 +1473,10 @@ mod tests {
             .await
             .unwrap();
 
-        let update = server.process_incoming_message(info.clone()).await.unwrap();
+        let update = server
+            .process_incoming_message_oneshot(info.clone())
+            .await
+            .unwrap();
         let info = info.into_group_info().unwrap();
 
         assert_matches!(update, ExternalReceivedMessage::GroupInfo(update_info) if update_info == info);
@@ -1427,7 +1489,10 @@ mod tests {
 
         let kp = test_key_package_message(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "john").await;
 
-        let update = server.process_incoming_message(kp.clone()).await.unwrap();
+        let update = server
+            .process_incoming_message_oneshot(kp.clone())
+            .await
+            .unwrap();
         let kp = kp.into_key_package().unwrap();
 
         assert_matches!(update, ExternalReceivedMessage::KeyPackage(update_kp) if update_kp == kp);
@@ -1451,7 +1516,10 @@ mod tests {
             .try_into()
             .unwrap();
 
-        let update = server.process_incoming_message(welcome).await.unwrap();
+        let update = server
+            .process_incoming_message_oneshot(welcome)
+            .await
+            .unwrap();
 
         assert_matches!(update, ExternalReceivedMessage::Welcome);
     }

--- a/mls-rs/src/group/commit/processor.rs
+++ b/mls-rs/src/group/commit/processor.rs
@@ -2,6 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+use core::fmt::Debug;
+
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
@@ -359,7 +361,7 @@ mod tests {
     use crate::{
         client::test_utils::{TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
         crypto::test_utils::TestCryptoProvider,
-        group::{ReceivedMessage, Sender},
+        group::Sender,
         mls_rules::{CommitSource, ProposalInfo},
         test_utils::get_test_groups,
     };
@@ -388,11 +390,12 @@ mod tests {
 
         let member_0 = groups[0].roster().member_with_index(0).unwrap();
 
-        let ReceivedMessage::CommitProcessor(processor) =
-            groups[1].process_incoming_message(commit).await.unwrap()
-        else {
-            panic!("expected commit processor")
-        };
+        let processor = groups[1]
+            .process_incoming_message(commit)
+            .await
+            .unwrap()
+            .into_processor()
+            .unwrap();
 
         assert_eq!(
             &processor.proposals().removals,

--- a/mls-rs/src/group/interop_test_vectors/passive_client.rs
+++ b/mls-rs/src/group/interop_test_vectors/passive_client.rs
@@ -20,7 +20,7 @@ use rand::{seq::IteratorRandom, Rng, SeedableRng};
 use crate::{
     client_builder::{ClientBuilder, MlsConfig},
     crypto::test_utils::TestCryptoProvider,
-    group::{ClientConfig, CommitBuilder, ExportedTree, ReceivedMessage},
+    group::{ClientConfig, CommitBuilder, ExportedTree},
     identity::basic::BasicIdentityProvider,
     mls_rules::CommitOptions,
     test_utils::{
@@ -214,11 +214,12 @@ async fn interop_passive_client() {
 
             let group_clone = group.clone();
 
-            let ReceivedMessage::CommitProcessor(mut processor) =
-                group.process_incoming_message(message).await.unwrap()
-            else {
-                panic!("expected  commit")
-            };
+            let mut processor = group
+                .process_incoming_message(message)
+                .await
+                .unwrap()
+                .into_processor()
+                .unwrap();
 
             processor = test_case
                 .external_psks

--- a/mls-rs/src/group/message_processor.rs
+++ b/mls-rs/src/group/message_processor.rs
@@ -224,7 +224,7 @@ pub enum ReceivedMessageOrProcessor<'a, C: ClientConfig> {
 impl<'a, C: ClientConfig> Debug for ReceivedMessageOrProcessor<'a, C> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::ReceivedMessage(m) => f.write_str(&format!("ReceivedMessage({m:?})")),
+            Self::ReceivedMessage(m) => f.write_str(&alloc::format!("ReceivedMessage({m:?})")),
             Self::CommitProcessor(_) => f.write_str("CommitProcessor"),
         }
     }

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -11,7 +11,6 @@ use mls_rs_core::identity::MemberValidationContext;
 #[cfg(feature = "psk")]
 use mls_rs_core::psk::PreSharedKey;
 use mls_rs_core::secret::Secret;
-use mls_rs_core::time::MlsTime;
 use snapshot::PendingCommitSnapshot;
 
 use crate::cipher_suite::CipherSuite;
@@ -1164,11 +1163,12 @@ where
     /// [`GroupStateStorage`](crate::GroupStateStorage)
     /// in use by this group until [`Group::write_to_storage`] is called.
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
     #[inline(never)]
     pub async fn process_incoming_message(
         &mut self,
         message: MlsMessage,
-    ) -> Result<ReceivedMessage, MlsError> {
+    ) -> Result<ReceivedMessage<'_, C>, MlsError> {
         if let Some(pending) = self.pending_commit.commit_hash()? {
             let message_hash = MessageHash::compute(&self.cipher_suite_provider, &message).await?;
 
@@ -1201,36 +1201,18 @@ where
         .await
     }
 
-    /// Process an inbound message for this group, providing additional context
-    /// with a message timestamp.
-    ///
-    /// Providing a timestamp is useful when the
-    /// [`IdentityProvider`](crate::IdentityProvider)
-    /// in use by the group can determine validity based on a timestamp.
-    /// For example, this allows for checking X.509 certificate expiration
-    /// at the time when `message` was received by a server rather than when
-    /// a specific client asynchronously received `message`
-    ///
-    /// # Warning
-    ///
-    /// Changes to the group's state as a result of processing `message` will
-    /// not be persisted by the
-    /// [`GroupStateStorage`](crate::GroupStateStorage)
-    /// in use by this group until [`Group::write_to_storage`] is called.
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
-    pub async fn process_incoming_message_with_time(
+    pub async fn process_incoming_message_oneshot(
         &mut self,
         message: MlsMessage,
-        time: MlsTime,
-    ) -> Result<ReceivedMessage, MlsError> {
-        MessageProcessor::process_incoming_message_with_time(
-            self,
-            message,
-            #[cfg(feature = "by_ref_proposal")]
-            true,
-            Some(time),
-        )
-        .await
+    ) -> Result<ReceivedMessage<'_, C>, MlsError> {
+        let received_message = self.process_incoming_message(message).await?;
+
+        match received_message {
+            ReceivedMessage::CommitProcessor(p) => p.process().await.map(ReceivedMessage::Commit),
+            other => Ok(other),
+        }
     }
 
     /// Find a group member by
@@ -1562,13 +1544,13 @@ where
     all(not(target_arch = "wasm32"), mls_build_async),
     maybe_async::must_be_async
 )]
-impl<C> MessageProcessor for Group<C>
+impl<'a, C> MessageProcessor<'a> for Group<C>
 where
-    C: ClientConfig + Clone,
+    C: 'a + ClientConfig + Clone,
 {
     type MlsRules = C::MlsRules;
     type IdentityProvider = C::IdentityProvider;
-    type OutputType = ReceivedMessage;
+    type OutputType = ReceivedMessage<'a, C>;
     type CipherSuiteProvider = <C::CryptoProvider as CryptoProvider>::CipherSuiteProvider;
 
     #[cfg(feature = "private_message")]
@@ -2707,7 +2689,7 @@ mod tests {
         let (_carol, commit) = alice.join("carol").await;
 
         // Apply the commit that adds carol
-        bob.process_incoming_message(commit).await.unwrap();
+        bob.process_incoming_message_oneshot(commit).await.unwrap();
 
         let bob_identity = bob.current_member_signing_identity().unwrap().clone();
         let signer = bob.signer.clone();
@@ -2749,7 +2731,7 @@ mod tests {
         let commit_output = alice_sub_group.commit(vec![]).await.unwrap();
 
         bob_sub_group
-            .process_incoming_message(commit_output.commit_message)
+            .process_incoming_message_oneshot(commit_output.commit_message)
             .await
             .unwrap();
     }
@@ -3097,7 +3079,7 @@ mod tests {
         let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[1]
-            .process_incoming_message(commit_output.commit_message)
+            .process_message(commit_output.commit_message)
             .await;
 
         assert_matches!(res, Err(MlsError::UnsupportedGroupExtension(EXT_TYPE)));
@@ -3125,7 +3107,7 @@ mod tests {
         let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[2]
-            .process_incoming_message(commit_output.commit_message)
+            .process_message(commit_output.commit_message)
             .await;
 
         assert!(res.is_err());
@@ -3158,7 +3140,7 @@ mod tests {
         let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[2]
-            .process_incoming_message(commit_output.commit_message)
+            .process_message(commit_output.commit_message)
             .await;
 
         assert_matches!(res, Err(MlsError::CredentialTypeOfNewLeafIsUnsupported));
@@ -3179,7 +3161,7 @@ mod tests {
         let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[2]
-            .process_incoming_message(commit_output.commit_message)
+            .process_message(commit_output.commit_message)
             .await;
 
         assert_matches!(res, Err(MlsError::InUseCredentialTypeUnsupportedByNewLeaf));
@@ -3207,7 +3189,7 @@ mod tests {
         let commit_output = groups[0].commit(vec![]).await.unwrap();
 
         let res = groups[2]
-            .process_incoming_message(commit_output.commit_message)
+            .process_message(commit_output.commit_message)
             .await;
 
         assert_matches!(res, Err(MlsError::RequiredCredentialNotFound(_)));
@@ -3288,7 +3270,10 @@ mod tests {
         };
 
         let commit = alice.commit(vec![]).await.unwrap();
-        let res = bob.process_incoming_message(commit.commit_message).await;
+
+        let res = bob
+            .process_incoming_message_oneshot(commit.commit_message)
+            .await;
 
         assert_matches!(
             res,
@@ -3552,9 +3537,14 @@ mod tests {
             MlsTime::from_duration_since_epoch(core::time::Duration::from_secs(future_time));
 
         groups[1].process_incoming_message(proposal).await.unwrap();
-        let res = groups[1]
-            .process_incoming_message_with_time(commit, future_time)
-            .await;
+
+        let received_message = groups[1].process_incoming_message(commit).await.unwrap();
+
+        let ReceivedMessage::CommitProcessor(p) = received_message else {
+            panic!("expected commit processor");
+        };
+
+        let res = p.time_sent(future_time).process().await;
 
         assert_matches!(res, Err(MlsError::InvalidLifetime));
     }
@@ -3597,7 +3587,7 @@ mod tests {
         let ReceivedMessage::Commit(CommitMessageDescription {
             effect: CommitEffect::NewEpoch(new_epoch),
             ..
-        }) = bob.process_incoming_message(commit).await.unwrap()
+        }) = bob.process_incoming_message_oneshot(commit).await.unwrap()
         else {
             panic!("unexpected commit effect");
         };
@@ -3703,7 +3693,6 @@ mod tests {
 
         bob.commit_processor(commit.commit_message)
             .await
-            .unwrap()
             .with_external_psk(psk_id_external, psk_external)
             .with_resumption_psk(psk_id_resumption, psk_resumption)
             .process()
@@ -3766,7 +3755,6 @@ mod tests {
 
         bob.commit_processor(commit.commit_message)
             .await
-            .unwrap()
             .with_external_psk(psk_id_external2.clone(), psk_external.clone())
             .with_external_psk(psk_id_external1, psk_external)
             .with_resumption_psk(psk_id_resumption, psk_resumption)
@@ -4117,7 +4105,10 @@ mod tests {
         let commit = groups[0].commit(vec![]).await.unwrap().commit_message;
         groups[1].commit(vec![]).await.unwrap();
 
-        groups[1].process_incoming_message(commit).await.unwrap();
+        groups[1]
+            .process_incoming_message_oneshot(commit)
+            .await
+            .unwrap();
 
         let res = groups[1].apply_pending_commit().await;
         assert_matches!(res, Err(MlsError::PendingCommitNotFound));
@@ -4163,7 +4154,11 @@ mod tests {
 
         bob.process_incoming_message(upd).await.unwrap();
         let commit = bob.commit(vec![]).await.unwrap().commit_message;
-        let update = alice.process_incoming_message(commit).await.unwrap();
+
+        let update = alice
+            .process_incoming_message_oneshot(commit)
+            .await
+            .unwrap();
 
         let ReceivedMessage::Commit(CommitMessageDescription {
             effect: CommitEffect::NewEpoch(new_epoch),

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1177,7 +1177,7 @@ where
                 let message_description = self.apply_pending_commit().await?;
 
                 return Ok(ReceivedMessageOrProcessor::ReceivedMessage(
-                    ReceivedMessage::Commit(message_description),
+                    ReceivedMessage::Commit(message_description).into(),
                 ));
             }
         }
@@ -1192,7 +1192,7 @@ where
 
             if let Some(cached) = cached_own_proposal {
                 return Ok(ReceivedMessageOrProcessor::ReceivedMessage(
-                    ReceivedMessage::Proposal(cached),
+                    ReceivedMessage::Proposal(cached).into(),
                 ));
             }
         }
@@ -1218,7 +1218,7 @@ where
             ReceivedMessageOrProcessor::CommitProcessor(p) => {
                 p.process().await.map(ReceivedMessage::Commit)
             }
-            ReceivedMessageOrProcessor::ReceivedMessage(m) => Ok(m),
+            ReceivedMessageOrProcessor::ReceivedMessage(m) => Ok(*m),
         }
     }
 

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -133,8 +133,8 @@ impl TestGroup {
     pub(crate) async fn process_message(
         &mut self,
         message: MlsMessage,
-    ) -> Result<ReceivedMessage, MlsError> {
-        self.process_incoming_message(message).await
+    ) -> Result<ReceivedMessage<'_, TestClientConfig>, MlsError> {
+        self.process_incoming_message_oneshot(message).await
     }
 
     #[cfg(feature = "private_message")]
@@ -153,6 +153,17 @@ impl TestGroup {
         .unwrap();
 
         self.format_for_wire(auth_content).await.unwrap()
+    }
+
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub async fn commit_processor(
+        &mut self,
+        commit: MlsMessage,
+    ) -> CommitProcessor<'_, TestClientConfig> {
+        match self.process_incoming_message(commit).await.unwrap() {
+            ReceivedMessage::CommitProcessor(p) => p,
+            _ => panic!("expected commit"),
+        }
     }
 }
 
@@ -310,7 +321,7 @@ pub(crate) async fn get_test_groups_with_features(
     n: usize,
     extensions: ExtensionList,
     leaf_extensions: ExtensionList,
-) -> Vec<Group<TestClientConfig>> {
+) -> Vec<TestGroup> {
     let mut clients = Vec::new();
 
     for i in 0..n {
@@ -330,7 +341,7 @@ pub(crate) async fn get_test_groups_with_features(
         .await
         .unwrap();
 
-    let mut groups = vec![group];
+    let mut groups = vec![TestGroup { group }];
 
     for client in clients.iter().skip(1) {
         let key_package = client
@@ -350,18 +361,18 @@ pub(crate) async fn get_test_groups_with_features(
 
         for group in groups.iter_mut().skip(1) {
             group
-                .process_incoming_message(commit_output.commit_message.clone())
+                .process_message(commit_output.commit_message.clone())
                 .await
                 .unwrap();
         }
 
-        groups.push(
-            client
+        groups.push(TestGroup {
+            group: client
                 .join_group(None, &commit_output.welcome_messages[0])
                 .await
                 .unwrap()
                 .0,
-        );
+        });
     }
 
     groups
@@ -413,11 +424,12 @@ impl GroupWithoutKeySchedule {
     all(not(target_arch = "wasm32"), mls_build_async),
     maybe_async::must_be_async
 )]
-impl MessageProcessor for GroupWithoutKeySchedule {
-    type CipherSuiteProvider = <Group<TestClientConfig> as MessageProcessor>::CipherSuiteProvider;
-    type OutputType = <Group<TestClientConfig> as MessageProcessor>::OutputType;
-    type IdentityProvider = <Group<TestClientConfig> as MessageProcessor>::IdentityProvider;
-    type MlsRules = <Group<TestClientConfig> as MessageProcessor>::MlsRules;
+impl<'a> MessageProcessor<'a> for GroupWithoutKeySchedule {
+    type CipherSuiteProvider =
+        <Group<TestClientConfig> as MessageProcessor<'a>>::CipherSuiteProvider;
+    type OutputType = <Group<TestClientConfig> as MessageProcessor<'a>>::OutputType;
+    type IdentityProvider = <Group<TestClientConfig> as MessageProcessor<'a>>::IdentityProvider;
+    type MlsRules = <Group<TestClientConfig> as MessageProcessor<'a>>::MlsRules;
 
     fn group_state(&self) -> &GroupState {
         self.inner.group_state()
@@ -488,5 +500,27 @@ impl MessageProcessor for GroupWithoutKeySchedule {
         self.provisional_public_state = Some(provisional_public_state);
         self.secrets = secrets;
         Ok(())
+    }
+}
+
+impl<'a> From<InternalCommitProcessor<'a, GroupWithoutKeySchedule>>
+    for ReceivedMessage<'a, TestClientConfig>
+{
+    fn from(value: InternalCommitProcessor<'a, GroupWithoutKeySchedule>) -> Self {
+        let value = InternalCommitProcessor {
+            processor: &mut value.processor.inner,
+            path: value.path,
+            proposals: value.proposals,
+            committer: value.committer,
+            authenticated_data: value.authenticated_data,
+            interim_transcript_hash: value.interim_transcript_hash,
+            confirmation_tag: value.confirmation_tag,
+            confirmed_transcript_hash: value.confirmed_transcript_hash,
+            time_sent: value.time_sent,
+            #[cfg(feature = "psk")]
+            psks: value.psks,
+        };
+
+        ReceivedMessage::CommitProcessor(CommitProcessor(value))
     }
 }

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -522,6 +522,6 @@ impl<'a> From<InternalCommitProcessor<'a, GroupWithoutKeySchedule>>
             psks: value.psks,
         };
 
-        ReceivedMessageOrProcessor::CommitProcessor(CommitProcessor(value))
+        ReceivedMessageOrProcessor::CommitProcessor(CommitProcessor(value).into())
     }
 }

--- a/mls-rs/src/group_joiner.rs
+++ b/mls-rs/src/group_joiner.rs
@@ -355,7 +355,7 @@ mod tests {
             .0;
 
         group_bob
-            .process_incoming_message(commit2.commit_message)
+            .process_incoming_message_oneshot(commit2.commit_message)
             .await
             .unwrap();
 

--- a/mls-rs/src/test_utils/mod.rs
+++ b/mls-rs/src/test_utils/mod.rs
@@ -289,7 +289,7 @@ pub async fn all_process_message<C: MlsConfig>(
     for group in groups {
         if sender != group.current_member_index() as usize {
             group
-                .process_incoming_message(message.clone())
+                .process_incoming_message_oneshot(message.clone())
                 .await
                 .unwrap();
         } else if is_commit {

--- a/mls-rs/test_harness_integration/src/main.rs
+++ b/mls-rs/test_harness_integration/src/main.rs
@@ -507,10 +507,11 @@ impl MlsClient for MlsClientImpl {
             .as_mut()
             .ok_or_else(|| Status::aborted("no group with such index."))?
             .process_incoming_message(ciphertext)
-            .map_err(abort)?;
+            .map_err(abort)?
+            .into_received_message();
 
         let app_msg = match message {
-            ReceivedMessage::ApplicationMessage(app_msg) => app_msg,
+            Some(ReceivedMessage::ApplicationMessage(app_msg)) => app_msg,
             _ => return Err(Status::aborted("message type is not application data.")),
         };
 
@@ -914,11 +915,11 @@ impl MlsClientImpl {
         #[cfg(feature = "psk")]
         let group_clone = group.clone();
 
-        let ReceivedMessage::CommitProcessor(processor) =
-            group.process_incoming_message(commit).map_err(abort)?
-        else {
-            return Err(Status::aborted("expected commit message"));
-        };
+        let processor = group
+            .process_incoming_message(commit)
+            .map_err(abort)?
+            .into_processor()
+            .ok_or(Status::aborted("expected commit message"))?;
 
         #[cfg(feature = "psk")]
         let required_external_psks = processor

--- a/mls-rs/test_harness_integration/src/main.rs
+++ b/mls-rs/test_harness_integration/src/main.rs
@@ -914,7 +914,11 @@ impl MlsClientImpl {
         #[cfg(feature = "psk")]
         let group_clone = group.clone();
 
-        let processor = group.commit_processor(commit).map_err(abort)?;
+        let ReceivedMessage::CommitProcessor(processor) =
+            group.process_incoming_message(commit).map_err(abort)?
+        else {
+            return Err(Status::aborted("expected commit message"));
+        };
 
         #[cfg(feature = "psk")]
         let required_external_psks = processor

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -376,6 +376,8 @@ async fn test_application_messages(
                     let decrypted = g
                         .process_incoming_message(ciphertext.clone())
                         .await
+                        .unwrap()
+                        .into_received_message()
                         .unwrap();
 
                     assert_matches!(decrypted, ReceivedMessage::ApplicationMessage(m) if m.data() == test_message);
@@ -435,6 +437,8 @@ async fn test_out_of_order_application_messages() {
         let res = bob_group
             .process_incoming_message(ciphertexts[i].clone())
             .await
+            .unwrap()
+            .into_received_message()
             .unwrap();
 
         assert_matches!(
@@ -467,12 +471,9 @@ async fn processing_message_from_self_returns_error(
         .await
         .unwrap();
 
-    let error = creator_group
-        .process_incoming_message(msg)
-        .await
-        .unwrap_err();
+    let res = creator_group.process_incoming_message(msg).await;
 
-    assert_matches!(error, MlsError::CantProcessMessageFromSelf);
+    assert_matches!(res, Err(MlsError::CantProcessMessageFromSelf));
 }
 
 #[cfg(feature = "private_message")]
@@ -542,6 +543,8 @@ async fn external_commits_work(
             let processed = group
                 .process_incoming_message(message.clone())
                 .await
+                .unwrap()
+                .into_received_message()
                 .unwrap();
 
             if let ReceivedMessage::Proposal(p) = &processed {

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -412,7 +412,10 @@ async fn test_out_of_order_application_messages() {
 
     alice_group.apply_pending_commit().await.unwrap();
 
-    bob_group.process_incoming_message(commit).await.unwrap();
+    bob_group
+        .process_incoming_message_oneshot(commit)
+        .await
+        .unwrap();
 
     ciphertexts.push(
         alice_group
@@ -520,7 +523,7 @@ async fn external_commits_work(
 
         for group in groups.iter_mut() {
             group
-                .process_incoming_message(commit.clone())
+                .process_incoming_message_oneshot(commit.clone())
                 .await
                 .unwrap();
         }
@@ -604,6 +607,7 @@ async fn reinit_works() {
         .create_group(Default::default(), Default::default())
         .await
         .unwrap();
+
     let kp = bob1.generate_key_package().await.unwrap();
 
     let welcome = &alice_group
@@ -633,7 +637,7 @@ async fn reinit_works() {
 
     // Bob commits the reinit
     bob_group
-        .process_incoming_message(reinit_proposal_message)
+        .process_incoming_message_oneshot(reinit_proposal_message)
         .await
         .unwrap();
 
@@ -644,7 +648,10 @@ async fn reinit_works() {
     let commit_effect = bob_group.apply_pending_commit().await.unwrap().effect;
     assert_matches!(commit_effect, CommitEffect::ReInit(_));
 
-    let message = alice_group.process_incoming_message(commit).await.unwrap();
+    let message = alice_group
+        .process_incoming_message_oneshot(commit)
+        .await
+        .unwrap();
 
     assert_matches!(
         message,
@@ -724,7 +731,7 @@ async fn reinit_works() {
     alice_group.apply_pending_commit().await.unwrap();
 
     bob_group
-        .process_incoming_message(commit_output.commit_message)
+        .process_incoming_message_oneshot(commit_output.commit_message)
         .await
         .unwrap();
 


### PR DESCRIPTION
```
let ReceivedMessage::CommitProcessor(processor) = group.process_incoming_message(msg)? else {...}

let ReceivedMessage::Commit(commit) = group.process_incoming_message_oneshot(msg)? else {...}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
