### PR TITLE
[1.x] Remove mls rules, part 1

### DIFF
--- a/mls-rs/benches/group_add.rs
+++ b/mls-rs/benches/group_add.rs
@@ -9,7 +9,6 @@ use mls_rs::{
         basic::{BasicCredential, BasicIdentityProvider},
         SigningIdentity,
     },
-    mls_rules::{CommitOptions, DefaultMlsRules},
     test_utils::TestClient,
     CipherSuite, CipherSuiteProvider, Client, CryptoProvider,
 };
@@ -45,6 +44,7 @@ fn bench(c: &mut Criterion) {
                             .fold(alice.commit_builder(), |builder, key_package| {
                                 builder.add_member(key_package).unwrap()
                             })
+                            .ratchet_tree_extension(false)
                             .build()
                             .unwrap();
                     },
@@ -72,10 +72,6 @@ fn make_client(name: &str) -> TestClient<impl MlsConfig> {
     Client::builder()
         .crypto_provider(crypto_provider)
         .identity_provider(BasicIdentityProvider)
-        .mls_rules(
-            DefaultMlsRules::new()
-                .with_commit_options(CommitOptions::new().with_ratchet_tree_extension(false)),
-        )
         .signing_identity(
             SigningIdentity::new(
                 BasicCredential::new(name.as_bytes().to_vec()).into_credential(),

--- a/mls-rs/examples/large_group.rs
+++ b/mls-rs/examples/large_group.rs
@@ -10,7 +10,6 @@ use mls_rs::{
         basic::{BasicCredential, BasicIdentityProvider},
         SigningIdentity,
     },
-    mls_rules::{CommitOptions, DefaultMlsRules},
     CipherSuite, CipherSuiteProvider, Client, CryptoProvider, Group,
 };
 
@@ -74,6 +73,7 @@ fn make_groups_best_case<P: CryptoProvider + Clone>(
             .last_mut()
             .unwrap()
             .commit_builder()
+            .path_required(true)
             .add_member(bob_kpkg.key_package_message)?
             .build()?;
 
@@ -110,7 +110,7 @@ fn make_groups_worst_case<P: CryptoProvider + Clone>(
         .collect::<Result<Vec<_>, _>>()?;
 
     // Alice adds all Bob's clients in a single commit.
-    let mut commit_builder = alice_group.commit_builder();
+    let mut commit_builder = alice_group.commit_builder().path_required(true);
     let mut kpkgs = vec![];
 
     for bob_client in &bob_clients {
@@ -152,10 +152,6 @@ fn make_client<P: CryptoProvider + Clone>(
     Ok(Client::builder()
         .identity_provider(BasicIdentityProvider)
         .crypto_provider(crypto_provider)
-        .mls_rules(
-            DefaultMlsRules::new()
-                .with_commit_options(CommitOptions::new().with_path_required(true)),
-        )
         .signing_identity(signing_identity, secret, CIPHERSUITE)
         .build())
 }

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -818,6 +818,11 @@ pub(crate) mod test_utils {
     pub const TEST_CUSTOM_PROPOSAL_TYPE: ProposalType = ProposalType::new(65001);
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub async fn test_client(identity: &str) -> (TestClient<TestClientConfig>, MlsMessage) {
+        test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, identity).await
+    }
+
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn test_client_with_key_pkg(
         protocol_version: ProtocolVersion,
         cipher_suite: CipherSuite,
@@ -1144,8 +1149,7 @@ mod tests {
             .await
             .group;
 
-        let (bob, kp) =
-            test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "bob").await;
+        let (bob, kp) = test_client("bob").await;
 
         let commit = alice
             .commit_builder()
@@ -1194,9 +1198,7 @@ mod tests {
             .await
             .group;
 
-        let bob = test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "bob")
-            .await
-            .0;
+        let bob = test_client("bob").await.0;
 
         let group_info = alice.group_info_message(false).await.unwrap();
         let alice_signer = alice.current_member_signing_identity().unwrap().clone();

--- a/mls-rs/src/grease.rs
+++ b/mls-rs/src/grease.rs
@@ -162,7 +162,7 @@ mod tests {
     use mls_rs_core::extension::ExtensionList;
 
     use crate::{
-        client::test_utils::{test_client_with_key_pkg, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
+        client::test_utils::{test_client, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
         group::test_utils::test_group,
     };
 
@@ -170,11 +170,7 @@ mod tests {
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn key_package_is_greased() {
-        let key_pkg = test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "alice")
-            .await
-            .1
-            .into_key_package()
-            .unwrap();
+        let key_pkg = test_client("alice").await.1.into_key_package().unwrap();
 
         assert!(is_ext_greased(&key_pkg.extensions));
         assert!(is_ext_greased(&key_pkg.leaf_node.extensions));

--- a/mls-rs/src/group/commit/builder.rs
+++ b/mls-rs/src/group/commit/builder.rs
@@ -59,7 +59,7 @@ use crate::group::{
 };
 
 #[cfg(feature = "by_ref_proposal")]
-use crate::group::mls_rules::CommitDirection;
+use crate::group::proposal_filter::CommitDirection;
 
 #[cfg(feature = "custom_proposal")]
 use crate::group::proposal::CustomProposal;

--- a/mls-rs/src/group/commit/processor.rs
+++ b/mls-rs/src/group/commit/processor.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 #[cfg(feature = "by_ref_proposal")]
-use crate::mls_rules::CommitDirection;
+use crate::group::proposal_filter::CommitDirection;
 
 #[cfg(feature = "psk")]
 use mls_rs_core::psk::{ExternalPskId, PreSharedKey};

--- a/mls-rs/src/group/commit/processor.rs
+++ b/mls-rs/src/group/commit/processor.rs
@@ -372,7 +372,6 @@ mod tests {
             TEST_PROTOCOL_VERSION,
             TEST_CIPHER_SUITE,
             3,
-            None,
             false,
             &TestCryptoProvider::new(),
         )

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -38,7 +38,7 @@ use crate::group::{
     PreSharedKeyProposal, {JustPreSharedKeyID, PreSharedKeyID},
 };
 
-use super::{validate_tree_and_info_joiner, ExportedTree, Sender};
+use super::{validate_tree_and_info_joiner, CommitOptions, ExportedTree, Sender};
 
 /// A builder that aids with the construction of an external commit.
 #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::ffi_type(opaque))]
@@ -51,12 +51,12 @@ pub struct ExternalCommitBuilder<C: ClientConfig> {
     to_remove: Option<u32>,
     #[cfg(feature = "psk")]
     external_psks: Vec<(ExternalPskId, PreSharedKey)>,
-    authenticated_data: Vec<u8>,
     #[cfg(feature = "custom_proposal")]
     custom_proposals: Vec<Proposal>,
     #[cfg(feature = "custom_proposal")]
     received_custom_proposals: Vec<MlsMessage>,
     group_info: MlsMessage,
+    options: CommitOptions,
 }
 
 impl<C: ClientConfig> ExternalCommitBuilder<C> {
@@ -72,7 +72,14 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             config,
             group_info,
             tree_data: None,
-            authenticated_data: Vec::new(),
+            options: CommitOptions {
+                sender: Sender::NewMemberCommit,
+                path_required: false,
+                ratchet_tree_extension: true,
+                single_welcome_message: true,
+                allow_external_commit: false,
+                authenticated_data: Default::default(),
+            },
             leaf_node_extensions: Default::default(),
             to_remove: Default::default(),
             #[cfg(feature = "custom_proposal")]
@@ -106,11 +113,9 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
 
     #[must_use]
     /// Add plaintext authenticated data to the resulting commit message.
-    pub fn with_authenticated_data(self, data: Vec<u8>) -> Self {
-        Self {
-            authenticated_data: data,
-            ..self
-        }
+    pub fn with_authenticated_data(mut self, data: Vec<u8>) -> Self {
+        self.options.authenticated_data = data;
+        self
     }
 
     #[cfg(feature = "psk")]
@@ -148,6 +153,11 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             leaf_node_extensions,
             ..self
         }
+    }
+
+    pub fn allow_external_commit(mut self, allow_external_commit: bool) -> Self {
+        self.options.allow_external_commit = allow_external_commit;
+        self
     }
 
     /// Build the external commit using a GroupInfo message provided by an existing group member.
@@ -272,14 +282,13 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             .commit_internal(
                 proposal_bundle,
                 Some(&leaf_node),
-                self.authenticated_data,
                 Default::default(),
                 None,
                 None,
                 None,
+                self.options,
                 #[cfg(feature = "psk")]
                 psks,
-                Sender::NewMemberCommit,
             )
             .await?;
 

--- a/mls-rs/src/group/message_verifier.rs
+++ b/mls-rs/src/group/message_verifier.rs
@@ -224,6 +224,7 @@ mod tests {
         group::{
             membership_tag::MembershipTag,
             message_signature::{AuthenticatedContent, MessageSignature},
+            test_utils::test_group,
             test_utils::TestGroup,
             Group, PublicMessage,
         },
@@ -250,10 +251,7 @@ mod tests {
     use alloc::boxed::Box;
 
     #[cfg(feature = "by_ref_proposal")]
-    use crate::group::{
-        test_utils::{test_group, test_member},
-        Sender,
-    };
+    use crate::group::{test_utils::test_member, Sender};
 
     #[cfg(feature = "by_ref_proposal")]
     use crate::identity::test_utils::get_test_signing_identity;

--- a/mls-rs/src/group/message_verifier.rs
+++ b/mls-rs/src/group/message_verifier.rs
@@ -216,7 +216,7 @@ mod tests {
     use super::*;
     use crate::{
         client::{
-            test_utils::{test_client_with_key_pkg, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
+            test_utils::{test_client, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
             MlsError,
         },
         client_builder::test_utils::TestClientConfig,
@@ -224,7 +224,7 @@ mod tests {
         group::{
             membership_tag::MembershipTag,
             message_signature::{AuthenticatedContent, MessageSignature},
-            test_utils::{test_group_custom, TestGroup},
+            test_utils::TestGroup,
             Group, PublicMessage,
         },
     };
@@ -277,17 +277,8 @@ mod tests {
     impl TestEnv {
         #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
         async fn new() -> Self {
-            let mut alice = test_group_custom(
-                TEST_PROTOCOL_VERSION,
-                TEST_CIPHER_SUITE,
-                Default::default(),
-                None,
-                None,
-            )
-            .await;
-
-            let (bob_client, bob_key_pkg) =
-                test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "bob").await;
+            let mut alice = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
+            let (bob_client, bob_key_pkg) = test_client("bob").await;
 
             let commit_output = alice
                 .commit_builder()

--- a/mls-rs/src/group/mls_rules.rs
+++ b/mls-rs/src/group/mls_rules.rs
@@ -17,12 +17,6 @@ use mls_rs_core::{error::IntoAnyError, group::Member, identity::SigningIdentity}
 
 use super::GroupContext;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum CommitDirection {
-    Send,
-    Receive,
-}
-
 /// The source of the commit: either a current member or a new member joining
 /// via external commit.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2667,7 +2667,12 @@ mod tests {
         .unwrap();
 
         let (mut alice_sub_group, welcome) = alice
-            .branch(b"subgroup".to_vec(), vec![new_key_pkg.key_package_message])
+            .branch(
+                b"subgroup".to_vec(),
+                vec![new_key_pkg.key_package_message],
+                true,
+                true,
+            )
             .await
             .unwrap();
 

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -584,7 +584,7 @@ mod tests {
 
     use super::test_utils::{make_proposal_cache, CommitReceiver};
     use super::{CachedProposal, ProposalCache};
-    use crate::client::test_utils::test_client_with_key_pkg;
+    use crate::client::test_utils::test_client;
     use crate::client::MlsError;
     use crate::group::message_processor::ProvisionalState;
     use crate::group::proposal_filter::{ProposalBundle, ProposalInfo, ProposalSource};
@@ -3457,8 +3457,7 @@ mod tests {
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     async fn unsupported_credential_key_package(name: &str) -> KeyPackage {
-        let (client, _) =
-            test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, name).await;
+        let (client, _) = test_client(name).await;
 
         let mut kp_builder = client.key_package_builder(None).unwrap();
 

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -22,10 +22,9 @@ use crate::psk::JustPreSharedKeyID;
 #[cfg(feature = "by_ref_proposal")]
 use crate::{
     group::{
-        message_hash::MessageHash, Proposal, ProposalMessageDescription, ProposalRef,
-        ProtocolVersion,
+        message_hash::MessageHash, proposal_filter::CommitDirection, Proposal,
+        ProposalMessageDescription, ProposalRef, ProtocolVersion,
     },
-    mls_rules::CommitDirection,
     MlsMessage,
 };
 
@@ -342,8 +341,8 @@ pub(crate) mod test_utils {
         client::test_utils::TEST_PROTOCOL_VERSION,
         group::{
             confirmation_tag::ConfirmationTag,
-            mls_rules::CommitDirection,
             proposal::{Proposal, ProposalOrRef},
+            proposal_filter::CommitDirection,
             proposal_ref::ProposalRef,
             state::GroupState,
             test_utils::{get_test_group_context, TEST_GROUP},

--- a/mls-rs/src/group/proposal_filter.rs
+++ b/mls-rs/src/group/proposal_filter.rs
@@ -21,3 +21,9 @@ pub(crate) use filtering::proposer_can_propose;
 
 #[cfg(feature = "custom_proposal")]
 pub(crate) use filtering_common::filter_out_unsupported_custom_proposals;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CommitDirection {
+    Send,
+    Receive,
+}

--- a/mls-rs/src/group/proposal_filter.rs
+++ b/mls-rs/src/group/proposal_filter.rs
@@ -22,6 +22,7 @@ pub(crate) use filtering::proposer_can_propose;
 #[cfg(feature = "custom_proposal")]
 pub(crate) use filtering_common::filter_out_unsupported_custom_proposals;
 
+#[cfg(feature = "by_ref_proposal")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum CommitDirection {
     Send,

--- a/mls-rs/src/group/proposal_filter/filtering.rs
+++ b/mls-rs/src/group/proposal_filter/filtering.rs
@@ -10,7 +10,6 @@ use crate::{
         AddProposal, ProposalType, RemoveProposal, Sender, UpdateProposal,
     },
     iter::wrap_iter,
-    mls_rules::CommitDirection,
     protocol_version::ProtocolVersion,
     time::MlsTime,
     tree_kem::{
@@ -22,7 +21,7 @@ use crate::{
 
 use super::{
     filtering_common::{filter_out_invalid_psks, ApplyProposalsOutput, ProposalApplier},
-    ProposalSource,
+    CommitDirection, ProposalSource,
 };
 
 #[cfg(feature = "by_ref_proposal")]

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -20,7 +20,6 @@ use crate::{
     crypto::test_utils::test_cipher_suite_provider,
     extension::ExtensionType,
     identity::test_utils::get_test_signing_identity,
-    mls_rules::{CommitOptions, DefaultMlsRules},
 };
 
 use crate::extension::RequiredCapabilitiesExt;
@@ -226,14 +225,11 @@ pub(crate) async fn test_group_custom(
     cipher_suite: CipherSuite,
     extension_types: Vec<ExtensionType>,
     leaf_extensions: Option<ExtensionList>,
-    commit_options: Option<CommitOptions>,
 ) -> TestGroup {
     let leaf_extensions = leaf_extensions.unwrap_or_default();
-    let commit_options = commit_options.unwrap_or_default();
 
     let (signing_identity, secret_key) = get_test_signing_identity(cipher_suite, b"member").await;
     let group = TestClientBuilder::new_for_test()
-        .mls_rules(DefaultMlsRules::default().with_commit_options(commit_options))
         .extension_types(extension_types)
         .protocol_versions(ProtocolVersion::all())
         .used_protocol_version(protocol_version)
@@ -251,14 +247,7 @@ pub(crate) async fn test_group(
     protocol_version: ProtocolVersion,
     cipher_suite: CipherSuite,
 ) -> TestGroup {
-    test_group_custom(
-        protocol_version,
-        cipher_suite,
-        Default::default(),
-        None,
-        None,
-    )
-    .await
+    test_group_custom(protocol_version, cipher_suite, Default::default(), None).await
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]

--- a/mls-rs/src/group_joiner.rs
+++ b/mls-rs/src/group_joiner.rs
@@ -315,17 +315,14 @@ mod tests {
     use mls_rs_core::psk::{ExternalPskId, PreSharedKey};
 
     use crate::{
-        client::test_utils::{test_client_with_key_pkg, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION},
+        client::test_utils::{test_client, TEST_CIPHER_SUITE},
         psk::{PskGroupId, ResumptionPSKUsage, ResumptionPsk},
     };
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn outputs_correct_join_info() {
-        let (alice, _kp_alice) =
-            test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "alice").await;
-
-        let (bob, kp_bob) =
-            test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "bob").await;
+        let (alice, _kp_alice) = test_client("alice").await;
+        let (bob, kp_bob) = test_client("bob").await;
 
         let mut group_alice = alice
             .create_group(Default::default(), Default::default())

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -168,7 +168,7 @@ pub use mls_rs_core::{
 /// Dependencies of [`MlsRules`].
 pub mod mls_rules {
     pub use crate::group::{
-        mls_rules::{CommitDirection, CommitSource, DefaultMlsRules, EncryptionOptions},
+        mls_rules::{CommitSource, DefaultMlsRules, EncryptionOptions},
         proposal_filter::{ProposalBundle, ProposalInfo, ProposalSource},
     };
 

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -168,9 +168,7 @@ pub use mls_rs_core::{
 /// Dependencies of [`MlsRules`].
 pub mod mls_rules {
     pub use crate::group::{
-        mls_rules::{
-            CommitDirection, CommitOptions, CommitSource, DefaultMlsRules, EncryptionOptions,
-        },
+        mls_rules::{CommitDirection, CommitSource, DefaultMlsRules, EncryptionOptions},
         proposal_filter::{ProposalBundle, ProposalInfo, ProposalSource},
     };
 

--- a/mls-rs/src/test_utils/benchmarks.rs
+++ b/mls-rs/src/test_utils/benchmarks.rs
@@ -62,7 +62,6 @@ async fn generate_test_cases(cs: CipherSuite) -> Vec<MlsMessage> {
             ProtocolVersion::MLS_10,
             cs,
             size,
-            None,
             false,
             &MlsCryptoProvider::new(),
         )
@@ -110,7 +109,6 @@ pub async fn join_group(cs: CipherSuite, group_info: MlsMessage) -> GroupStates<
         cs,
         ProtocolVersion::MLS_10,
         99999999999,
-        None,
         false,
         &MlsCryptoProvider::new(),
     );
@@ -121,7 +119,6 @@ pub async fn join_group(cs: CipherSuite, group_info: MlsMessage) -> GroupStates<
         cs,
         ProtocolVersion::MLS_10,
         99999999998,
-        None,
         false,
         &MlsCryptoProvider::new(),
     );

--- a/mls-rs/test_harness_integration/src/branch_reinit.rs
+++ b/mls-rs/test_harness_integration/src/branch_reinit.rs
@@ -170,14 +170,10 @@ pub(crate) mod inner {
                 .collect::<Result<_, _>>()
                 .map_err(abort)?;
 
-            {
-                let mut mls_rules = client.mls_rules.commit_options.lock().unwrap();
-                mls_rules.path_required = force_path;
-                mls_rules.ratchet_tree_extension = !external_tree;
-            };
-
             let (new_group, welcome) = if let Some(id) = subgroup_id {
-                group.branch(id, new_key_pkgs).map_err(abort)?
+                group
+                    .branch(id, new_key_pkgs, force_path, !external_tree)
+                    .map_err(abort)?
             } else {
                 let client = group
                     .clone()
@@ -188,7 +184,7 @@ pub(crate) mod inner {
                     .map_err(abort)?;
 
                 client
-                    .commit(new_key_pkgs, Default::default())
+                    .commit(new_key_pkgs, Default::default(), force_path, !external_tree)
                     .map_err(abort)?
             };
 

--- a/mls-rs/test_harness_integration/src/main.rs
+++ b/mls-rs/test_harness_integration/src/main.rs
@@ -23,7 +23,7 @@ use mls_rs::{
         basic::{BasicCredential, BasicIdentityProvider},
         Credential, SigningIdentity,
     },
-    mls_rules::{CommitOptions, EncryptionOptions, ProposalBundle},
+    mls_rules::{CommitOptions, EncryptionOptions},
     psk::ExternalPskId,
     storage_provider::in_memory::{InMemoryKeyPackageStorage, InMemoryPreSharedKeyStorage},
     CipherSuite, CipherSuiteProvider, Client, CryptoProvider, Extension, ExtensionList, Group,
@@ -158,15 +158,6 @@ impl TestMlsRules {
 
 impl MlsRules for TestMlsRules {
     type Error = Infallible;
-
-    fn commit_options(
-        &self,
-        _: &Roster,
-        _: &GroupContext,
-        _: &ProposalBundle,
-    ) -> Result<CommitOptions, Self::Error> {
-        Ok(*self.commit_options.lock().unwrap())
-    }
 
     fn encryption_options(
         &self,

--- a/mls-rs/test_harness_integration/src/main.rs
+++ b/mls-rs/test_harness_integration/src/main.rs
@@ -119,6 +119,8 @@ struct ClientDetails {
     group: Option<Group<TestClientConfig>>,
     signing_identity: SigningIdentity,
     signer: SignatureSecretKey,
+    // TODO follow up PR removes this field
+    #[allow(unused)]
     mls_rules: TestMlsRules,
 }
 

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -704,7 +704,7 @@ async fn reinit_works() {
         .unwrap();
 
     let (mut alice_group, welcome) = alice2
-        .commit(vec![kp.key_package_message], Default::default())
+        .commit(vec![kp.key_package_message], Default::default(), true, true)
         .await
         .unwrap();
 

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -9,7 +9,6 @@ use mls_rs::error::MlsError;
 use mls_rs::group::proposal::Proposal;
 use mls_rs::group::ReceivedMessage;
 use mls_rs::identity::SigningIdentity;
-use mls_rs::mls_rules::CommitOptions;
 use mls_rs::CryptoProvider;
 use mls_rs::ExtensionList;
 use mls_rs::MlsMessage;
@@ -43,7 +42,6 @@ async fn generate_client(
         cipher_suite,
         protocol_version,
         id,
-        None,
         encrypt_controls,
         &TestCryptoProvider::default(),
     )
@@ -61,7 +59,6 @@ pub async fn get_test_groups(
         version,
         cipher_suite,
         num_participants,
-        None,
         encrypt_controls,
         &TestCryptoProvider::default(),
     )
@@ -841,18 +838,18 @@ async fn external_info_from_commit_allows_to_join() {
     let cs = CipherSuite::P256_AES128;
     let version = ProtocolVersion::MLS_10;
 
-    let mut alice = mls_rs::test_utils::get_test_groups(
-        version,
-        cs,
-        1,
-        Some(CommitOptions::new().with_allow_external_commit(true)),
-        false,
-        &TestCryptoProvider::default(),
-    )
-    .await
-    .remove(0);
+    let mut alice =
+        mls_rs::test_utils::get_test_groups(version, cs, 1, false, &TestCryptoProvider::default())
+            .await
+            .remove(0);
 
-    let commit = alice.commit(vec![]).await.unwrap();
+    let commit = alice
+        .commit_builder()
+        .allow_external_commit(true)
+        .build()
+        .await
+        .unwrap();
+
     alice.apply_pending_commit().await.unwrap();
     let bob = generate_client(cs, version, 0xdead, false).await;
 


### PR DESCRIPTION
Replaces the `commit_options` function by the appropriate functions of `CommitBuilder`. The `CommitOptions` struct only collects.

Follow up: remove MlsRules

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
