### PR TITLE
Fixing missing update_hash for SelfRemove proposals

### DIFF
--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1704,6 +1704,7 @@ where
         };
 
         info.grease(self.cipher_suite_provider())?;
+
         info.sign(&self.cipher_suite_provider, &self.signer, &())
             .await?;
 

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -237,6 +237,13 @@ impl ProposalBundle {
         #[cfg(feature = "custom_proposal")]
         let len = len + self.custom_proposals.len();
 
+        #[cfg(all(
+            feature = "by_ref_proposal",
+            feature = "custom_proposal",
+            feature = "self_remove_proposal"
+        ))]
+        let len = len + self.self_removes.len();
+
         #[cfg(feature = "by_ref_proposal")]
         let len = len + self.updates.len();
 
@@ -342,7 +349,7 @@ impl ProposalBundle {
             feature = "custom_proposal",
             feature = "self_remove_proposal"
         ))]
-        let group_context_extensions_to_chain = group_context_extensions_to_chain.chain(
+        let res = res.chain(
             self.self_removes
                 .into_iter()
                 .map(|p| p.map(Proposal::SelfRemove)),

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -572,6 +572,8 @@ impl TreeKemPublic {
         Ok(added)
     }
 
+    #[cfg(not(feature = "by_ref_proposal"))]
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn batch_edit_lite<I, CP>(
         &mut self,
         proposal_bundle: &ProposalBundle,
@@ -624,8 +626,6 @@ impl TreeKemPublic {
             .map(|p| p.proposal.to_remove)
             .chain(added.iter().copied())
             .collect_vec();
-
-        let updated_leaves = chained.collect_vec();
 
         self.update_hashes(&updated_leaves, cipher_suite_provider)
             .await?;

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -393,6 +393,7 @@ impl TreeKemPublic {
     {
         // Apply removes (they commute with updates because they don't touch the same leaves)
         // Self-removes take precedence
+        #[cfg(all(feature = "custom_proposal", feature = "self_remove_proposal"))]
         let mut self_removed = vec![];
         #[cfg(all(feature = "custom_proposal", feature = "self_remove_proposal"))]
         for i in (0..proposal_bundle.self_removes.len()).rev() {
@@ -557,14 +558,17 @@ impl TreeKemPublic {
 
         self.nodes.trim();
 
-        let updated_leaves = proposal_bundle
+        let chained = proposal_bundle
             .remove_proposals()
             .iter()
             .map(|p| p.proposal.to_remove)
-            .chain(self_removed)
             .chain(updated_indices)
-            .chain(added.iter().copied())
-            .collect_vec();
+            .chain(added.iter().copied());
+
+        #[cfg(all(feature = "custom_proposal", feature = "self_remove_proposal"))]
+        let chained = chained.chain(self_removed);
+
+        let updated_leaves = chained.collect_vec();
 
         self.update_hashes(&updated_leaves, cipher_suite_provider)
             .await?;


### PR DESCRIPTION
Bug fix; missing updating the hashes on self-removed leaves in `batch_edit` . This caused a `TreeHashMismatch` error on construction of an external commit with the GroupInfo after processing a commit with a self-remove proposal, because the tree hash in the group context did not match the true tree hash.

This PR fixes the bug and adds a test that was repro'ing the previous bug.