### PR TITLE
Stop storing server secret key in group state

### DIFF
--- a/mls-rs-ffi/Cargo.toml
+++ b/mls-rs-ffi/Cargo.toml
@@ -24,7 +24,7 @@ private_message = ["mls-rs/private_message"]
 secret_tree_access = ["mls-rs/secret_tree_access"]
 
 [dependencies]
-mls-rs = { path = "../mls-rs", version = "0.45.0", features = ["ffi"] }
+mls-rs = { path = "../mls-rs", version = "0.46.0", features = ["ffi"] }
 mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.14.0", optional = true }
 mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.15.0", optional = true }
 mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.15.0", default-features = false, optional = true }

--- a/mls-rs-uniffi/Cargo.toml
+++ b/mls-rs-uniffi/Cargo.toml
@@ -17,7 +17,7 @@ name = "mls_rs_uniffi"
 [dependencies]
 async-trait = "0.1.77"
 maybe-async = "0.2.10"
-mls-rs = { version = "0.45.0", path = "../mls-rs" }
+mls-rs = { version = "0.46.0", path = "../mls-rs" }
 mls-rs-core = { version = "0.21.0", path = "../mls-rs-core" }
 mls-rs-crypto-openssl = { version = "0.14.0", path = "../mls-rs-crypto-openssl" }
 thiserror = "1.0.57"

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.45.3"
+version = "0.46.0"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/fuzz/Cargo.toml
+++ b/mls-rs/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-mls-rs = { version = "0.45.0", path = "..", features = ["arbitrary", "fuzz_util"] }
+mls-rs = { version = "0.46.0", path = "..", features = ["arbitrary", "fuzz_util"] }
 futures = "0.3.25"
 libfuzzer-sys = "0.4"
 once_cell = "1.13.0"

--- a/mls-rs/src/external_client/builder.rs
+++ b/mls-rs/src/external_client/builder.rs
@@ -14,9 +14,7 @@ use crate::{
         mls_rules::{DefaultMlsRules, MlsRules},
         proposal::ProposalType,
     },
-    identity::CredentialType,
     protocol_version::ProtocolVersion,
-    tree_kem::Capabilities,
     CryptoProvider, Sealed,
 };
 use std::{
@@ -134,14 +132,6 @@ impl<C: IntoConfig> ExternalClientBuilder<C> {
         let mut c = self.0.into_config();
         c.0.settings.extension_types.extend(types);
         ExternalClientBuilder(c)
-    }
-
-    /// Add a custom proposal type to the list of proposals types supported by the client.
-    pub fn custom_proposal_type(
-        self,
-        type_: ProposalType,
-    ) -> ExternalClientBuilder<IntoConfigOutput<C>> {
-        self.custom_proposal_types(Some(type_))
     }
 
     /// Add multiple custom proposal types to the list of proposal types supported by the client.
@@ -347,10 +337,6 @@ where
     type MlsRules = Pr;
     type CryptoProvider = Cp;
 
-    fn supported_extensions(&self) -> Vec<ExtensionType> {
-        self.settings.extension_types.clone()
-    }
-
     fn supported_protocol_versions(&self) -> Vec<ProtocolVersion> {
         self.settings.protocol_versions.clone()
     }
@@ -380,10 +366,6 @@ where
 
     fn cache_proposals(&self) -> bool {
         self.settings.cache_proposals
-    }
-
-    fn supported_custom_proposals(&self) -> Vec<ProposalType> {
-        self.settings.custom_proposal_types.clone()
     }
 }
 
