### PR TITLE
Adding a trait to provide current time through the client config

### DIFF
--- a/mls-rs-core/src/time.rs
+++ b/mls-rs-core/src/time.rs
@@ -60,7 +60,6 @@ impl MlsTime {
 #[derive(Clone, Debug, Default)]
 pub struct DefaultCurrentTime {}
 
-#[cfg(any(target_arch = "wasm32", feature = "std"))]
 impl CurrentTimeProvider for DefaultCurrentTime {
     fn get_current_time_seconds(&self) -> u64 {
         #[cfg(target_arch = "wasm32")]
@@ -70,6 +69,8 @@ impl CurrentTimeProvider for DefaultCurrentTime {
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
+        #[cfg(all(not(target_arch = "wasm32"), not(feature = "std")))]
+        let ret_val = 0;
         ret_val
     }
 }

--- a/mls-rs-core/src/time.rs
+++ b/mls-rs-core/src/time.rs
@@ -4,7 +4,7 @@
 
 use core::time::Duration;
 
-pub trait CurrentTimeProvider: std::marker::Sync + std::marker::Send {
+pub trait CurrentTimeProvider: core::marker::Sync + core::marker::Send {
     fn get_current_time_seconds(&self) -> u64;
 }
 
@@ -48,6 +48,7 @@ extern "C" {
     fn date_now() -> f64;
 }
 
+#[cfg(any(target_arch = "wasm32", feature = "std"))]
 impl MlsTime {
     pub fn now<CT: CurrentTimeProvider>(ct: &CT) -> Self {
         Self {
@@ -56,6 +57,7 @@ impl MlsTime {
     }
 }
 
+#[cfg(any(target_arch = "wasm32", feature = "std"))]
 #[derive(Clone, Debug)]
 pub struct DefaultCurrentTime {}
 impl CurrentTimeProvider for DefaultCurrentTime {

--- a/mls-rs-core/src/time.rs
+++ b/mls-rs-core/src/time.rs
@@ -48,7 +48,6 @@ extern "C" {
     fn date_now() -> f64;
 }
 
-
 impl MlsTime {
     pub fn now<CT: CurrentTimeProvider>(ct: &CT) -> Self {
         Self {
@@ -58,16 +57,16 @@ impl MlsTime {
 }
 
 #[derive(Clone, Debug)]
-pub struct DefaultCurrentTime{}
+pub struct DefaultCurrentTime {}
 impl CurrentTimeProvider for DefaultCurrentTime {
     fn get_current_time_seconds(&self) -> u64 {
         #[cfg(target_arch = "wasm32")]
         let ret_val = (date_now() / 1000.0) as u64;
         #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
         let ret_val = std::time::SystemTime::now()
-                .duration_since(std::time::SystemTime::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
         ret_val
     }
 }

--- a/mls-rs-core/src/time.rs
+++ b/mls-rs-core/src/time.rs
@@ -57,9 +57,10 @@ impl MlsTime {
     }
 }
 
-#[cfg(any(target_arch = "wasm32", feature = "std"))]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct DefaultCurrentTime {}
+
+#[cfg(any(target_arch = "wasm32", feature = "std"))]
 impl CurrentTimeProvider for DefaultCurrentTime {
     fn get_current_time_seconds(&self) -> u64 {
         #[cfg(target_arch = "wasm32")]

--- a/mls-rs-crypto-awslc/src/x509/validator.rs
+++ b/mls-rs-crypto-awslc/src/x509/validator.rs
@@ -11,10 +11,7 @@ use crate::aws_lc_sys_impl::{
     X509_VERIFY_PARAM_set_time, X509_verify_cert, X509_verify_cert_error_string, X509_VERIFY_PARAM,
     X509_V_FLAG_NO_CHECK_TIME, X509_V_OK,
 };
-use mls_rs_core::{
-    crypto::SignaturePublicKey,
-    time::{MlsTime},
-};
+use mls_rs_core::{crypto::SignaturePublicKey, time::MlsTime};
 use mls_rs_identity_x509::{CertificateChain, DerCertificate, X509CredentialValidator};
 
 use crate::{check_non_null, check_res, AwsLcCryptoError};

--- a/mls-rs-crypto-awslc/src/x509/validator.rs
+++ b/mls-rs-crypto-awslc/src/x509/validator.rs
@@ -13,7 +13,7 @@ use crate::aws_lc_sys_impl::{
 };
 use mls_rs_core::{
     crypto::SignaturePublicKey,
-    time::{DefaultCurrentTime, MlsTime},
+    time::{MlsTime},
 };
 use mls_rs_identity_x509::{CertificateChain, DerCertificate, X509CredentialValidator};
 

--- a/mls-rs-crypto-awslc/src/x509/validator.rs
+++ b/mls-rs-crypto-awslc/src/x509/validator.rs
@@ -11,7 +11,10 @@ use crate::aws_lc_sys_impl::{
     X509_VERIFY_PARAM_set_time, X509_verify_cert, X509_verify_cert_error_string, X509_VERIFY_PARAM,
     X509_V_FLAG_NO_CHECK_TIME, X509_V_OK,
 };
-use mls_rs_core::{crypto::SignaturePublicKey, time::{MlsTime, DefaultCurrentTime}};
+use mls_rs_core::{
+    crypto::SignaturePublicKey,
+    time::{DefaultCurrentTime, MlsTime},
+};
 use mls_rs_identity_x509::{CertificateChain, DerCertificate, X509CredentialValidator};
 
 use crate::{check_non_null, check_res, AwsLcCryptoError};
@@ -133,7 +136,7 @@ mod tests {
     use std::time::Duration;
 
     use assert_matches::assert_matches;
-    use mls_rs_core::time::{MlsTime, DefaultCurrentTime};
+    use mls_rs_core::time::{DefaultCurrentTime, MlsTime};
     use mls_rs_identity_x509::{CertificateChain, DerCertificate, X509CredentialValidator};
 
     use crate::{
@@ -158,7 +161,7 @@ mod tests {
         let validator = CertificateValidator::new_der(&[load_test_ca()]).unwrap();
 
         validator
-            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})))
+            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})))
             .unwrap();
     }
 
@@ -167,7 +170,10 @@ mod tests {
         let validator = CertificateValidator::new_der(&[]).unwrap();
         let empty: Vec<Vec<u8>> = Vec::new();
 
-        let res = validator.validate_chain(&CertificateChain::from(empty), Some(MlsTime::now(&DefaultCurrentTime{})));
+        let res = validator.validate_chain(
+            &CertificateChain::from(empty),
+            Some(MlsTime::now(&DefaultCurrentTime {})),
+        );
 
         assert_matches!(res, Err(AwsLcCryptoError::CryptoError));
     }
@@ -177,7 +183,7 @@ mod tests {
         let chain = load_test_invalid_chain();
         let validator = CertificateValidator::new_der(&[load_test_ca()]).unwrap();
 
-        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})));
 
         assert_matches!(res, Err(AwsLcCryptoError::CertValidationFailure(_)));
     }
@@ -186,7 +192,7 @@ mod tests {
     fn will_fail_on_invalid_ca() {
         let chain = load_test_invalid_ca_chain();
         let validator = CertificateValidator::new_der(&[load_another_ca()]).unwrap();
-        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})));
 
         assert_matches!(res, Err(AwsLcCryptoError::CertValidationFailure(_)));
     }

