### PR TITLE
Remove unused `InvalidCertificateChain` variant

### DIFF
--- a/mls-rs-identity-x509/src/error.rs
+++ b/mls-rs-identity-x509/src/error.rs
@@ -14,8 +14,6 @@ pub enum X509IdentityError {
         error("signing identity public key does not match the leaf certificate")
     )]
     SignatureKeyMismatch,
-    #[cfg_attr(feature = "std", error("unable to parse certificate chain data"))]
-    InvalidCertificateChain,
     #[cfg_attr(feature = "std", error("invalid offset within certificate chain"))]
     InvalidOffset,
     #[cfg_attr(feature = "std", error("empty certificate chain"))]


### PR DESCRIPTION
### Description of changes:

Removes an unused enum variant. I did a quick search and don't see the variant used anywhere.

### Testing:
Existing unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.