### PR TITLE
Remove unused `IdentityWarningProviderError` variant

### DIFF
--- a/mls-rs-identity-x509/src/error.rs
+++ b/mls-rs-identity-x509/src/error.rs
@@ -28,8 +28,6 @@ pub enum X509IdentityError {
     IdentityExtractorError(AnyError),
     #[cfg_attr(feature = "std", error(transparent))]
     X509ValidationError(AnyError),
-    #[cfg_attr(feature = "std", error(transparent))]
-    IdentityWarningProviderError(AnyError),
 }
 
 impl mls_rs_core::error::IntoAnyError for X509IdentityError {


### PR DESCRIPTION
### Description of changes:

Removes an unused enum variant. I did a quick search and don't see the variant used anywhere.

### Testing:

Existing unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
