### PR TITLE
Cleaning up `non_domain_separated_hpke_encrypt_decrypt` cfgs

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.45.0"
+version = "0.45.1"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -631,12 +631,9 @@ where
     /// Returns `ciphertext` and `kem_output` inside `HpkeCiphertext`.
     ///
     /// WARNING: The message sender is not authenticated.
-    #[cfg(all(feature = "non_domain_separated_hpke_encrypt_decrypt", feature = "ffi"))]
-    #[cfg_attr(
-        not(mls_build_async),
-        maybe_async::must_be_sync,
-        safer_ffi_gen::safer_ffi_gen_ignore
-    )]
+    #[cfg(feature = "non_domain_separated_hpke_encrypt_decrypt")]
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    #[cfg_attr(feature = "ffi", safer_ffi_gen::safer_ffi_gen_ignore)]
     pub async fn hpke_encrypt_to_recipient(
         &self,
         recipient_index: u32,
@@ -709,13 +706,9 @@ where
     /// current member.
     ///
     /// WARNING: The message sender is not authenticated.
-    #[cfg(all(feature = "non_domain_separated_hpke_encrypt_decrypt", feature = "ffi"))]
-    #[cfg_attr(
-        not(mls_build_async),
-        // all(feature = "ffi", not(test)),
-        maybe_async::must_be_sync,
-        safer_ffi_gen::safer_ffi_gen_ignore
-    )]
+    #[cfg(feature = "non_domain_separated_hpke_encrypt_decrypt")]
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    #[cfg_attr(feature = "ffi", safer_ffi_gen::safer_ffi_gen_ignore)]
     pub async fn hpke_decrypt_for_current_member(
         &self,
         context_info: &[u8],


### PR DESCRIPTION
Cleaning up the cfgs so users can use non_domain_separated_hpke_encrypt_decrypt without ffi feature enabled

In the current state, the `cfg`s for the `non_domain_separated_hpke_encrypt_decrypt` flagged-out functions are configured such that they can only be used if a user has the `ffi` feature also enabled. This requires a dependency on `safer_ffi_gen`. (This is my mistake, for how I configured these)

This PR just changes the configuration to remove this dependency, so users can use the `non_domain_separated_hpke_encrypt_decrypt` functions even without `ffi`.

