### PR TITLE
Simplify X.509 certificate validity check

### DIFF
--- a/mls-rs-crypto-rustcrypto/src/x509/validator.rs
+++ b/mls-rs-crypto-rustcrypto/src/x509/validator.rs
@@ -142,9 +142,11 @@ fn verify_time(cert: &Certificate, time: MlsTime) -> Result<(), X509Error> {
     let not_before = validity.not_before.to_unix_duration().as_secs();
     let not_after = validity.not_after.to_unix_duration().as_secs();
 
-    (not_before <= now && now <= not_after)
-        .then_some(())
-        .ok_or_else(|| X509Error::ValidityError(now, format!("{cert:?}")))
+    if not_before <= now && now <= not_after {
+        Ok(())
+    } else {
+        Err(X509Error::ValidityError(now, format!("{cert:?}")))
+    }
 }
 
 fn verify_cert(


### PR DESCRIPTION
### Description of changes:

Refactor of the `verify_time` code for X.509 certificates: instead of chaining `Option` values, I used a simple `if` statement. I find that clearer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