--- a/mls-rs-crypto-openssl/src/x509.rs
+++ b/mls-rs-crypto-openssl/src/x509.rs
@@ -573,7 +573,7 @@ mod tests {
     use assert_matches::assert_matches;
     use mls_rs_core::{
         crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey},
-        time::MlsTime,
+        time::{MlsTime, DefaultCurrentTime},
     };
     use mls_rs_identity_x509::{
         CertificateChain, CertificateRequestParameters, DerCertificateRequest, SubjectAltName,
@@ -627,7 +627,7 @@ mod tests {
         let system_validator = X509Validator::new(vec![]).unwrap().with_system_ca();
 
         validator
-            .validate_chain(&chain, Some(MlsTime::now()))
+            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})))
             .unwrap();
 
         assert_matches!(
@@ -641,7 +641,7 @@ mod tests {
         let validator = X509Validator::new(vec![]).unwrap();
         let empty: Vec<Vec<u8>> = Vec::new();
 
-        let res = validator.validate_chain(&CertificateChain::from(empty), Some(MlsTime::now()));
+        let res = validator.validate_chain(&CertificateChain::from(empty), Some(MlsTime::now(&DefaultCurrentTime{})));
 
         assert_matches!(res, Err(X509Error::EmptyCertificateChain));
     }
@@ -672,7 +672,7 @@ mod tests {
         let chain = load_test_invalid_chain();
         let validator = X509Validator::new(vec![load_test_ca()]).unwrap();
 
-        let res = validator.validate_chain(&chain, Some(MlsTime::now()));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
 
         assert_matches!(res, Err(X509Error::ChainValidationFailure(_)));
     }
@@ -681,7 +681,7 @@ mod tests {
     fn will_fail_on_invalid_ca() {
         let chain = load_test_invalid_ca_chain();
         let validator = X509Validator::new(vec![load_another_ca()]).unwrap();
-        let res = validator.validate_chain(&chain, Some(MlsTime::now()));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
 
         assert_matches!(res, Err(X509Error::ChainValidationFailure(_)));
     }

--- a/mls-rs-crypto-openssl/src/x509.rs
+++ b/mls-rs-crypto-openssl/src/x509.rs
@@ -573,7 +573,7 @@ mod tests {
     use assert_matches::assert_matches;
     use mls_rs_core::{
         crypto::{CipherSuite, SignaturePublicKey, SignatureSecretKey},
-        time::{MlsTime, DefaultCurrentTime},
+        time::{DefaultCurrentTime, MlsTime},
     };
     use mls_rs_identity_x509::{
         CertificateChain, CertificateRequestParameters, DerCertificateRequest, SubjectAltName,
@@ -627,7 +627,7 @@ mod tests {
         let system_validator = X509Validator::new(vec![]).unwrap().with_system_ca();
 
         validator
-            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})))
+            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})))
             .unwrap();
 
         assert_matches!(
@@ -641,7 +641,10 @@ mod tests {
         let validator = X509Validator::new(vec![]).unwrap();
         let empty: Vec<Vec<u8>> = Vec::new();
 
-        let res = validator.validate_chain(&CertificateChain::from(empty), Some(MlsTime::now(&DefaultCurrentTime{})));
+        let res = validator.validate_chain(
+            &CertificateChain::from(empty),
+            Some(MlsTime::now(&DefaultCurrentTime {})),
+        );
 
         assert_matches!(res, Err(X509Error::EmptyCertificateChain));
     }
@@ -672,7 +675,7 @@ mod tests {
         let chain = load_test_invalid_chain();
         let validator = X509Validator::new(vec![load_test_ca()]).unwrap();
 
-        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})));
 
         assert_matches!(res, Err(X509Error::ChainValidationFailure(_)));
     }
@@ -681,7 +684,7 @@ mod tests {
     fn will_fail_on_invalid_ca() {
         let chain = load_test_invalid_ca_chain();
         let validator = X509Validator::new(vec![load_another_ca()]).unwrap();
-        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})));
 
         assert_matches!(res, Err(X509Error::ChainValidationFailure(_)));
     }

--- a/mls-rs-crypto-rustcrypto/src/x509/validator.rs
+++ b/mls-rs-crypto-rustcrypto/src/x509/validator.rs
@@ -217,7 +217,7 @@ mod tests {
     use std::time::Duration;
 
     use assert_matches::assert_matches;
-    use mls_rs_core::time::{MlsTime, DefaultCurrentTime};
+    use mls_rs_core::time::{DefaultCurrentTime, MlsTime};
     use mls_rs_identity_x509::{CertificateChain, X509CredentialValidator};
     use spki::der::Decode;
     use x509_cert::Certificate;
@@ -242,7 +242,7 @@ mod tests {
         let validator = X509Validator::new(vec![load_test_ca()]).unwrap();
 
         validator
-            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})))
+            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})))
             .unwrap();
     }
 
@@ -254,7 +254,7 @@ mod tests {
         let validator = X509Validator::new(vec![load_test_ca()]).unwrap();
 
         validator
-            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})))
+            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})))
             .unwrap();
     }
 
@@ -266,7 +266,7 @@ mod tests {
         validator.set_pinned_cert(Some(chain.get(1).unwrap().clone()));
 
         validator
-            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})))
+            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})))
             .unwrap();
     }
 
@@ -277,7 +277,12 @@ mod tests {
 
         let chain = vec![load_test_ca()].into();
 
-        X509CredentialValidator::validate_chain(&validator, &chain, Some(MlsTime::now(&DefaultCurrentTime{}))).unwrap();
+        X509CredentialValidator::validate_chain(
+            &validator,
+            &chain,
+            Some(MlsTime::now(&DefaultCurrentTime {})),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -287,7 +292,12 @@ mod tests {
 
         let chain = vec![load_test_p384_ca()].into();
 
-        X509CredentialValidator::validate_chain(&validator, &chain, Some(MlsTime::now(&DefaultCurrentTime{}))).unwrap();
+        X509CredentialValidator::validate_chain(
+            &validator,
+            &chain,
+            Some(MlsTime::now(&DefaultCurrentTime {})),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -297,7 +307,11 @@ mod tests {
 
         let chain = vec![load_test_ca(), load_another_ca()].into();
 
-        let res = X509CredentialValidator::validate_chain(&validator, &chain, Some(MlsTime::now(&DefaultCurrentTime{})));
+        let res = X509CredentialValidator::validate_chain(
+            &validator,
+            &chain,
+            Some(MlsTime::now(&DefaultCurrentTime {})),
+        );
 
         assert_matches!(res, Err(X509Error::SelfSignedWrongLength(2)))
     }
@@ -309,7 +323,7 @@ mod tests {
         let mut validator = X509Validator::new(vec![load_test_ca()]).unwrap();
         validator.set_pinned_cert(Some(load_another_ca()));
 
-        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})));
 
         assert_matches!(res, Err(X509Error::PinnedCertNotFound));
     }
@@ -337,7 +351,10 @@ mod tests {
         let validator = X509Validator::new(vec![]).unwrap();
         let empty: Vec<Vec<u8>> = Vec::new();
 
-        let res = validator.validate_chain(&CertificateChain::from(empty), Some(MlsTime::now(&DefaultCurrentTime{})));
+        let res = validator.validate_chain(
+            &CertificateChain::from(empty),
+            Some(MlsTime::now(&DefaultCurrentTime {})),
+        );
 
         assert_matches!(res, Err(X509Error::EmptyCertificateChain));
     }
@@ -347,7 +364,7 @@ mod tests {
         let chain = load_test_invalid_chain();
         let validator = X509Validator::new(vec![load_test_ca()]).unwrap();
 
-        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})));
 
         assert_matches!(
             res,
@@ -359,7 +376,7 @@ mod tests {
     fn will_fail_on_invalid_ca() {
         let chain = load_test_invalid_ca_chain();
         let validator = X509Validator::new(vec![load_another_ca()]).unwrap();
-        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime {})));
 
         assert_matches!(
             res,

--- a/mls-rs-crypto-rustcrypto/src/x509/validator.rs
+++ b/mls-rs-crypto-rustcrypto/src/x509/validator.rs
@@ -217,7 +217,7 @@ mod tests {
     use std::time::Duration;
 
     use assert_matches::assert_matches;
-    use mls_rs_core::time::MlsTime;
+    use mls_rs_core::time::{MlsTime, DefaultCurrentTime};
     use mls_rs_identity_x509::{CertificateChain, X509CredentialValidator};
     use spki::der::Decode;
     use x509_cert::Certificate;
@@ -242,7 +242,7 @@ mod tests {
         let validator = X509Validator::new(vec![load_test_ca()]).unwrap();
 
         validator
-            .validate_chain(&chain, Some(MlsTime::now()))
+            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})))
             .unwrap();
     }
 
@@ -254,7 +254,7 @@ mod tests {
         let validator = X509Validator::new(vec![load_test_ca()]).unwrap();
 
         validator
-            .validate_chain(&chain, Some(MlsTime::now()))
+            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})))
             .unwrap();
     }
 
@@ -266,7 +266,7 @@ mod tests {
         validator.set_pinned_cert(Some(chain.get(1).unwrap().clone()));
 
         validator
-            .validate_chain(&chain, Some(MlsTime::now()))
+            .validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})))
             .unwrap();
     }
 
@@ -277,7 +277,7 @@ mod tests {
 
         let chain = vec![load_test_ca()].into();
 
-        X509CredentialValidator::validate_chain(&validator, &chain, Some(MlsTime::now())).unwrap();
+        X509CredentialValidator::validate_chain(&validator, &chain, Some(MlsTime::now(&DefaultCurrentTime{}))).unwrap();
     }
 
     #[test]
@@ -287,7 +287,7 @@ mod tests {
 
         let chain = vec![load_test_p384_ca()].into();
 
-        X509CredentialValidator::validate_chain(&validator, &chain, Some(MlsTime::now())).unwrap();
+        X509CredentialValidator::validate_chain(&validator, &chain, Some(MlsTime::now(&DefaultCurrentTime{}))).unwrap();
     }
 
     #[test]
@@ -297,7 +297,7 @@ mod tests {
 
         let chain = vec![load_test_ca(), load_another_ca()].into();
 
-        let res = X509CredentialValidator::validate_chain(&validator, &chain, Some(MlsTime::now()));
+        let res = X509CredentialValidator::validate_chain(&validator, &chain, Some(MlsTime::now(&DefaultCurrentTime{})));
 
         assert_matches!(res, Err(X509Error::SelfSignedWrongLength(2)))
     }
@@ -309,7 +309,7 @@ mod tests {
         let mut validator = X509Validator::new(vec![load_test_ca()]).unwrap();
         validator.set_pinned_cert(Some(load_another_ca()));
 
-        let res = validator.validate_chain(&chain, Some(MlsTime::now()));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
 
         assert_matches!(res, Err(X509Error::PinnedCertNotFound));
     }
