### PR TITLE
Remove unused `CredentialEncodingError` variant

### DIFF
--- a/mls-rs-identity-x509/src/error.rs
+++ b/mls-rs-identity-x509/src/error.rs
@@ -21,8 +21,6 @@ pub enum X509IdentityError {
     #[cfg_attr(feature = "std", error("empty certificate chain"))]
     EmptyCertificateChain,
     #[cfg_attr(feature = "std", error(transparent))]
-    CredentialEncodingError(AnyError),
-    #[cfg_attr(feature = "std", error(transparent))]
     X509ReaderError(AnyError),
     #[cfg_attr(feature = "std", error(transparent))]
     IdentityExtractorError(AnyError),


### PR DESCRIPTION

### Description of changes:

Removes an unused enum variant. I did a quick search and don't see the variant used anywhere.

### Testing:

Existing unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