@@ -421,16 +403,8 @@ impl<T: MlsConfig> ExternalClientConfig for T {
     type MlsRules = <T::Output as ExternalClientConfig>::MlsRules;
     type CryptoProvider = <T::Output as ExternalClientConfig>::CryptoProvider;
 
-    fn supported_extensions(&self) -> Vec<ExtensionType> {
-        self.get().supported_extensions()
-    }
-
     fn supported_protocol_versions(&self) -> Vec<ProtocolVersion> {
         self.get().supported_protocol_versions()
-    }
-
-    fn supported_custom_proposals(&self) -> Vec<ProposalType> {
-        self.get().supported_custom_proposals()
     }
 
     fn identity_provider(&self) -> Self::IdentityProvider {
@@ -457,16 +431,8 @@ impl<T: MlsConfig> ExternalClientConfig for T {
         self.get().max_epoch_jitter()
     }
 
-    fn capabilities(&self) -> Capabilities {
-        self.get().capabilities()
-    }
-
     fn version_supported(&self, version: ProtocolVersion) -> bool {
         self.get().version_supported(version)
-    }
-
-    fn supported_credentials(&self) -> Vec<CredentialType> {
-        self.get().supported_credentials()
     }
 }
 

--- a/mls-rs/src/external_client/config.rs
+++ b/mls-rs/src/external_client/config.rs
@@ -5,12 +5,7 @@
 use mls_rs_core::identity::IdentityProvider;
 
 use crate::{
-    crypto::SignaturePublicKey,
-    extension::ExtensionType,
-    group::{mls_rules::MlsRules, proposal::ProposalType},
-    identity::CredentialType,
-    protocol_version::ProtocolVersion,
-    tree_kem::Capabilities,
+    crypto::SignaturePublicKey, group::mls_rules::MlsRules, protocol_version::ProtocolVersion,
     CryptoProvider,
 };
 
@@ -19,36 +14,18 @@ pub trait ExternalClientConfig: Send + Sync + Clone {
     type MlsRules: MlsRules + Clone;
     type CryptoProvider: CryptoProvider;
 
-    fn supported_extensions(&self) -> Vec<ExtensionType>;
-    fn supported_custom_proposals(&self) -> Vec<ProposalType>;
     fn supported_protocol_versions(&self) -> Vec<ProtocolVersion>;
     fn identity_provider(&self) -> Self::IdentityProvider;
     fn crypto_provider(&self) -> Self::CryptoProvider;
     fn external_signing_key(&self, external_key_id: &[u8]) -> Option<SignaturePublicKey>;
-
     fn mls_rules(&self) -> Self::MlsRules;
-
     fn cache_proposals(&self) -> bool;
 
     fn max_epoch_jitter(&self) -> Option<u64> {
         None
     }
 
-    fn capabilities(&self) -> Capabilities {
-        Capabilities {
-            protocol_versions: self.supported_protocol_versions(),
-            cipher_suites: self.crypto_provider().supported_cipher_suites(),
-            extensions: self.supported_extensions(),
-            proposals: self.supported_custom_proposals(),
-            credentials: self.supported_credentials(),
-        }
-    }
-
     fn version_supported(&self, version: ProtocolVersion) -> bool {
         self.supported_protocol_versions().contains(&version)
-    }
-
-    fn supported_credentials(&self) -> Vec<CredentialType> {
-        self.identity_provider().supported_types()
     }
 }

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mls-rs = { version = "0.45.0", path = "..", default-features = false, features = ["std", "external_client"]}
+mls-rs = { version = "0.46.0", path = "..", default-features = false, features = ["std", "external_client"]}
 tonic = "0.10.2"
 prost = "0.12.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
### Description of changes:

#### Commit 1
Current code of ExternalClient _always_ stores the secret signing key in ExternalSnapshot. This is bad for security, as it requires servers to store all snapshots very securely. This CR removes the key from ExternalSnapshot and uses instead the key used to build ExternalClient loading the snapshot.

#### Commit 2
Remove unused functions.

### Call-outs:

Applications that relied on secret key being inside ExternalSnapshot should store the key separately and provide to `ExternalClientBuilder::signer` or `ExternalClient::new`.

If you want a migration that deletes the key from an existing ExternalSnapshot, see `legacy_snapshot_migration` test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