@@ -337,7 +337,7 @@ mod tests {
         let validator = X509Validator::new(vec![]).unwrap();
         let empty: Vec<Vec<u8>> = Vec::new();
 
-        let res = validator.validate_chain(&CertificateChain::from(empty), Some(MlsTime::now()));
+        let res = validator.validate_chain(&CertificateChain::from(empty), Some(MlsTime::now(&DefaultCurrentTime{})));
 
         assert_matches!(res, Err(X509Error::EmptyCertificateChain));
     }
@@ -347,7 +347,7 @@ mod tests {
         let chain = load_test_invalid_chain();
         let validator = X509Validator::new(vec![load_test_ca()]).unwrap();
 
-        let res = validator.validate_chain(&chain, Some(MlsTime::now()));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
 
         assert_matches!(
             res,
@@ -359,7 +359,7 @@ mod tests {
     fn will_fail_on_invalid_ca() {
         let chain = load_test_invalid_ca_chain();
         let validator = X509Validator::new(vec![load_another_ca()]).unwrap();
-        let res = validator.validate_chain(&chain, Some(MlsTime::now()));
+        let res = validator.validate_chain(&chain, Some(MlsTime::now(&DefaultCurrentTime{})));
 
         assert_matches!(
             res,

--- a/mls-rs-identity-x509/src/provider.rs
+++ b/mls-rs-identity-x509/src/provider.rs
@@ -10,7 +10,7 @@ use mls_rs_core::{
     error::IntoAnyError,
     extension::ExtensionList,
     identity::{CredentialType, IdentityProvider, MemberValidationContext, SigningIdentity},
-    time::{MlsTime, DefaultCurrentTime},
+    time::{DefaultCurrentTime, MlsTime},
 };
 
 #[cfg(not(feature = "std"))]
@@ -217,7 +217,7 @@ mod tests {
 
         let test_signing_identity = test_signing_identity_with_chain(chain.clone());
 
-        let test_timestamp = MlsTime::now(&DefaultCurrentTime{});
+        let test_timestamp = MlsTime::now(&DefaultCurrentTime {});
 
         let test_provider = test_setup(|_, validator| {
             let validation_result = test_signing_identity.signature_key.clone();

--- a/mls-rs-identity-x509/src/provider.rs
+++ b/mls-rs-identity-x509/src/provider.rs
@@ -170,7 +170,9 @@ where
 mod tests {
     use super::*;
     use mls_rs_core::{
-        crypto::SignaturePublicKey, identity::CredentialType, time::{MlsTime, DefaultCurrentTime},
+        crypto::SignaturePublicKey,
+        identity::CredentialType,
+        time::{DefaultCurrentTime, MlsTime},
     };
 
     use crate::{

--- a/mls-rs-identity-x509/src/provider.rs
+++ b/mls-rs-identity-x509/src/provider.rs
@@ -10,7 +10,7 @@ use mls_rs_core::{
     error::IntoAnyError,
     extension::ExtensionList,
     identity::{CredentialType, IdentityProvider, MemberValidationContext, SigningIdentity},
-    time::MlsTime,
+    time::{MlsTime, DefaultCurrentTime},
 };
 
 #[cfg(not(feature = "std"))]
@@ -217,7 +217,7 @@ mod tests {
 
         let test_signing_identity = test_signing_identity_with_chain(chain.clone());
 
-        let test_timestamp = MlsTime::now();
+        let test_timestamp = MlsTime::now(&DefaultCurrentTime{});
 
         let test_provider = test_setup(|_, validator| {
             let validation_result = test_signing_identity.signature_key.clone();

--- a/mls-rs-identity-x509/src/provider.rs
+++ b/mls-rs-identity-x509/src/provider.rs
@@ -10,7 +10,7 @@ use mls_rs_core::{
     error::IntoAnyError,
     extension::ExtensionList,
     identity::{CredentialType, IdentityProvider, MemberValidationContext, SigningIdentity},
-    time::{MlsTime},
+    time::MlsTime,
 };
 
 #[cfg(not(feature = "std"))]
@@ -169,7 +169,9 @@ where
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
-    use mls_rs_core::{crypto::SignaturePublicKey, identity::CredentialType, time::MlsTime};
+    use mls_rs_core::{
+        crypto::SignaturePublicKey, identity::CredentialType, time::MlsTime, DefaultCurrentTime,
+    };
 
     use crate::{
         test_utils::{

--- a/mls-rs-identity-x509/src/provider.rs
+++ b/mls-rs-identity-x509/src/provider.rs
@@ -10,7 +10,7 @@ use mls_rs_core::{
     error::IntoAnyError,
     extension::ExtensionList,
     identity::{CredentialType, IdentityProvider, MemberValidationContext, SigningIdentity},
-    time::{DefaultCurrentTime, MlsTime},
+    time::{MlsTime},
 };
 
 #[cfg(not(feature = "std"))]

--- a/mls-rs-identity-x509/src/provider.rs
+++ b/mls-rs-identity-x509/src/provider.rs
@@ -170,7 +170,7 @@ where
 mod tests {
     use super::*;
     use mls_rs_core::{
-        crypto::SignaturePublicKey, identity::CredentialType, time::MlsTime, DefaultCurrentTime,
+        crypto::SignaturePublicKey, identity::CredentialType, time::{MlsTime, DefaultCurrentTime},
     };
 
     use crate::{

--- a/mls-rs-provider-sqlite/src/key_package.rs
+++ b/mls-rs-provider-sqlite/src/key_package.rs
@@ -5,7 +5,7 @@
 use mls_rs_core::{
     key_package::{KeyPackageData, KeyPackageStorage},
     mls_rs_codec::{MlsDecode, MlsEncode},
-    time::MlsTime,
+    time::{MlsTime, CurrentTimeProvider},
 };
 use rusqlite::{params, Connection, OptionalExtension};
 use std::sync::{Arc, Mutex};
@@ -76,8 +76,8 @@ impl SqLiteKeyPackageStorage {
     }
 
     /// Delete key packages that are expired based on the current system clock time.
-    pub fn delete_expired(&self) -> Result<(), SqLiteDataStorageError> {
-        self.delete_expired_by_time(MlsTime::now().seconds_since_epoch())
+    pub fn delete_expired<CT: CurrentTimeProvider>(&self, ct: &CT) -> Result<(), SqLiteDataStorageError> {
+        self.delete_expired_by_time(MlsTime::now(ct).seconds_since_epoch())
     }
 
     /// Delete key packages that are expired based on an application provided time in seconds since
@@ -147,7 +147,7 @@ mod tests {
         {connection_strategy::MemoryStrategy, test_utils::gen_rand_bytes},
     };
     use assert_matches::assert_matches;
-    use mls_rs_core::{crypto::HpkeSecretKey, key_package::KeyPackageData};
+    use mls_rs_core::{crypto::HpkeSecretKey, key_package::KeyPackageData, time::DefaultCurrentTime};
 
     fn test_storage() -> SqLiteKeyPackageStorage {
         SqLiteDataStorageEngine::new(MemoryStrategy)
@@ -239,7 +239,7 @@ mod tests {
         storage.get(&data[2].0).unwrap().unwrap();
         storage.get(&data[3].0).unwrap().unwrap();
 
-        storage.delete_expired().unwrap();
+        storage.delete_expired(&DefaultCurrentTime{}).unwrap();
 
         assert!(storage.get(&data[2].0).unwrap().is_none());
         assert!(storage.get(&data[3].0).unwrap().is_none());

--- a/mls-rs-provider-sqlite/src/key_package.rs
+++ b/mls-rs-provider-sqlite/src/key_package.rs
@@ -5,7 +5,7 @@
 use mls_rs_core::{
     key_package::{KeyPackageData, KeyPackageStorage},
     mls_rs_codec::{MlsDecode, MlsEncode},
-    time::{MlsTime, CurrentTimeProvider},
+    time::{CurrentTimeProvider, MlsTime},
 };
 use rusqlite::{params, Connection, OptionalExtension};
 use std::sync::{Arc, Mutex};
@@ -76,7 +76,10 @@ impl SqLiteKeyPackageStorage {
     }
 
     /// Delete key packages that are expired based on the current system clock time.
-    pub fn delete_expired<CT: CurrentTimeProvider>(&self, ct: &CT) -> Result<(), SqLiteDataStorageError> {
+    pub fn delete_expired<CT: CurrentTimeProvider>(
+        &self,
+        ct: &CT,
+    ) -> Result<(), SqLiteDataStorageError> {
         self.delete_expired_by_time(MlsTime::now(ct).seconds_since_epoch())
     }
 
@@ -147,7 +150,9 @@ mod tests {
         {connection_strategy::MemoryStrategy, test_utils::gen_rand_bytes},
     };
     use assert_matches::assert_matches;
-    use mls_rs_core::{crypto::HpkeSecretKey, key_package::KeyPackageData, time::DefaultCurrentTime};
+    use mls_rs_core::{
+        crypto::HpkeSecretKey, key_package::KeyPackageData, time::DefaultCurrentTime,
+    };
 
     fn test_storage() -> SqLiteKeyPackageStorage {
         SqLiteDataStorageEngine::new(MemoryStrategy)
@@ -239,7 +244,7 @@ mod tests {
         storage.get(&data[2].0).unwrap().unwrap();
         storage.get(&data[3].0).unwrap().unwrap();
 
-        storage.delete_expired(&DefaultCurrentTime{}).unwrap();
+        storage.delete_expired(&DefaultCurrentTime {}).unwrap();
 
         assert!(storage.get(&data[2].0).unwrap().is_none());
         assert!(storage.get(&data[3].0).unwrap().is_none());

--- a/mls-rs/src/client_builder.rs
+++ b/mls-rs/src/client_builder.rs
@@ -27,7 +27,8 @@ use crate::{
 };
 
 #[cfg(feature = "std")]
-use crate::time::{CurrentTimeProvider, DefaultCurrentTime, MlsTime};
+use crate::time::MlsTime;
+use crate::time::{CurrentTimeProvider, DefaultCurrentTime};
 
 use alloc::vec::Vec;
 

--- a/mls-rs/src/client_builder.rs
+++ b/mls-rs/src/client_builder.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 #[cfg(feature = "std")]
-use crate::time::{MlsTime, DefaultCurrentTime, CurrentTimeProvider};
+use crate::time::{CurrentTimeProvider, DefaultCurrentTime, MlsTime};
 
 use alloc::vec::Vec;
 
@@ -65,7 +65,8 @@ pub type BaseInMemoryConfig = Config<
     DefaultCurrentTime,
 >;
 
-pub type EmptyConfig = Config<Missing, Missing, Missing, Missing, Missing, Missing, DefaultCurrentTime>;
+pub type EmptyConfig =
+    Config<Missing, Missing, Missing, Missing, Missing, Missing, DefaultCurrentTime>;
 
 /// Base client configuration that is backed by SQLite storage.
 #[cfg(feature = "sqlite")]
@@ -206,7 +207,7 @@ impl ClientBuilder<BaseConfig> {
             signer: Default::default(),
             signing_identity: Default::default(),
             version: ProtocolVersion::MLS_10,
-            current_time: DefaultCurrentTime{},
+            current_time: DefaultCurrentTime {},
         }))
     }
 }
@@ -224,7 +225,7 @@ impl ClientBuilder<EmptyConfig> {
             signer: Default::default(),
             signing_identity: Default::default(),
             version: ProtocolVersion::MLS_10,
-            current_time: DefaultCurrentTime{},
+            current_time: DefaultCurrentTime {},
         }))
     }
 }
@@ -337,8 +338,9 @@ impl<C: IntoConfig> ClientBuilder<C> {
     /// Set the current time accessor to be used by the client.
     ///
     /// By default, an implementation using the SystemTime::now (except for WASM) is used.
-    pub fn current_time<CT>(self, current_time: CT) -> ClientBuilder<WithCurrentTime<CT, C>> 
-    where CT: CurrentTimeProvider,
+    pub fn current_time<CT>(self, current_time: CT) -> ClientBuilder<WithCurrentTime<CT, C>>
+    where
+        CT: CurrentTimeProvider,
     {
         let Config(c) = self.0.into_config();
 
@@ -354,7 +356,7 @@ impl<C: IntoConfig> ClientBuilder<C> {
             signing_identity: c.signing_identity,
             version: c.version,
             current_time,
-        }))    
+        }))
     }
 
     /// Set the PSK store to be used by the client.
@@ -931,7 +933,9 @@ mod private {
     use crate::client_builder::{IntoConfigOutput, Settings};
 
     #[derive(Clone, Debug)]
-    pub struct Config<Kpr, Ps, Gss, Ip, Pr, Cp, CT>(pub(crate) ConfigInner<Kpr, Ps, Gss, Ip, Pr, Cp, CT>);
+    pub struct Config<Kpr, Ps, Gss, Ip, Pr, Cp, CT>(
+        pub(crate) ConfigInner<Kpr, Ps, Gss, Ip, Pr, Cp, CT>,
+    );
 
     #[derive(Clone, Debug)]
     pub struct ConfigInner<Kpr, Ps, Gss, Ip, Pr, Cp, CT> {

--- a/mls-rs/src/client_config.rs
+++ b/mls-rs/src/client_config.rs
@@ -9,6 +9,7 @@ use crate::{
     protocol_version::ProtocolVersion,
     tree_kem::{leaf_node::ConfigProperties, Capabilities, Lifetime},
     ExtensionList,
+    time::CurrentTimeProvider,
 };
 use alloc::vec::Vec;
 use mls_rs_core::{
@@ -23,6 +24,7 @@ pub trait ClientConfig: Send + Sync + Clone {
     type IdentityProvider: IdentityProvider + Clone;
     type MlsRules: MlsRules + Clone;
     type CryptoProvider: CryptoProvider + Clone;
+    type CurrentTimeProvider: CurrentTimeProvider + Clone;
 
     fn supported_extensions(&self) -> Vec<ExtensionType>;
     fn supported_custom_proposals(&self) -> Vec<ProposalType>;
@@ -36,6 +38,7 @@ pub trait ClientConfig: Send + Sync + Clone {
     fn group_state_storage(&self) -> Self::GroupStateStorage;
     fn identity_provider(&self) -> Self::IdentityProvider;
     fn crypto_provider(&self) -> Self::CryptoProvider;
+    fn current_time(&self) -> Self::CurrentTimeProvider;
 
     fn lifetime(&self) -> Lifetime;
 

--- a/mls-rs/src/client_config.rs
+++ b/mls-rs/src/client_config.rs
@@ -7,9 +7,9 @@ use crate::{
     group::{mls_rules::MlsRules, proposal::ProposalType},
     identity::CredentialType,
     protocol_version::ProtocolVersion,
+    time::CurrentTimeProvider,
     tree_kem::{leaf_node::ConfigProperties, Capabilities, Lifetime},
     ExtensionList,
-    time::CurrentTimeProvider,
 };
 use alloc::vec::Vec;
 use mls_rs_core::{

--- a/mls-rs/src/external_client.rs
+++ b/mls-rs/src/external_client.rs
@@ -162,6 +162,10 @@ where
     pub fn identity_provider(&self) -> <C as ExternalClientConfig>::IdentityProvider {
         self.config.identity_provider()
     }
+
+    pub fn current_time(&self) -> <C as ExternalClientConfig>::CurrentTimeProvider {
+        self.config.current_time()
+    }
 }
 
 #[cfg(test)]

--- a/mls-rs/src/external_client.rs
+++ b/mls-rs/src/external_client.rs
@@ -152,8 +152,9 @@ where
             .ok_or(MlsError::UnsupportedCipherSuite(key_package.cipher_suite))?;
 
         let id = self.config.identity_provider();
+        let ct = self.current_time();
 
-        validate_key_package(&key_package, version, &cs, &id).await?;
+        validate_key_package(&key_package, version, &cs, &id, &ct).await?;
 
         Ok(key_package)
     }

--- a/mls-rs/src/external_client/builder.rs
+++ b/mls-rs/src/external_client/builder.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 /// Base client configuration type when instantiating `ExternalClientBuilder`
-pub type ExternalBaseConfig = Config<Missing, DefaultMlsRules, Missing>;
+pub type ExternalBaseConfig = Config<Missing, DefaultMlsRules, Missing, DefaultCurrentTime>;
 
 /// Builder for [`ExternalClient`]
 ///
@@ -222,7 +222,7 @@ impl<C: IntoConfig> ExternalClientBuilder<C> {
     }
 
     /// Set the current time accessor to be used by the client.
-    pub fn current_time<I>(self, current_time: CT) -> ExternalClientBuilder<WithCurrentTime<CT, C>>
+    pub fn current_time<CT>(self, current_time: CT) -> ExternalClientBuilder<WithCurrentTime<CT, C>>
     where
         CT: CurrentTimeProvider,
     {
@@ -254,6 +254,7 @@ impl<C: IntoConfig> ExternalClientBuilder<C> {
             mls_rules: c.mls_rules,
             crypto_provider,
             signing_data: c.signing_data,
+            current_time: c.current_time,
         }))
     }
 
@@ -275,6 +276,7 @@ impl<C: IntoConfig> ExternalClientBuilder<C> {
             mls_rules,
             crypto_provider: c.crypto_provider,
             signing_data: c.signing_data,
+            current_time: c.current_time,
         }))
     }
 
@@ -295,6 +297,7 @@ where
     C::IdentityProvider: IdentityProvider + Clone,
     C::MlsRules: MlsRules + Clone,
     C::CryptoProvider: CryptoProvider + Clone,
+    C::CurrentTimeProvider: CurrentTimeProvider + Clone,
 {
     pub(crate) fn build_config(self) -> IntoConfigOutput<C> {
         let mut c = self.0.into_config();
@@ -423,7 +426,7 @@ where
     Cp: CryptoProvider + Clone,
     CT: CurrentTimeProvider + Clone,
 {
-    type Output = ConfigInner<Ip, Pr, Cp>;
+    type Output = ConfigInner<Ip, Pr, Cp, CT>;
 
     fn get(&self) -> &Self::Output {
         &self.0

--- a/mls-rs/src/external_client/builder.rs
+++ b/mls-rs/src/external_client/builder.rs
@@ -15,8 +15,8 @@ use crate::{
         proposal::ProposalType,
     },
     protocol_version::ProtocolVersion,
+    time::{CurrentTimeProvider, DefaultCurrentTime},
     CryptoProvider, Sealed,
-    time::{CurrentTimeProvider, DefaultCurrentTime}
 };
 use std::{
     collections::HashMap,
@@ -112,7 +112,7 @@ impl ExternalClientBuilder<ExternalBaseConfig> {
             mls_rules: DefaultMlsRules::new(),
             crypto_provider: Missing,
             signing_data: None,
-            current_time: DefaultCurrentTime{},
+            current_time: DefaultCurrentTime {},
         }))
     }
 }
@@ -222,10 +222,7 @@ impl<C: IntoConfig> ExternalClientBuilder<C> {
     }
 
     /// Set the current time accessor to be used by the client.
-    pub fn current_time<I>(
-        self,
-        current_time: CT,
-    ) -> ExternalClientBuilder<WithCurrentTime<CT, C>>
+    pub fn current_time<I>(self, current_time: CT) -> ExternalClientBuilder<WithCurrentTime<CT, C>>
     where
         CT: CurrentTimeProvider,
     {
@@ -327,22 +324,39 @@ pub struct Missing;
 /// Change the identity validator used by a client configuration.
 ///
 /// See [`ExternalClientBuilder::identity_provider`].
-pub type WithIdentityProvider<I, C> =
-    Config<I, <C as IntoConfig>::MlsRules, <C as IntoConfig>::CryptoProvider, <C as IntoConfig>::CurrentTimeProvider>;
+pub type WithIdentityProvider<I, C> = Config<
+    I,
+    <C as IntoConfig>::MlsRules,
+    <C as IntoConfig>::CryptoProvider,
+    <C as IntoConfig>::CurrentTimeProvider,
+>;
 
-pub type WithCurrentTime<CT, C> = Config<<C as IntoConfig>::IdentityProvider, <C as IntoConfig>::MlsRules, <C as IntoConfig>::CryptoProvider, CT>;
+pub type WithCurrentTime<CT, C> = Config<
+    <C as IntoConfig>::IdentityProvider,
+    <C as IntoConfig>::MlsRules,
+    <C as IntoConfig>::CryptoProvider,
+    CT,
+>;
 
 /// Change the proposal filter used by a client configuration.
 ///
 /// See [`ExternalClientBuilder::mls_rules`].
-pub type WithMlsRules<Pr, C> =
-    Config<<C as IntoConfig>::IdentityProvider, Pr, <C as IntoConfig>::CryptoProvider, <C as IntoConfig>::CurrentTimeProvider>;
+pub type WithMlsRules<Pr, C> = Config<
+    <C as IntoConfig>::IdentityProvider,
+    Pr,
+    <C as IntoConfig>::CryptoProvider,
+    <C as IntoConfig>::CurrentTimeProvider,
+>;
 
 /// Change the crypto provider used by a client configuration.
 ///
 /// See [`ExternalClientBuilder::crypto_provider`].
-pub type WithCryptoProvider<Cp, C> =
-    Config<<C as IntoConfig>::IdentityProvider, <C as IntoConfig>::MlsRules, Cp, <C as IntoConfig>::CurrentTimeProvider>;
+pub type WithCryptoProvider<Cp, C> = Config<
+    <C as IntoConfig>::IdentityProvider,
+    <C as IntoConfig>::MlsRules,
+    Cp,
+    <C as IntoConfig>::CurrentTimeProvider,
+>;
 
 /// Helper alias for `Config`.
 pub type IntoConfigOutput<C> = Config<
@@ -571,19 +585,21 @@ use private::{Config, ConfigInner, IntoConfig};
 pub(crate) mod test_utils {
     use crate::{
         cipher_suite::CipherSuite, crypto::test_utils::TestCryptoProvider,
-        identity::basic::BasicIdentityProvider,
-        time::DefaultCurrentTime,
+        identity::basic::BasicIdentityProvider, time::DefaultCurrentTime,
     };
 
     use super::{
-        ExternalBaseConfig, ExternalClientBuilder, WithCryptoProvider, WithIdentityProvider, WithCurrentTime
+        ExternalBaseConfig, ExternalClientBuilder, WithCryptoProvider, WithCurrentTime,
+        WithIdentityProvider,
     };
 
     pub type TestExternalClientConfig = WithIdentityProvider<
         BasicIdentityProvider,
-        WithCryptoProvider<TestCryptoProvider, 
-        WithCurrentTime<DefaultCurrentTime, ExternalBaseConfig>,
-    >>;
+        WithCryptoProvider<
+            TestCryptoProvider,
+            WithCurrentTime<DefaultCurrentTime, ExternalBaseConfig>,
+        >,
+    >;
 
     pub type TestExternalClientBuilder = ExternalClientBuilder<TestExternalClientConfig>;
 

--- a/mls-rs/src/external_client/config.rs
+++ b/mls-rs/src/external_client/config.rs
@@ -6,7 +6,7 @@ use mls_rs_core::identity::IdentityProvider;
 
 use crate::{
     crypto::SignaturePublicKey, group::mls_rules::MlsRules, protocol_version::ProtocolVersion,
-    CryptoProvider, time::CurrentTimeProvider
+    time::CurrentTimeProvider, CryptoProvider,
 };
 
 pub trait ExternalClientConfig: Send + Sync + Clone {

--- a/mls-rs/src/external_client/config.rs
+++ b/mls-rs/src/external_client/config.rs
@@ -6,16 +6,18 @@ use mls_rs_core::identity::IdentityProvider;
 
 use crate::{
     crypto::SignaturePublicKey, group::mls_rules::MlsRules, protocol_version::ProtocolVersion,
-    CryptoProvider,
+    CryptoProvider, time::CurrentTimeProvider
 };
 
 pub trait ExternalClientConfig: Send + Sync + Clone {
     type IdentityProvider: IdentityProvider + Clone;
     type MlsRules: MlsRules + Clone;
     type CryptoProvider: CryptoProvider;
+    type CurrentTimeProvider: CurrentTimeProvider;
 
     fn supported_protocol_versions(&self) -> Vec<ProtocolVersion>;
     fn identity_provider(&self) -> Self::IdentityProvider;
+    fn current_time(&self) -> Self::CurrentTimeProvider;
     fn crypto_provider(&self) -> Self::CryptoProvider;
     fn external_signing_key(&self, external_key_id: &[u8]) -> Option<SignaturePublicKey>;
     fn mls_rules(&self) -> Self::MlsRules;

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -612,9 +612,14 @@ where
     type PreSharedKeyStorage = AlwaysFoundPskStorage;
     type OutputType = ExternalReceivedMessage;
     type CipherSuiteProvider = <C::CryptoProvider as CryptoProvider>::CipherSuiteProvider;
+    type CurrentTimeProvider = C::CurrentTimeProvider;
 
     fn mls_rules(&self) -> Self::MlsRules {
         self.config.mls_rules()
+    }
+
+    fn current_time(&self) -> Self::CurrentTimeProvider {
+        self.config.current_time()
     }
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -502,6 +502,7 @@ where
         }
 
         let mls_rules = self.config.mls_rules();
+        let ct = self.config.current_time();
 
         let is_external = external_leaf.is_some();
 
@@ -518,7 +519,7 @@ where
         let old_signer = &self.signer;
 
         #[cfg(feature = "std")]
-        let time = Some(crate::time::MlsTime::now());
+        let time = Some(crate::time::MlsTime::now(&ct));
 
         #[cfg(not(feature = "std"))]
         let time = None;

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -502,6 +502,7 @@ where
         }
 
         let mls_rules = self.config.mls_rules();
+        #[cfg(feature = "std")]
         let ct = self.config.current_time();
 
         let is_external = external_leaf.is_some();

--- a/mls-rs/src/group/interop_test_vectors/passive_client.rs
+++ b/mls-rs/src/group/interop_test_vectors/passive_client.rs
@@ -29,6 +29,7 @@ use crate::{
     },
     tree_kem::Lifetime,
     Client, Group, MlsMessage,
+    time::DefaultCurrentTime,
 };
 
 const VERSION: ProtocolVersion = ProtocolVersion::MLS_10;
@@ -207,7 +208,7 @@ async fn interop_passive_client() {
                 let message = MlsMessage::from_bytes(&proposal.0).unwrap();
 
                 group
-                    .process_incoming_message_with_time(message, MlsTime::now())
+                    .process_incoming_message_with_time(message, MlsTime::now(&DefaultCurrentTime{}))
                     .await
                     .unwrap();
             }
@@ -215,7 +216,7 @@ async fn interop_passive_client() {
             let message = MlsMessage::from_bytes(&epoch.commit).unwrap();
 
             group
-                .process_incoming_message_with_time(message, MlsTime::now())
+                .process_incoming_message_with_time(message, MlsTime::now(&DefaultCurrentTime{}))
                 .await
                 .unwrap();
 

--- a/mls-rs/src/group/interop_test_vectors/passive_client.rs
+++ b/mls-rs/src/group/interop_test_vectors/passive_client.rs
@@ -27,9 +27,9 @@ use crate::{
         all_process_message, generate_basic_client, get_test_basic_credential, get_test_groups,
         make_test_ext_psk, TEST_EXT_PSK_ID,
     },
+    time::DefaultCurrentTime,
     tree_kem::Lifetime,
     Client, Group, MlsMessage,
-    time::DefaultCurrentTime,
 };
 
 const VERSION: ProtocolVersion = ProtocolVersion::MLS_10;
@@ -208,7 +208,10 @@ async fn interop_passive_client() {
                 let message = MlsMessage::from_bytes(&proposal.0).unwrap();
 
                 group
-                    .process_incoming_message_with_time(message, MlsTime::now(&DefaultCurrentTime{}))
+                    .process_incoming_message_with_time(
+                        message,
+                        MlsTime::now(&DefaultCurrentTime {}),
+                    )
                     .await
                     .unwrap();
             }
@@ -216,7 +219,7 @@ async fn interop_passive_client() {
             let message = MlsMessage::from_bytes(&epoch.commit).unwrap();
 
             group
-                .process_incoming_message_with_time(message, MlsTime::now(&DefaultCurrentTime{}))
+                .process_incoming_message_with_time(message, MlsTime::now(&DefaultCurrentTime {}))
                 .await
                 .unwrap();
 

--- a/mls-rs/src/group/message_processor.rs
+++ b/mls-rs/src/group/message_processor.rs
@@ -1007,12 +1007,12 @@ pub(crate) async fn validate_key_package<
     version: ProtocolVersion,
     cs: &C,
     id: &I,
-    ct: &CT,
+    _ct: &CT,
 ) -> Result<(), MlsError> {
     let validator = LeafNodeValidator::new(cs, id, MemberValidationContext::None);
 
     #[cfg(feature = "std")]
-    let context = Some(MlsTime::now::<CT>(ct));
+    let context = Some(MlsTime::now::<CT>(_ct));
 
     #[cfg(not(feature = "std"))]
     let context = None;

--- a/mls-rs/src/group/message_processor.rs
+++ b/mls-rs/src/group/message_processor.rs
@@ -25,7 +25,7 @@ use super::{
 use crate::{
     client::MlsError,
     key_package::validate_key_package_properties,
-    time::{MlsTime, CurrentTimeProvider},
+    time::{CurrentTimeProvider, MlsTime},
     tree_kem::{
         leaf_node_validator::{LeafNodeValidator, ValidationContext},
         node::LeafIndex,
@@ -998,7 +998,11 @@ pub(crate) trait MessageProcessor: Send + Sync {
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
-pub(crate) async fn validate_key_package<C: CipherSuiteProvider, I: IdentityProvider, CT: CurrentTimeProvider>(
+pub(crate) async fn validate_key_package<
+    C: CipherSuiteProvider,
+    I: IdentityProvider,
+    CT: CurrentTimeProvider,
+>(
     key_package: &KeyPackage,
     version: ProtocolVersion,
     cs: &C,

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2323,11 +2323,11 @@ mod tests {
         identity::test_utils::get_test_signing_identity,
         key_package::test_utils::test_key_package_message,
         mls_rules::CommitOptions,
+        time::{CurrentTimeProvider, DefaultCurrentTime},
         tree_kem::{
             leaf_node::{test_utils::get_test_capabilities, LeafNodeSource},
             UpdatePathNode,
         },
-        time::{DefaultCurrentTime, CurrentTimeProvider},
     };
 
     #[cfg(feature = "by_ref_proposal")]
@@ -4493,7 +4493,8 @@ mod tests {
         let commit = groups[0].commit(vec![]).await.unwrap().commit_message;
 
         // 10 years from now
-        let future_time = MlsTime::now(&DefaultCurrentTime{}).seconds_since_epoch() + 10 * 365 * 24 * 3600;
+        let future_time =
+            MlsTime::now(&DefaultCurrentTime {}).seconds_since_epoch() + 10 * 365 * 24 * 3600;
 
         let future_time =
             MlsTime::from_duration_since_epoch(core::time::Duration::from_secs(future_time));
@@ -5346,21 +5347,23 @@ mod tests {
             .current_time(CustomTimeProvider::new())
             .build();
 
-        let (alice_identity, secret_key) = get_test_signing_identity(TEST_CIPHER_SUITE, b"alice").await;
+        let (alice_identity, secret_key) =
+            get_test_signing_identity(TEST_CIPHER_SUITE, b"alice").await;
         let alice_time = CustomTimeProvider::new();
         let alice = TestClientBuilder::new_for_test()
             .signing_identity(alice_identity, secret_key, TEST_CIPHER_SUITE)
             .current_time(alice_time.clone())
             .build();
 
-        let mut alice_group = alice.create_group(Default::default(), Default::default())
-                            .await
-                            .unwrap();
+        let mut alice_group = alice
+            .create_group(Default::default(), Default::default())
+            .await
+            .unwrap();
 
-                            let bob_key_package = bob
-                            .generate_key_package_message(Default::default(), Default::default())
-                            .await
-                            .unwrap();
+        let bob_key_package = bob
+            .generate_key_package_message(Default::default(), Default::default())
+            .await
+            .unwrap();
 
         let commit_output = alice_group
             .commit_builder()
@@ -5370,9 +5373,13 @@ mod tests {
             .await
             .unwrap();
 
-        // alice_group.apply_pending_commit().await.unwrap();
-        alice_group.process_incoming_message_with_time(commit_output.commit_message, alice_time.get_current_time_seconds().into()).await.unwrap();
-        
+        alice_group
+            .process_incoming_message_with_time(
+                commit_output.commit_message,
+                alice_time.get_current_time_seconds().into(),
+            )
+            .await
+            .unwrap();
     }
 
     #[cfg(feature = "custom_proposal")]
@@ -5409,7 +5416,7 @@ mod tests {
             const INITIAL_TIME_S: u64 = 1740000000;
 
             Self {
-                cur_time_seconds: std::sync::Arc::new(std::sync::Mutex::new(INITIAL_TIME_S))
+                cur_time_seconds: std::sync::Arc::new(std::sync::Mutex::new(INITIAL_TIME_S)),
             }
         }
     }

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -5407,7 +5407,7 @@ mod tests {
 
     #[derive(Debug, Clone)]
     struct CustomTimeProvider {
-        cur_time_seconds: alloc::sync::Arc<alloc::sync::Mutex<u64>>,
+        cur_time_seconds: alloc::sync::Arc<spin::mutex::Mutex<u64>>,
     }
 
     impl CustomTimeProvider {
@@ -5416,14 +5416,14 @@ mod tests {
             const INITIAL_TIME_S: u64 = 1740000000;
 
             Self {
-                cur_time_seconds: alloc::sync::Arc::new(alloc::sync::Mutex::new(INITIAL_TIME_S)),
+                cur_time_seconds: alloc::sync::Arc::new(spin::mutex::Mutex::new(INITIAL_TIME_S)),
             }
         }
     }
 
     impl crate::time::CurrentTimeProvider for CustomTimeProvider {
         fn get_current_time_seconds(&self) -> u64 {
-            let mut current_time_ref = self.cur_time_seconds.lock().unwrap();
+            let mut current_time_ref = self.cur_time_seconds.lock();
             let old_time = *current_time_ref;
             let next_time = old_time + 1;
             *current_time_ref = next_time;

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -5339,6 +5339,7 @@ mod tests {
         alice.process_incoming_message(commit).await.unwrap();
     }
 
+    #[cfg(feature = "std")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn commit_processes_with_custom_time_provider() {
         let (bob_identity, secret_key) = get_test_signing_identity(TEST_CIPHER_SUITE, b"bob").await;

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2067,6 +2067,7 @@ where
     type PreSharedKeyStorage = C::PskStore;
     type OutputType = ReceivedMessage;
     type CipherSuiteProvider = <C::CryptoProvider as CryptoProvider>::CipherSuiteProvider;
+    type CurrentTimeProvider = C::CurrentTimeProvider;
 
     #[cfg(feature = "private_message")]
     async fn process_ciphertext(
@@ -2263,6 +2264,10 @@ where
         &mut self.state
     }
 
+    fn current_time(&self) -> Self::CurrentTimeProvider {
+        self.config.current_time()
+    }
+
     fn removal_proposal(
         &self,
         provisional_state: &ProvisionalState,
@@ -2322,6 +2327,7 @@ mod tests {
             leaf_node::{test_utils::get_test_capabilities, LeafNodeSource},
             UpdatePathNode,
         },
+        time::DefaultCurrentTime,
     };
 
     #[cfg(feature = "by_ref_proposal")]
@@ -4487,7 +4493,7 @@ mod tests {
         let commit = groups[0].commit(vec![]).await.unwrap().commit_message;
 
         // 10 years from now
-        let future_time = MlsTime::now().seconds_since_epoch() + 10 * 365 * 24 * 3600;
+        let future_time = MlsTime::now(&DefaultCurrentTime{}).seconds_since_epoch() + 10 * 365 * 24 * 3600;
 
         let future_time =
             MlsTime::from_duration_since_epoch(core::time::Duration::from_secs(future_time));

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -5407,7 +5407,7 @@ mod tests {
 
     #[derive(Debug, Clone)]
     struct CustomTimeProvider {
-        cur_time_seconds: std::sync::Arc<std::sync::Mutex<u64>>,
+        cur_time_seconds: alloc::sync::Arc<alloc::sync::Mutex<u64>>,
     }
 
     impl CustomTimeProvider {
@@ -5416,7 +5416,7 @@ mod tests {
             const INITIAL_TIME_S: u64 = 1740000000;
 
             Self {
-                cur_time_seconds: std::sync::Arc::new(std::sync::Mutex::new(INITIAL_TIME_S)),
+                cur_time_seconds: alloc::sync::Arc::new(alloc::sync::Mutex::new(INITIAL_TIME_S)),
             }
         }
     }

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -693,6 +693,7 @@ mod tests {
         identity::test_utils::{get_test_signing_identity, BasicWithCustomProvider},
         key_package::{test_utils::test_key_package, KeyPackageGenerator},
         mls_rules::{CommitOptions, DefaultMlsRules},
+        time::DefaultCurrentTime,
         psk::AlwaysFoundPskStorage,
         tree_kem::{
             leaf_node::{
@@ -3042,7 +3043,7 @@ mod tests {
                 properties,
                 signing_identity,
                 &signature_key,
-                Lifetime::years(1).unwrap(),
+                Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
             )
             .await
             .unwrap();
@@ -3611,7 +3612,7 @@ mod tests {
 
         generator
             .generate(
-                Lifetime::years(1).unwrap(),
+                Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
                 Capabilities {
                     credentials: vec![42.into()],
                     ..Default::default()

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -693,8 +693,8 @@ mod tests {
         identity::test_utils::{get_test_signing_identity, BasicWithCustomProvider},
         key_package::{test_utils::test_key_package, KeyPackageGenerator},
         mls_rules::{CommitOptions, DefaultMlsRules},
-        time::DefaultCurrentTime,
         psk::AlwaysFoundPskStorage,
+        time::DefaultCurrentTime,
         tree_kem::{
             leaf_node::{
                 test_utils::{
@@ -3043,7 +3043,7 @@ mod tests {
                 properties,
                 signing_identity,
                 &signature_key,
-                Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
+                Lifetime::years(1, &DefaultCurrentTime {}).unwrap(),
             )
             .await
             .unwrap();
@@ -3612,7 +3612,7 @@ mod tests {
 
         generator
             .generate(
-                Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
+                Lifetime::years(1, &DefaultCurrentTime {}).unwrap(),
                 Capabilities {
                     credentials: vec![42.into()],
                     ..Default::default()

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -23,6 +23,7 @@ use crate::{
     key_package::{KeyPackageGeneration, KeyPackageGenerator},
     mls_rules::{CommitOptions, DefaultMlsRules},
     tree_kem::{leaf_node::test_utils::get_test_capabilities, Lifetime},
+    time::DefaultCurrentTime,
 };
 
 use crate::extension::RequiredCapabilitiesExt;
@@ -203,7 +204,7 @@ pub(crate) fn group_extensions() -> ExtensionList {
 }
 
 pub(crate) fn lifetime() -> Lifetime {
-    Lifetime::years(1).unwrap()
+    Lifetime::years(1, &DefaultCurrentTime{}).unwrap()
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
@@ -445,6 +446,7 @@ impl MessageProcessor for GroupWithoutKeySchedule {
     type PreSharedKeyStorage = <Group<TestClientConfig> as MessageProcessor>::PreSharedKeyStorage;
     type IdentityProvider = <Group<TestClientConfig> as MessageProcessor>::IdentityProvider;
     type MlsRules = <Group<TestClientConfig> as MessageProcessor>::MlsRules;
+    type CurrentTimeProvider = <Group<TestClientConfig> as MessageProcessor>::CurrentTimeProvider;
 
     fn group_state(&self) -> &GroupState {
         self.inner.group_state()
@@ -457,6 +459,10 @@ impl MessageProcessor for GroupWithoutKeySchedule {
 
     fn mls_rules(&self) -> Self::MlsRules {
         self.inner.mls_rules()
+    }
+
+    fn current_time(&self) -> Self::CurrentTimeProvider {
+        self.inner.current_time()
     }
 
     fn identity_provider(&self) -> Self::IdentityProvider {

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -22,8 +22,8 @@ use crate::{
     identity::test_utils::get_test_signing_identity,
     key_package::{KeyPackageGeneration, KeyPackageGenerator},
     mls_rules::{CommitOptions, DefaultMlsRules},
-    tree_kem::{leaf_node::test_utils::get_test_capabilities, Lifetime},
     time::DefaultCurrentTime,
+    tree_kem::{leaf_node::test_utils::get_test_capabilities, Lifetime},
 };
 
 use crate::extension::RequiredCapabilitiesExt;
@@ -204,7 +204,7 @@ pub(crate) fn group_extensions() -> ExtensionList {
 }
 
 pub(crate) fn lifetime() -> Lifetime {
-    Lifetime::years(1, &DefaultCurrentTime{}).unwrap()
+    Lifetime::years(1, &DefaultCurrentTime {}).unwrap()
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]

--- a/mls-rs/src/key_package/generator.rs
+++ b/mls-rs/src/key_package/generator.rs
@@ -155,6 +155,7 @@ mod tests {
             Lifetime,
         },
         ExtensionList,
+        time::DefaultCurrentTime,
     };
 
     use super::KeyPackageGenerator;
@@ -172,7 +173,7 @@ mod tests {
     }
 
     fn test_lifetime() -> Lifetime {
-        Lifetime::years(1).unwrap()
+        Lifetime::years(1, &DefaultCurrentTime{}).unwrap()
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]

--- a/mls-rs/src/key_package/generator.rs
+++ b/mls-rs/src/key_package/generator.rs
@@ -149,13 +149,13 @@ mod tests {
         identity::test_utils::get_test_signing_identity,
         key_package::validate_key_package_properties,
         protocol_version::ProtocolVersion,
+        time::DefaultCurrentTime,
         tree_kem::{
             leaf_node::{test_utils::get_test_capabilities, LeafNodeSource},
             leaf_node_validator::{LeafNodeValidator, ValidationContext},
             Lifetime,
         },
         ExtensionList,
-        time::DefaultCurrentTime,
     };
 
     use super::KeyPackageGenerator;
@@ -173,7 +173,7 @@ mod tests {
     }
 
     fn test_lifetime() -> Lifetime {
-        Lifetime::years(1, &DefaultCurrentTime{}).unwrap()
+        Lifetime::years(1, &DefaultCurrentTime {}).unwrap()
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -176,6 +176,7 @@ pub(crate) mod test_utils {
         identity::test_utils::get_test_signing_identity,
         tree_kem::{leaf_node::test_utils::get_test_capabilities, Lifetime},
         MlsMessage,
+        time::DefaultCurrentTime,
     };
 
     use mls_rs_core::crypto::SignatureSecretKey;
@@ -209,7 +210,7 @@ pub(crate) mod test_utils {
 
         let key_package = generator
             .generate(
-                Lifetime::years(1).unwrap(),
+                Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
                 get_test_capabilities(),
                 ExtensionList::default(),
                 ExtensionList::default(),

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -174,9 +174,9 @@ pub(crate) mod test_utils {
         crypto::test_utils::test_cipher_suite_provider,
         group::framing::MlsMessagePayload,
         identity::test_utils::get_test_signing_identity,
+        time::DefaultCurrentTime,
         tree_kem::{leaf_node::test_utils::get_test_capabilities, Lifetime},
         MlsMessage,
-        time::DefaultCurrentTime,
     };
 
     use mls_rs_core::crypto::SignatureSecretKey;
@@ -210,7 +210,7 @@ pub(crate) mod test_utils {
 
         let key_package = generator
             .generate(
-                Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
+                Lifetime::years(1, &DefaultCurrentTime {}).unwrap(),
                 get_test_capabilities(),
                 ExtensionList::default(),
                 ExtensionList::default(),

--- a/mls-rs/src/tree_kem/leaf_node.rs
+++ b/mls-rs/src/tree_kem/leaf_node.rs
@@ -297,7 +297,7 @@ pub(crate) mod test_utils {
             secret,
             capabilities.unwrap_or_else(get_test_capabilities),
             extensions.unwrap_or_default(),
-            Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
+            Lifetime::years(1, &DefaultCurrentTime {}).unwrap(),
         )
         .await
     }
@@ -358,7 +358,7 @@ pub(crate) mod test_utils {
             },
             signing_identity,
             &signature_key,
-            Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
+            Lifetime::years(1, &DefaultCurrentTime {}).unwrap(),
         )
         .await
         .map(|(leaf, hpke_secret_key)| (leaf, hpke_secret_key, signature_key))
@@ -416,14 +416,14 @@ mod tests {
     use crate::crypto::test_utils::TestCryptoProvider;
     use crate::group::test_utils::random_bytes;
     use crate::identity::test_utils::get_test_signing_identity;
-    use assert_matches::assert_matches;
     use crate::time::DefaultCurrentTime;
+    use assert_matches::assert_matches;
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn test_node_generation() {
         let capabilities = get_test_capabilities();
         let extensions = get_test_extensions();
-        let lifetime = Lifetime::years(1, &DefaultCurrentTime{}).unwrap();
+        let lifetime = Lifetime::years(1, &DefaultCurrentTime {}).unwrap();
 
         for cipher_suite in TestCryptoProvider::all_supported_cipher_suites() {
             let (signing_identity, secret) = get_test_signing_identity(cipher_suite, b"foo").await;

--- a/mls-rs/src/tree_kem/leaf_node.rs
+++ b/mls-rs/src/tree_kem/leaf_node.rs
@@ -275,6 +275,7 @@ pub(crate) mod test_utils {
         cipher_suite::CipherSuite,
         crypto::test_utils::{test_cipher_suite_provider, TestCryptoProvider},
         identity::test_utils::{get_test_signing_identity, BasicWithCustomProvider},
+        time::DefaultCurrentTime,
     };
 
     use crate::extension::ApplicationIdExt;
@@ -296,7 +297,7 @@ pub(crate) mod test_utils {
             secret,
             capabilities.unwrap_or_else(get_test_capabilities),
             extensions.unwrap_or_default(),
-            Lifetime::years(1).unwrap(),
+            Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
         )
         .await
     }
@@ -357,7 +358,7 @@ pub(crate) mod test_utils {
             },
             signing_identity,
             &signature_key,
-            Lifetime::years(1).unwrap(),
+            Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
         )
         .await
         .map(|(leaf, hpke_secret_key)| (leaf, hpke_secret_key, signature_key))
@@ -416,12 +417,13 @@ mod tests {
     use crate::group::test_utils::random_bytes;
     use crate::identity::test_utils::get_test_signing_identity;
     use assert_matches::assert_matches;
+    use crate::time::DefaultCurrentTime;
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn test_node_generation() {
         let capabilities = get_test_capabilities();
         let extensions = get_test_extensions();
-        let lifetime = Lifetime::years(1).unwrap();
+        let lifetime = Lifetime::years(1, &DefaultCurrentTime{}).unwrap();
 
         for cipher_suite in TestCryptoProvider::all_supported_cipher_suites() {
             let (signing_identity, secret) = get_test_signing_identity(cipher_suite, b"foo").await;

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -237,6 +237,7 @@ mod tests {
     use crate::client::test_utils::TEST_PROTOCOL_VERSION;
     use crate::crypto::test_utils::try_test_cipher_suite_provider;
     use crate::extension::MlsExtension;
+    use crate::time::DefaultCurrentTime;
     use alloc::vec;
     use assert_matches::assert_matches;
     #[cfg(feature = "std")]
@@ -637,7 +638,7 @@ mod tests {
         let test_validator =
             LeafNodeValidator::new_for_test(&cipher_suite_provider, &BasicIdentityProvider);
 
-        let good_lifetime = MlsTime::now();
+        let good_lifetime = MlsTime::now(&DefaultCurrentTime{});
 
         let over_one_year = good_lifetime.seconds_since_epoch() + (86400 * 366);
 

--- a/mls-rs/src/tree_kem/leaf_node_validator.rs
+++ b/mls-rs/src/tree_kem/leaf_node_validator.rs
@@ -638,7 +638,7 @@ mod tests {
         let test_validator =
             LeafNodeValidator::new_for_test(&cipher_suite_provider, &BasicIdentityProvider);
 
-        let good_lifetime = MlsTime::now(&DefaultCurrentTime{});
+        let good_lifetime = MlsTime::now(&DefaultCurrentTime {});
 
         let over_one_year = good_lifetime.seconds_since_epoch() + (86400 * 366);
 

--- a/mls-rs/src/tree_kem/lifetime.rs
+++ b/mls-rs/src/tree_kem/lifetime.rs
@@ -2,7 +2,10 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use crate::{client::MlsError, time::{MlsTime, CurrentTimeProvider, DefaultCurrentTime}};
+use crate::{
+    client::MlsError,
+    time::{CurrentTimeProvider, DefaultCurrentTime, MlsTime},
+};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
 #[derive(Clone, Debug, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode, Default)]
@@ -61,21 +64,21 @@ mod tests {
 
     #[test]
     fn test_lifetime_overflow() {
-        let res = Lifetime::seconds(u64::MAX, &DefaultCurrentTime{});
+        let res = Lifetime::seconds(u64::MAX, &DefaultCurrentTime {});
         assert_matches!(res, Err(MlsError::TimeOverflow))
     }
 
     #[test]
     fn test_seconds() {
         let seconds = 10;
-        let lifetime = Lifetime::seconds(seconds, &DefaultCurrentTime{}).unwrap();
+        let lifetime = Lifetime::seconds(seconds, &DefaultCurrentTime {}).unwrap();
         assert_eq!(lifetime.not_after - lifetime.not_before, 3610);
     }
 
     #[test]
     fn test_days() {
         let days = 2;
-        let lifetime = Lifetime::days(days, &DefaultCurrentTime{}).unwrap();
+        let lifetime = Lifetime::days(days, &DefaultCurrentTime {}).unwrap();
 
         assert_eq!(
             lifetime.not_after - lifetime.not_before,
@@ -86,7 +89,7 @@ mod tests {
     #[test]
     fn test_years() {
         let years = 2;
-        let ct = DefaultCurrentTime{};
+        let ct = DefaultCurrentTime {};
         let lifetime = Lifetime::years(years, &ct).unwrap();
 
         assert_eq!(

--- a/mls-rs/src/tree_kem/lifetime.rs
+++ b/mls-rs/src/tree_kem/lifetime.rs
@@ -60,6 +60,7 @@ mod tests {
     use core::time::Duration;
 
     use super::*;
+    use crate::time::DefaultCurrentTime;
     use assert_matches::assert_matches;
 
     #[test]

--- a/mls-rs/src/tree_kem/lifetime.rs
+++ b/mls-rs/src/tree_kem/lifetime.rs
@@ -25,9 +25,9 @@ impl Lifetime {
         }
     }
 
-    pub fn seconds<CT: CurrentTimeProvider>(s: u64, ct: &CT) -> Result<Self, MlsError> {
+    pub fn seconds<CT: CurrentTimeProvider>(s: u64, _ct: &CT) -> Result<Self, MlsError> {
         #[cfg(feature = "std")]
-        let not_before = MlsTime::now::<CT>(ct).seconds_since_epoch();
+        let not_before = MlsTime::now::<CT>(_ct).seconds_since_epoch();
         #[cfg(not(feature = "std"))]
         // There is no clock on no_std, this is here just so that we can run tests.
         let not_before = 3600u64;

--- a/mls-rs/src/tree_kem/lifetime.rs
+++ b/mls-rs/src/tree_kem/lifetime.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     client::MlsError,
-    time::{CurrentTimeProvider, DefaultCurrentTime, MlsTime},
+    time::{CurrentTimeProvider, MlsTime},
 };
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -783,8 +783,8 @@ pub(crate) mod test_utils {
         cipher_suite::CipherSuite,
         crypto::{HpkeSecretKey, SignatureSecretKey},
         identity::basic::BasicIdentityProvider,
-        tree_kem::leaf_node::test_utils::get_basic_test_node_sig_key,
         time::DefaultCurrentTime,
+        tree_kem::leaf_node::test_utils::get_basic_test_node_sig_key,
     };
 
     use super::leaf_node::{ConfigProperties, LeafNodeSigningContext};
@@ -979,7 +979,7 @@ pub(crate) mod test_utils {
             properties,
             signing_identity,
             &signature_key,
-            Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
+            Lifetime::years(1, &DefaultCurrentTime {}).unwrap(),
         )
         .await
         .unwrap();

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -784,6 +784,7 @@ pub(crate) mod test_utils {
         crypto::{HpkeSecretKey, SignatureSecretKey},
         identity::basic::BasicIdentityProvider,
         tree_kem::leaf_node::test_utils::get_basic_test_node_sig_key,
+        time::DefaultCurrentTime,
     };
 
     use super::leaf_node::{ConfigProperties, LeafNodeSigningContext};
@@ -978,7 +979,7 @@ pub(crate) mod test_utils {
             properties,
             signing_identity,
             &signature_key,
-            Lifetime::years(1).unwrap(),
+            Lifetime::years(1, &DefaultCurrentTime{}).unwrap(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
There are various places in the source code currently where `MlsTime::now()` is called. This calls the `SystemTime::now` (unless we are running in WASM).

This PR adds the ability to specialize the clock. This is useful both for testing (setting a deterministic clock), and also for allowing an application to provide an external clock.