### PR TITLE
Add `process_incoming_message_with_time` to `ExternalGroup`

### DIFF
--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -4060,7 +4060,7 @@ mod tests {
             .send()
             .await;
 
-        assert_matches!(res, Err(MlsError::InvalidProposalTypeForSender { .. }))
+        assert_matches!(res, Err(MlsError::InvalidProposalTypeForSender))
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]


### PR DESCRIPTION
### Description of changes:

This allows validation of X.509 certificates when observing a group with an external client.

### Testing:

Since this is just a shim method, I rely on the existing `MessageProcessor` tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
