### PR TITLE
Add message description function from 1.x

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.45.0"
+version = "0.45.1"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.45.1"
+version = "0.45.2"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/src/lib.rs
+++ b/mls-rs/src/lib.rs
@@ -182,7 +182,7 @@ pub use mls_rs_core::extension::{Extension, ExtensionList};
 pub use crate::{
     client::Client,
     group::{
-        framing::{MlsMessage, WireFormat},
+        framing::{MlsMessage, MlsMessageDescription, WireFormat},
         mls_rules::MlsRules,
         Group,
     },


### PR DESCRIPTION
Knowing content type of a message is very useful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
