### PR TITLE
Server remove proposal

### DIFF
--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -23,6 +23,7 @@ serde = ["dep:serde", "zeroize/serde", "hex/serde", "dep:serde_bytes"]
 last_resort_key_package_ext = []
 post-quantum = []
 self_remove_proposal = []
+server_remove_proposal = []
 
 [dependencies]
 mls-rs-codec = { version = "0.6", path = "../mls-rs-codec", default-features = false}

--- a/mls-rs-core/src/group/proposal_type.rs
+++ b/mls-rs-core/src/group/proposal_type.rs
@@ -58,6 +58,7 @@ impl ProposalType {
     pub const GROUP_CONTEXT_EXTENSIONS: ProposalType = ProposalType(7);
     #[cfg(feature = "self_remove_proposal")]
     pub const SELF_REMOVE: ProposalType = ProposalType(0xF003);
+    pub const SERVER_REMOVE: ProposalType = ProposalType(0xF004);
 
     /// Default proposal types defined
     /// in [RFC 9420](https://www.rfc-editor.org/rfc/rfc9420.html#name-leaf-node-contents)

--- a/mls-rs-core/src/group/proposal_type.rs
+++ b/mls-rs-core/src/group/proposal_type.rs
@@ -58,6 +58,7 @@ impl ProposalType {
     pub const GROUP_CONTEXT_EXTENSIONS: ProposalType = ProposalType(7);
     #[cfg(feature = "self_remove_proposal")]
     pub const SELF_REMOVE: ProposalType = ProposalType(0xF003);
+    #[cfg(feature = "server_remove_proposal")]
     pub const SERVER_REMOVE: ProposalType = ProposalType(0xF004);
 
     /// Default proposal types defined

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -36,6 +36,7 @@ x509 = ["mls-rs-core/x509", "dep:mls-rs-identity-x509"]
 rfc_compliant = ["private_message", "custom_proposal", "out_of_order", "psk", "x509", "prior_epoch", "by_ref_proposal", "mls-rs-core/rfc_compliant"]
 last_resort_key_package_ext = ["mls-rs-core/last_resort_key_package_ext"]
 self_remove_proposal = ["mls-rs-core/self_remove_proposal"]
+server_remove_proposal = ["mls-rs-core/server_remove_proposal"]
 
 std = ["mls-rs-core/std", "mls-rs-codec/std", "mls-rs-identity-x509?/std", "hex/std", "futures/std", "itertools/use_std", "safer-ffi-gen?/std", "zeroize/std", "dep:debug_tree", "dep:thiserror", "serde?/std"]
 

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -43,6 +43,7 @@ use crate::{
     feature = "self_remove_proposal"
 ))]
 use crate::group::proposal::SelfRemoveProposal;
+use crate::group::proposal::ServerRemoveProposal;
 
 #[cfg(feature = "by_ref_proposal")]
 use crate::{
@@ -696,6 +697,13 @@ where
         &self,
         _provisional_state: &ProvisionalState,
     ) -> Option<ProposalInfo<SelfRemoveProposal>> {
+        None
+    }
+
+    fn server_removal_proposal(
+        &self,
+        _provisional_state: &ProvisionalState,
+    ) -> Option<ProposalInfo<ServerRemoveProposal>> {
         None
     }
 

--- a/mls-rs/src/external_client/group.rs
+++ b/mls-rs/src/external_client/group.rs
@@ -43,6 +43,7 @@ use crate::{
     feature = "self_remove_proposal"
 ))]
 use crate::group::proposal::SelfRemoveProposal;
+#[cfg(feature = "server_remove_proposal")]
 use crate::group::proposal::ServerRemoveProposal;
 
 #[cfg(feature = "by_ref_proposal")]
@@ -700,6 +701,8 @@ where
         None
     }
 
+    #[cfg(feature = "server_remove_proposal")]
+    #[cfg_attr(feature = "ffi", safer_ffi_gen::safer_ffi_gen_ignore)]
     fn server_removal_proposal(
         &self,
         _provisional_state: &ProvisionalState,

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -18,6 +18,7 @@ use crate::{
     Group, MlsMessage,
 };
 
+#[cfg(feature = "server_remove_proposal")]
 use crate::group::proposal::ServerRemoveProposal;
 
 #[cfg(any(feature = "secret_tree_access", feature = "private_message"))]
@@ -283,6 +284,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             }));
         }
 
+        #[cfg(feature = "server_remove_proposal")]
         for index_to_remove in self.to_server_remove {
             proposals.push(Proposal::ServerRemove(ServerRemoveProposal {
                 to_remove: LeafIndex(index_to_remove),

--- a/mls-rs/src/group/message_processor.rs
+++ b/mls-rs/src/group/message_processor.rs
@@ -8,6 +8,7 @@
     feature = "self_remove_proposal"
 ))]
 use super::SelfRemoveProposal;
+#[cfg(feature = "server_remove_proposal")]
 use super::ServerRemoveProposal;
 use super::{
     commit_sender,
@@ -92,6 +93,7 @@ pub(crate) fn path_update_required(proposals: &ProposalBundle) -> bool {
     ))]
     let res = res || !proposals.self_removes.is_empty();
 
+    #[cfg(feature = "server_remove_proposal")]
     let res = res || !proposals.server_removes.is_empty();
 
     res || proposals.length() == 0
@@ -730,6 +732,7 @@ pub(crate) trait MessageProcessor: Send + Sync {
         ))]
         let self_removed_by_self = self.self_removal_proposal(&provisional_state);
 
+        #[cfg(feature = "server_remove_proposal")]
         let self_removed_by_server = self.server_removal_proposal(&provisional_state);
 
         let is_self_removed = self_removed.is_some();
@@ -740,6 +743,7 @@ pub(crate) trait MessageProcessor: Send + Sync {
         ))]
         let is_self_removed = is_self_removed || self_removed_by_self.is_some();
 
+        #[cfg(feature = "server_remove_proposal")]
         let is_self_removed = is_self_removed || self_removed_by_server.is_some();
 
         let update_path = match commit.path {
@@ -790,6 +794,7 @@ pub(crate) trait MessageProcessor: Send + Sync {
             commit_effect
         };
 
+        #[cfg(feature = "server_remove_proposal")]
         let commit_effect = if let Some(server_remove_proposal) = self_removed_by_server {
             let new_epoch = NewEpoch::new(self.group_state().clone(), &provisional_state);
             CommitEffect::Removed {
@@ -868,6 +873,8 @@ pub(crate) trait MessageProcessor: Send + Sync {
         provisional_state: &ProvisionalState,
     ) -> Option<ProposalInfo<SelfRemoveProposal>>;
 
+    #[cfg(feature = "server_remove_proposal")]
+    #[cfg_attr(feature = "ffi", safer_ffi_gen::safer_ffi_gen_ignore)]
     fn server_removal_proposal(
         &self,
         provisional_state: &ProvisionalState,

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1078,6 +1078,24 @@ where
         self.proposal_message(proposal, authenticated_data).await
     }
 
+    #[cfg_attr(feature = "ffi", safer_ffi_gen::safer_ffi_gen_ignore)]
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub async fn propose_server_remove(
+        &mut self,
+        index: u32,
+        authenticated_data: Vec<u8>,
+    ) -> Result<MlsMessage, MlsError> {
+        let leaf_index = LeafIndex(index);
+
+        // Verify that this leaf is actually in the tree
+        self.current_epoch_tree().get_leaf_node(leaf_index)?;
+
+        let proposal = Proposal::ServerRemove(ServerRemoveProposal {
+            to_remove: leaf_index,
+        });
+        self.proposal_message(proposal, authenticated_data).await
+    }
+
     /// Create a proposal message that adds an external pre shared key to the group.
     ///
     /// Each group member will need to have the PSK associated with
@@ -2290,6 +2308,18 @@ where
             .self_removes
             .iter()
             .find(|p| p.sender == Sender::Member(*self.private_tree.self_index))
+            .cloned()
+    }
+
+    fn server_removal_proposal(
+        &self,
+        provisional_state: &ProvisionalState,
+    ) -> Option<ProposalInfo<ServerRemoveProposal>> {
+        provisional_state
+            .applied_proposals
+            .server_removes
+            .iter()
+            .find(|p| p.proposal.to_remove == self.private_tree.self_index)
             .cloned()
     }
 

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -4532,17 +4532,15 @@ mod tests {
 
     #[cfg(feature = "custom_proposal")]
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
-    async fn custom_proposal_setup() -> (TestGroup, TestGroup) {
+    async fn custom_proposal_setup(prop_type: ProposalType) -> (TestGroup, TestGroup) {
         let mut alice = test_group_custom_config(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, |b| {
-            b.custom_proposal_type(TEST_CUSTOM_PROPOSAL_TYPE)
+            b.custom_proposal_type(prop_type)
         })
         .await;
 
         let (bob, _) = alice
             .join_with_custom_config("bob", true, |c| {
-                c.0.settings
-                    .custom_proposal_types
-                    .push(TEST_CUSTOM_PROPOSAL_TYPE)
+                c.0.settings.custom_proposal_types.push(prop_type)
             })
             .await
             .unwrap();
@@ -4550,34 +4548,289 @@ mod tests {
         (alice, bob)
     }
 
-    #[cfg(all(
-        feature = "by_ref_proposal",
-        feature = "custom_proposal",
-        feature = "self_remove_proposal"
-    ))]
-    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
-    async fn self_remove_group_setup() -> (TestGroup, TestGroup) {
-        let mut alice = test_group_custom_config(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, |b| {
-            b.custom_proposal_type(ProposalType::SELF_REMOVE)
-        })
-        .await;
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn server_remove_removes_client() {
+        let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SERVER_REMOVE).await;
 
-        let (bob, _) = alice
-            .join_with_custom_config("bob", true, |c| {
-                c.0.settings
-                    .custom_proposal_types
-                    .push(ProposalType::SELF_REMOVE)
-            })
+        let propose_server_remove_bob = alice.propose_server_remove(1, Vec::new()).await.unwrap();
+        let commit = alice.commit_builder().build().await.unwrap().commit_message;
+
+        bob.process_incoming_message(propose_server_remove_bob)
             .await
             .unwrap();
 
-        (alice, bob)
+        let ReceivedMessage::Commit(CommitMessageDescription {
+            effect: CommitEffect::NewEpoch(new_epoch),
+            ..
+        }) = alice
+            .process_incoming_message(commit.clone())
+            .await
+            .unwrap()
+        else {
+            panic!("unexpected commit effect");
+        };
+
+        assert_eq!(new_epoch.applied_proposals.len(), 1);
+
+        let ReceivedMessage::Commit(CommitMessageDescription {
+            effect: CommitEffect::Removed { .. },
+            ..
+        }) = bob.process_incoming_message(commit).await.unwrap()
+        else {
+            panic!("unexpected commit effect");
+        };
+    }
+
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn commit_with_both_remove_and_server_remove_for_same_client_leaves_server_remove_unused()
+    {
+        let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SERVER_REMOVE).await;
+
+        // Bob proposes server-remove of self.
+        let bob_self_remove = bob.propose_server_remove(1, Vec::new()).await.unwrap();
+
+        // Alice receives the self-remove proposal to be committed.
+        alice
+            .process_incoming_message(bob_self_remove.clone())
+            .await
+            .unwrap();
+
+        // Alice also removes Bob with a regular remove proposal.
+        alice.propose_remove(1, Vec::new()).await.unwrap();
+
+        // Alice commits Bob's self-remove and Alice's removal of Bob. This filters out the remove proposal.
+        let commit = alice.commit(Vec::new()).await.unwrap();
+        let unused = &commit.unused_proposals[0];
+        assert_matches!(
+            unused,
+            ProposalInfo {
+                proposal: Proposal::ServerRemove(ServerRemoveProposal {
+                    to_remove: LeafIndex(1)
+                }),
+                sender: Sender::Member(1),
+                ..
+            }
+        );
+    }
+
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn external_commit_can_have_server_removes_by_reference() {
+        let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SERVER_REMOVE).await;
+
+        let carol_client = TestClientBuilder::new_for_test()
+            .with_random_signing_identity("carol", TEST_CIPHER_SUITE)
+            .await
+            .custom_proposal_type(ProposalType::SERVER_REMOVE)
+            .build();
+
+        // Alice adds Carol.
+        let commit = alice
+            .commit_builder()
+            .add_member(
+                carol_client
+                    .generate_key_package_message(Default::default(), Default::default())
+                    .await
+                    .unwrap(),
+            )
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        let mut carol = carol_client
+            .join_group(None, &commit.welcome_messages[0])
+            .await
+            .unwrap()
+            .0;
+        alice
+            .process_incoming_message(commit.commit_message.clone())
+            .await
+            .unwrap();
+        bob.process_incoming_message(commit.commit_message)
+            .await
+            .unwrap();
+
+        let bob_server_removes_self = bob.propose_server_remove(1, Vec::new()).await.unwrap();
+        let bob_server_removes_alice = bob.propose_server_remove(0, Vec::new()).await.unwrap();
+
+        let group_info = alice
+            .group_info_message_allowing_ext_commit(true)
+            .await
+            .unwrap();
+        alice
+            .process_incoming_message(bob_server_removes_self.clone())
+            .await
+            .unwrap();
+        alice
+            .process_incoming_message(bob_server_removes_alice.clone())
+            .await
+            .unwrap();
+        carol
+            .process_incoming_message(bob_server_removes_self.clone())
+            .await
+            .unwrap();
+        carol
+            .process_incoming_message(bob_server_removes_alice.clone())
+            .await
+            .unwrap();
+
+        let (carol_new_group, commit) = carol_client
+            .external_commit_builder()
+            .unwrap()
+            .with_removal(carol.current_member_index())
+            .with_received_custom_proposal(bob_server_removes_self)
+            .with_received_custom_proposal(bob_server_removes_alice)
+            .build(group_info)
+            .await
+            .unwrap();
+
+        carol
+            .process_incoming_message(commit.clone())
+            .await
+            .unwrap();
+        bob.process_incoming_message(commit.clone()).await.unwrap();
+        alice.process_incoming_message(commit).await.unwrap();
+
+        // Assert that after applying the commit removing Bob, that Bob and Alice are no longer in the group.
+        let carol_identity = carol_new_group.current_member_signing_identity().unwrap();
+        let expected_member_identities = vec![carol_identity.clone()];
+        itertools::assert_equal(
+            carol_new_group
+                .roster()
+                .members_iter()
+                .map(|m| m.signing_identity),
+            expected_member_identities.clone(),
+        );
+    }
+
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn external_commit_can_have_server_removes_by_value() {
+        let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SERVER_REMOVE).await;
+
+        let carol_client = TestClientBuilder::new_for_test()
+            .with_random_signing_identity("carol", TEST_CIPHER_SUITE)
+            .await
+            .custom_proposal_type(ProposalType::SERVER_REMOVE)
+            .build();
+
+        // Alice adds Carol.
+        let commit = alice
+            .commit_builder()
+            .add_member(
+                carol_client
+                    .generate_key_package_message(Default::default(), Default::default())
+                    .await
+                    .unwrap(),
+            )
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        let mut carol = carol_client
+            .join_group(None, &commit.welcome_messages[0])
+            .await
+            .unwrap()
+            .0;
+        alice
+            .process_incoming_message(commit.commit_message.clone())
+            .await
+            .unwrap();
+        bob.process_incoming_message(commit.commit_message)
+            .await
+            .unwrap();
+
+        let group_info = alice
+            .group_info_message_allowing_ext_commit(true)
+            .await
+            .unwrap();
+
+        let (carol_new_group, commit) = carol_client
+            .external_commit_builder()
+            .unwrap()
+            .with_removal(carol.current_member_index())
+            .with_server_removal(1) // bob
+            .with_server_removal(0) // alice
+            .build(group_info)
+            .await
+            .unwrap();
+
+        carol
+            .process_incoming_message(commit.clone())
+            .await
+            .unwrap();
+        bob.process_incoming_message(commit.clone()).await.unwrap();
+        alice.process_incoming_message(commit).await.unwrap();
+
+        // Assert that after applying the commit removing Bob, that Bob and Alice are no longer in the group.
+        let carol_identity = carol_new_group.current_member_signing_identity().unwrap();
+        let expected_member_identities = vec![carol_identity.clone()];
+        itertools::assert_equal(
+            carol_new_group
+                .roster()
+                .members_iter()
+                .map(|m| m.signing_identity),
+            expected_member_identities.clone(),
+        );
+    }
+
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn server_remove_self_with_resync_external_commit_fails() {
+        let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SERVER_REMOVE).await;
+
+        let carol_client = TestClientBuilder::new_for_test()
+            .with_random_signing_identity("carol", TEST_CIPHER_SUITE)
+            .await
+            .custom_proposal_type(ProposalType::SERVER_REMOVE)
+            .build();
+
+        // Alice adds Carol.
+        let commit = alice
+            .commit_builder()
+            .add_member(
+                carol_client
+                    .generate_key_package_message(Default::default(), Default::default())
+                    .await
+                    .unwrap(),
+            )
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        let carol = carol_client
+            .join_group(None, &commit.welcome_messages[0])
+            .await
+            .unwrap()
+            .0;
+        alice
+            .process_incoming_message(commit.commit_message.clone())
+            .await
+            .unwrap();
+        bob.process_incoming_message(commit.commit_message)
+            .await
+            .unwrap();
+
+        let group_info = alice
+            .group_info_message_allowing_ext_commit(true)
+            .await
+            .unwrap();
+
+        let carol_self_remove_with_server_kick = carol_client
+            .external_commit_builder()
+            .unwrap()
+            .with_removal(carol.current_member_index())
+            .with_server_removal(2) // carol
+            .build(group_info)
+            .await;
+
+        assert!(matches!(
+            carol_self_remove_with_server_kick,
+            Err(MlsError::RemovingNonExistingMember)
+        ));
     }
 
     #[cfg(feature = "custom_proposal")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn custom_proposal_by_value() {
-        let (mut alice, mut bob) = custom_proposal_setup().await;
+        let (mut alice, mut bob) = custom_proposal_setup(TEST_CUSTOM_PROPOSAL_TYPE).await;
 
         let custom_proposal = CustomProposal::new(TEST_CUSTOM_PROPOSAL_TYPE, vec![0, 1, 2]);
 
@@ -4608,7 +4861,7 @@ mod tests {
     #[cfg(feature = "custom_proposal")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn custom_proposal_by_reference() {
-        let (mut alice, mut bob) = custom_proposal_setup().await;
+        let (mut alice, mut bob) = custom_proposal_setup(TEST_CUSTOM_PROPOSAL_TYPE).await;
 
         let custom_proposal = CustomProposal::new(TEST_CUSTOM_PROPOSAL_TYPE, vec![0, 1, 2]);
 
@@ -4862,7 +5115,7 @@ mod tests {
     ))]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn client_can_self_remove_and_another_client_can_commit() {
-        let (mut alice, mut bob) = self_remove_group_setup().await;
+        let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SELF_REMOVE).await;
 
         let carol_client = TestClientBuilder::new_for_test()
             .with_random_signing_identity("carol", TEST_CIPHER_SUITE)
@@ -4941,7 +5194,7 @@ mod tests {
     ))]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn commit_with_both_remove_and_self_remove_for_same_client_leaves_remove_unused() {
-        let (mut alice, mut bob) = self_remove_group_setup().await;
+        let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SELF_REMOVE).await;
 
         // Bob proposes self-remove.
         let bob_self_remove = bob.propose_self_remove(Vec::new()).await.unwrap();
@@ -4977,7 +5230,7 @@ mod tests {
     ))]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn client_processing_commit_with_self_remove_without_processing_proposal_first_errors() {
-        let (mut alice, mut bob) = self_remove_group_setup().await;
+        let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SELF_REMOVE).await;
 
         let carol_client = TestClientBuilder::new_for_test()
             .with_random_signing_identity("carol", TEST_CIPHER_SUITE)
@@ -5040,7 +5293,7 @@ mod tests {
     ))]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn external_commit_can_have_self_remove() {
-        let (mut alice, mut bob) = self_remove_group_setup().await;
+        let (mut alice, mut bob) = custom_proposal_type(ProposalType::SELF_REMOVE).await;
 
         let carol_client = TestClientBuilder::new_for_test()
             .with_random_signing_identity("carol", TEST_CIPHER_SUITE)
@@ -5141,7 +5394,7 @@ mod tests {
     ))]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn external_commit_can_have_multiple_self_removes() {
-        let (mut alice, mut bob) = self_remove_group_setup().await;
+        let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SELF_REMOVE).await;
 
         let carol_client = TestClientBuilder::new_for_test()
             .with_random_signing_identity("carol", TEST_CIPHER_SUITE)

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1078,6 +1078,7 @@ where
         self.proposal_message(proposal, authenticated_data).await
     }
 
+    #[cfg(feature = "server_remove_proposal")]
     #[cfg_attr(feature = "ffi", safer_ffi_gen::safer_ffi_gen_ignore)]
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn propose_server_remove(
@@ -2311,6 +2312,8 @@ where
             .cloned()
     }
 
+    #[cfg(feature = "server_remove_proposal")]
+    #[cfg_attr(feature = "ffi", safer_ffi_gen::safer_ffi_gen_ignore)]
     fn server_removal_proposal(
         &self,
         provisional_state: &ProvisionalState,
@@ -4548,6 +4551,7 @@ mod tests {
         (alice, bob)
     }
 
+    #[cfg(feature = "server_remove_proposal")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn server_remove_removes_client() {
         let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SERVER_REMOVE).await;
@@ -4581,6 +4585,7 @@ mod tests {
         };
     }
 
+    #[cfg(feature = "server_remove_proposal")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn commit_with_both_remove_and_server_remove_for_same_client_leaves_server_remove_unused()
     {
@@ -4613,6 +4618,11 @@ mod tests {
         );
     }
 
+    #[cfg(all(
+        feature = "by_ref_proposal",
+        feature = "custom_proposal",
+        feature = "server_remove_proposal"
+    ))]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn external_commit_can_have_server_removes_by_reference() {
         let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SERVER_REMOVE).await;
@@ -4702,6 +4712,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "server_remove_proposal")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn external_commit_can_have_server_removes_by_value() {
         let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SERVER_REMOVE).await;
@@ -4772,6 +4783,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "server_remove_proposal")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn server_remove_self_with_resync_external_commit_fails() {
         let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SERVER_REMOVE).await;
@@ -5293,7 +5305,7 @@ mod tests {
     ))]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn external_commit_can_have_self_remove() {
-        let (mut alice, mut bob) = custom_proposal_type(ProposalType::SELF_REMOVE).await;
+        let (mut alice, mut bob) = custom_proposal_setup(ProposalType::SELF_REMOVE).await;
 
         let carol_client = TestClientBuilder::new_for_test()
             .with_random_signing_identity("carol", TEST_CIPHER_SUITE)

--- a/mls-rs/src/group/proposal.rs
+++ b/mls-rs/src/group/proposal.rs
@@ -247,12 +247,14 @@ pub struct SelfRemoveProposal {}
 #[derive(Clone, PartialEq, Eq, MlsSize, MlsEncode, MlsDecode, Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg(feature = "server_remove_proposal")]
 /// A proposal that the server remove an existing [`Member`](mls_rs_core::group::Member) of a
 /// [`Group`](crate::group::Group).
 pub struct ServerRemoveProposal {
     pub(crate) to_remove: LeafIndex,
 }
 
+#[cfg(feature = "server_remove_proposal")]
 impl ServerRemoveProposal {
     /// The index of the [`Member`](mls_rs_core::group::Member) that will be removed by
     /// this proposal.
@@ -261,6 +263,7 @@ impl ServerRemoveProposal {
     }
 }
 
+#[cfg(feature = "server_remove_proposal")]
 impl From<u32> for ServerRemoveProposal {
     fn from(value: u32) -> Self {
         ServerRemoveProposal {
@@ -375,6 +378,7 @@ pub enum Proposal {
         feature = "self_remove_proposal"
     ))]
     SelfRemove(SelfRemoveProposal),
+    #[cfg(feature = "server_remove_proposal")]
     ServerRemove(ServerRemoveProposal),
     #[cfg(feature = "custom_proposal")]
     Custom(CustomProposal),
@@ -398,6 +402,7 @@ impl MlsSize for Proposal {
                 feature = "self_remove_proposal"
             ))]
             Proposal::SelfRemove(p) => p.mls_encoded_len(),
+            #[cfg(feature = "server_remove_proposal")]
             Proposal::ServerRemove(p) => p.mls_encoded_len(),
             #[cfg(feature = "custom_proposal")]
             Proposal::Custom(p) => mls_rs_codec::byte_vec::mls_encoded_len(&p.data),
@@ -427,6 +432,7 @@ impl MlsEncode for Proposal {
                 feature = "self_remove_proposal"
             ))]
             Proposal::SelfRemove(p) => p.mls_encode(writer),
+            #[cfg(feature = "server_remove_proposal")]
             Proposal::ServerRemove(p) => p.mls_encode(writer),
             #[cfg(feature = "custom_proposal")]
             Proposal::Custom(p) => {
@@ -473,6 +479,7 @@ impl MlsDecode for Proposal {
             ProposalType::SELF_REMOVE => {
                 Proposal::SelfRemove(SelfRemoveProposal::mls_decode(reader)?)
             }
+            #[cfg(feature = "server_remove_proposal")]
             ProposalType::SERVER_REMOVE => {
                 Proposal::ServerRemove(ServerRemoveProposal::mls_decode(reader)?)
             }
@@ -506,6 +513,7 @@ impl Proposal {
                 feature = "self_remove_proposal"
             ))]
             Proposal::SelfRemove(_) => ProposalType::SELF_REMOVE,
+            #[cfg(feature = "server_remove_proposal")]
             Proposal::ServerRemove(_) => ProposalType::SERVER_REMOVE,
             #[cfg(feature = "custom_proposal")]
             Proposal::Custom(c) => c.proposal_type,
@@ -531,6 +539,7 @@ pub enum BorrowedProposal<'a> {
         feature = "self_remove_proposal"
     ))]
     SelfRemove(&'a SelfRemoveProposal),
+    #[cfg(feature = "server_remove_proposal")]
     ServerRemove(&'a ServerRemoveProposal),
     #[cfg(feature = "custom_proposal")]
     Custom(&'a CustomProposal),
@@ -556,6 +565,7 @@ impl<'a> From<BorrowedProposal<'a>> for Proposal {
                 feature = "self_remove_proposal"
             ))]
             BorrowedProposal::SelfRemove(self_remove) => Proposal::SelfRemove(self_remove.clone()),
+            #[cfg(feature = "server_remove_proposal")]
             BorrowedProposal::ServerRemove(server_remove) => {
                 Proposal::ServerRemove(server_remove.clone())
             }
@@ -583,6 +593,7 @@ impl BorrowedProposal<'_> {
                 feature = "self_remove_proposal"
             ))]
             BorrowedProposal::SelfRemove(_) => ProposalType::SELF_REMOVE,
+            #[cfg(feature = "server_remove_proposal")]
             BorrowedProposal::ServerRemove(_) => ProposalType::SERVER_REMOVE,
             #[cfg(feature = "custom_proposal")]
             BorrowedProposal::Custom(c) => c.proposal_type,
@@ -608,6 +619,7 @@ impl<'a> From<&'a Proposal> for BorrowedProposal<'a> {
                 feature = "self_remove_proposal"
             ))]
             Proposal::SelfRemove(p) => BorrowedProposal::SelfRemove(p),
+            #[cfg(feature = "server_remove_proposal")]
             Proposal::ServerRemove(p) => BorrowedProposal::ServerRemove(p),
             #[cfg(feature = "custom_proposal")]
             Proposal::Custom(p) => BorrowedProposal::Custom(p),
@@ -670,6 +682,7 @@ impl<'a> From<&'a SelfRemoveProposal> for BorrowedProposal<'a> {
     }
 }
 
+#[cfg(feature = "server_remove_proposal")]
 impl<'a> From<&'a ServerRemoveProposal> for BorrowedProposal<'a> {
     fn from(p: &'a ServerRemoveProposal) -> Self {
         Self::ServerRemove(p)

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -23,6 +23,7 @@ use crate::{
     feature = "self_remove_proposal"
 ))]
 use crate::group::SelfRemoveProposal;
+use crate::group::ServerRemoveProposal;
 
 #[cfg(feature = "by_ref_proposal")]
 use crate::group::{proposal_cache::CachedProposal, LeafIndex, ProposalRef, UpdateProposal};
@@ -58,6 +59,7 @@ pub struct ProposalBundle {
         feature = "self_remove_proposal"
     ))]
     pub(crate) self_removes: Vec<ProposalInfo<SelfRemoveProposal>>,
+    pub(crate) server_removes: Vec<ProposalInfo<ServerRemoveProposal>>,
     #[cfg(feature = "custom_proposal")]
     pub(crate) custom_proposals: Vec<ProposalInfo<CustomProposal>>,
 }
@@ -110,6 +112,11 @@ impl ProposalBundle {
                 feature = "self_remove_proposal"
             ))]
             Proposal::SelfRemove(proposal) => self.self_removes.push(ProposalInfo {
+                proposal,
+                sender,
+                source,
+            }),
+            Proposal::ServerRemove(proposal) => self.server_removes.push(ProposalInfo {
                 proposal,
                 sender,
                 source,
@@ -240,6 +247,8 @@ impl ProposalBundle {
         #[cfg(feature = "by_ref_proposal")]
         let len = len + self.updates.len();
 
+        let len = len + self.server_removes.len();
+
         len + self.additions.len()
             + self.removals.len()
             + self.reinitializations.len()
@@ -271,6 +280,12 @@ impl ProposalBundle {
             self.self_removes
                 .iter()
                 .map(|p| p.as_ref().map(BorrowedProposal::SelfRemove)),
+        );
+
+        let res = res.chain(
+            self.server_removes
+                .iter()
+                .map(|p| p.as_ref().map(BorrowedProposal::ServerRemove)),
         );
 
         #[cfg(feature = "by_ref_proposal")]
@@ -346,6 +361,12 @@ impl ProposalBundle {
             self.self_removes
                 .into_iter()
                 .map(|p| p.map(Proposal::SelfRemove)),
+        );
+
+        let res = res.chain(
+            self.server_removes
+                .into_iter()
+                .map(|p| p.map(Proposal::ServerRemove)),
         );
 
         res.chain(
@@ -427,6 +448,10 @@ impl ProposalBundle {
     #[cfg_attr(feature = "ffi", safer_ffi_gen::safer_ffi_gen_ignore)]
     pub fn self_remove_proposals(&self) -> &[ProposalInfo<SelfRemoveProposal>] {
         &self.self_removes
+    }
+
+    pub fn server_remove_proposals(&self) -> &[ProposalInfo<ServerRemoveProposal>] {
+        &self.server_removes
     }
 
     /// Custom proposals in the bundle.
@@ -726,6 +751,7 @@ impl_proposable!(ExternalInit, EXTERNAL_INIT, external_initializations);
     feature = "self_remove_proposal"
 ))]
 impl_proposable!(SelfRemoveProposal, SELF_REMOVE, self_removes);
+impl_proposable!(ServerRemoveProposal, SERVER_REMOVE, server_removes);
 impl_proposable!(
     ExtensionList,
     GROUP_CONTEXT_EXTENSIONS,

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -23,6 +23,7 @@ use crate::{
     feature = "self_remove_proposal"
 ))]
 use crate::group::SelfRemoveProposal;
+#[cfg(feature = "server_remove_proposal")]
 use crate::group::ServerRemoveProposal;
 
 #[cfg(feature = "by_ref_proposal")]
@@ -59,6 +60,7 @@ pub struct ProposalBundle {
         feature = "self_remove_proposal"
     ))]
     pub(crate) self_removes: Vec<ProposalInfo<SelfRemoveProposal>>,
+    #[cfg(feature = "server_remove_proposal")]
     pub(crate) server_removes: Vec<ProposalInfo<ServerRemoveProposal>>,
     #[cfg(feature = "custom_proposal")]
     pub(crate) custom_proposals: Vec<ProposalInfo<CustomProposal>>,
@@ -116,6 +118,7 @@ impl ProposalBundle {
                 sender,
                 source,
             }),
+            #[cfg(feature = "server_remove_proposal")]
             Proposal::ServerRemove(proposal) => self.server_removes.push(ProposalInfo {
                 proposal,
                 sender,
@@ -247,6 +250,7 @@ impl ProposalBundle {
         #[cfg(feature = "by_ref_proposal")]
         let len = len + self.updates.len();
 
+        #[cfg(feature = "server_remove_proposal")]
         let len = len + self.server_removes.len();
 
         len + self.additions.len()
@@ -282,6 +286,7 @@ impl ProposalBundle {
                 .map(|p| p.as_ref().map(BorrowedProposal::SelfRemove)),
         );
 
+        #[cfg(feature = "server_remove_proposal")]
         let res = res.chain(
             self.server_removes
                 .iter()
@@ -363,6 +368,7 @@ impl ProposalBundle {
                 .map(|p| p.map(Proposal::SelfRemove)),
         );
 
+        #[cfg(feature = "server_remove_proposal")]
         let res = res.chain(
             self.server_removes
                 .into_iter()
@@ -450,6 +456,8 @@ impl ProposalBundle {
         &self.self_removes
     }
 
+    #[cfg(feature = "server_remove_proposal")]
+    #[cfg_attr(feature = "ffi", safer_ffi_gen::safer_ffi_gen_ignore)]
     pub fn server_remove_proposals(&self) -> &[ProposalInfo<ServerRemoveProposal>] {
         &self.server_removes
     }
@@ -751,6 +759,7 @@ impl_proposable!(ExternalInit, EXTERNAL_INIT, external_initializations);
     feature = "self_remove_proposal"
 ))]
 impl_proposable!(SelfRemoveProposal, SELF_REMOVE, self_removes);
+#[cfg(feature = "server_remove_proposal")]
 impl_proposable!(ServerRemoveProposal, SERVER_REMOVE, server_removes);
 impl_proposable!(
     ExtensionList,

--- a/mls-rs/src/group/proposal_filter/filtering.rs
+++ b/mls-rs/src/group/proposal_filter/filtering.rs
@@ -35,6 +35,7 @@ use crate::extension::ExternalSendersExt;
     feature = "self_remove_proposal"
 ))]
 use crate::group::SelfRemoveProposal;
+#[cfg(feature = "server_remove_proposal")]
 use crate::group::ServerRemoveProposal;
 
 use alloc::vec::Vec;
@@ -121,6 +122,7 @@ where
         ))]
         let proposals = filter_out_remove_if_self_remove_same_leaf(strategy, proposals)?;
 
+        #[cfg(feature = "server_remove_proposal")]
         let proposals = filter_out_server_remove_if_remove_same_leaf(strategy, proposals)?;
 
         self.apply_proposal_changes(strategy, proposals, commit_time)
@@ -346,6 +348,7 @@ fn filter_out_remove_if_self_remove_same_leaf(
         )
     })?;
 
+    #[cfg(feature = "server_remove_proposal")]
     proposals.retain_by_type::<ServerRemoveProposal, _, _>(|p| {
         apply_strategy(
             strategy,
@@ -358,6 +361,7 @@ fn filter_out_remove_if_self_remove_same_leaf(
     Ok(proposals)
 }
 
+#[cfg(feature = "server_remove_proposal")]
 fn filter_out_server_remove_if_remove_same_leaf(
     strategy: FilterStrategy,
     mut proposals: ProposalBundle,
@@ -427,6 +431,7 @@ fn filter_out_removal_of_committer(
             .ok_or(MlsError::CommitterSelfRemoval),
         )
     })?;
+    #[cfg(feature = "server_remove_proposal")]
     proposals.retain_by_type::<ServerRemoveProposal, _, _>(|p| {
         apply_strategy(
             strategy,
@@ -572,6 +577,7 @@ pub(crate) fn proposer_can_propose(
                     | ProposalType::RE_INIT
                     | ProposalType::GROUP_CONTEXT_EXTENSIONS
             );
+            #[cfg(feature = "server_remove_proposal")]
             let can_propose = can_propose || matches!(proposal_type, ProposalType::SERVER_REMOVE);
             can_propose
         }
@@ -590,6 +596,7 @@ pub(crate) fn proposer_can_propose(
                 feature = "self_remove_proposal"
             ))]
             let can_propose = can_propose || matches!(proposal_type, ProposalType::SELF_REMOVE);
+            #[cfg(feature = "server_remove_proposal")]
             let can_propose = can_propose || matches!(proposal_type, ProposalType::SERVER_REMOVE);
             can_propose
         }
@@ -609,6 +616,7 @@ pub(crate) fn proposer_can_propose(
                 feature = "self_remove_proposal"
             ))]
             let can_propose = can_propose || matches!(proposal_type, ProposalType::SELF_REMOVE);
+            #[cfg(feature = "server_remove_proposal")]
             let can_propose = can_propose || matches!(proposal_type, ProposalType::SERVER_REMOVE);
             can_propose
         }
@@ -624,6 +632,7 @@ pub(crate) fn proposer_can_propose(
                     | ProposalType::PSK
                     | ProposalType::GROUP_CONTEXT_EXTENSIONS
             );
+            #[cfg(feature = "server_remove_proposal")]
             let can_propose = can_propose || matches!(proposal_type, ProposalType::SERVER_REMOVE);
             can_propose
         }
@@ -632,6 +641,7 @@ pub(crate) fn proposer_can_propose(
                 proposal_type,
                 ProposalType::REMOVE | ProposalType::PSK | ProposalType::EXTERNAL_INIT
             );
+            #[cfg(feature = "server_remove_proposal")]
             let can_propose = can_propose || matches!(proposal_type, ProposalType::SERVER_REMOVE);
             can_propose
         }
@@ -693,6 +703,7 @@ pub(crate) fn filter_out_invalid_proposers(
         }
     }
 
+    #[cfg(feature = "server_remove_proposal")]
     for i in (0..proposals.server_remove_proposals().len()).rev() {
         let p = &proposals.server_remove_proposals()[i];
         let res = proposer_can_propose(p.sender, ProposalType::SERVER_REMOVE, &p.source);

--- a/mls-rs/src/group/proposal_filter/filtering_common.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_common.rs
@@ -508,6 +508,7 @@ fn ensure_proposals_in_external_commit_are_allowed(
             feature = "self_remove_proposal"
         ))]
         ProposalType::SELF_REMOVE,
+        ProposalType::SERVER_REMOVE,
     ];
 
     let unsupported_proposal = proposals.iter_proposals().find(|proposal| {

--- a/mls-rs/src/group/proposal_filter/filtering_common.rs
+++ b/mls-rs/src/group/proposal_filter/filtering_common.rs
@@ -508,6 +508,7 @@ fn ensure_proposals_in_external_commit_are_allowed(
             feature = "self_remove_proposal"
         ))]
         ProposalType::SELF_REMOVE,
+        #[cfg(feature = "server_remove_proposal")]
         ProposalType::SERVER_REMOVE,
     ];
 

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -491,6 +491,8 @@ impl MessageProcessor for GroupWithoutKeySchedule {
         self.inner.self_removal_proposal(provisional_state)
     }
 
+    #[cfg(feature = "server_remove_proposal")]
+    #[cfg_attr(feature = "ffi", safer_ffi_gen::safer_ffi_gen_ignore)]
     fn server_removal_proposal(
         &self,
         provisional_state: &ProvisionalState,

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -491,6 +491,13 @@ impl MessageProcessor for GroupWithoutKeySchedule {
         self.inner.self_removal_proposal(provisional_state)
     }
 
+    fn server_removal_proposal(
+        &self,
+        provisional_state: &ProvisionalState,
+    ) -> Option<ProposalInfo<ServerRemoveProposal>> {
+        self.inner.server_removal_proposal(provisional_state)
+    }
+
     #[cfg(feature = "private_message")]
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn min_epoch_available(&self) -> Option<u64> {

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -32,6 +32,7 @@ use crate::group::proposal::{AddProposal, UpdateProposal};
     feature = "self_remove_proposal"
 ))]
 use crate::group::proposal::SelfRemoveProposal;
+#[cfg(feature = "server_remove_proposal")]
 use crate::group::proposal::ServerRemoveProposal;
 
 #[cfg(any(test, feature = "by_ref_proposal"))]
@@ -424,7 +425,10 @@ impl TreeKemPublic {
             )
             .await?;
         }
+
+        #[cfg(feature = "server_remove_proposal")]
         let mut server_removed = vec![];
+        #[cfg(feature = "server_remove_proposal")]
         for i in (0..proposal_bundle.server_remove_proposals().len()).rev() {
             let index = proposal_bundle.server_remove_proposals()[i]
                 .proposal
@@ -580,6 +584,7 @@ impl TreeKemPublic {
             .chain(updated_indices)
             .chain(added.iter().copied());
 
+        #[cfg(feature = "server_remove_proposal")]
         let chained = chained.chain(server_removed);
 
         let updated_leaves = chained.collect_vec();
@@ -640,6 +645,7 @@ impl TreeKemPublic {
                 .await?;
         }
 
+        #[cfg(feature = "server_remove_proposal")]
         for p in &proposal_bundle.server_removes {
             let index = p.proposal.to_remove;
 
@@ -667,6 +673,7 @@ impl TreeKemPublic {
             .map(|p| p.proposal.to_remove)
             .chain(added.iter().copied());
 
+        #[cfg(feature = "server_remove_proposal")]
         let chained = chained.chain(
             proposal_bundle
                 .server_remove_proposals()

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -32,6 +32,7 @@ use crate::group::proposal::{AddProposal, UpdateProposal};
     feature = "self_remove_proposal"
 ))]
 use crate::group::proposal::SelfRemoveProposal;
+use crate::group::proposal::ServerRemoveProposal;
 
 #[cfg(any(test, feature = "by_ref_proposal"))]
 use crate::group::{proposal::RemoveProposal, proposal_filter::bundle::Proposable};
@@ -423,6 +424,23 @@ impl TreeKemPublic {
             )
             .await?;
         }
+        let mut server_removed = vec![];
+        for i in (0..proposal_bundle.server_remove_proposals().len()).rev() {
+            let index = proposal_bundle.server_remove_proposals()[i]
+                .proposal
+                .to_remove;
+            server_removed.push(index);
+            self.apply_remove::<ServerRemoveProposal, I>(
+                index,
+                i,
+                proposal_bundle.server_remove_proposals()[i].is_by_value(),
+                proposal_bundle,
+                extensions,
+                id_provider,
+                filter,
+            )
+            .await?;
+        }
 
         // Remove from the tree old leaves from updates
         let mut partial_updates = vec![];
@@ -555,18 +573,50 @@ impl TreeKemPublic {
 
         self.nodes.trim();
 
-        let updated_leaves = proposal_bundle
+        let chained = proposal_bundle
             .remove_proposals()
             .iter()
             .map(|p| p.proposal.to_remove)
             .chain(updated_indices)
-            .chain(added.iter().copied())
-            .collect_vec();
+            .chain(added.iter().copied());
+
+        let chained = chained.chain(server_removed);
+
+        let updated_leaves = chained.collect_vec();
 
         self.update_hashes(&updated_leaves, cipher_suite_provider)
             .await?;
 
         Ok(added)
+    }
+
+    #[cfg(not(feature = "by_ref_proposal"))]
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    async fn apply_remove_lite<I>(
+        &mut self,
+        index: LeafIndex,
+        extensions: &ExtensionList,
+        id_provider: &I,
+    ) -> Result<(), MlsError>
+    where
+        I: IdentityProvider,
+    {
+        #[cfg(feature = "tree_index")]
+        {
+            // If this fails, it's not because the proposal is bad.
+            let old_leaf = self.nodes.blank_leaf_node(index)?;
+
+            let identity = identity(&old_leaf.signing_identity, id_provider, extensions).await?;
+
+            self.index.remove(&old_leaf, &identity);
+        }
+
+        #[cfg(not(feature = "tree_index"))]
+        self.nodes.blank_leaf_node(index)?;
+
+        self.nodes.blank_direct_path(index)?;
+
+        Ok(())
     }
 
     #[cfg(not(feature = "by_ref_proposal"))]
@@ -586,21 +636,15 @@ impl TreeKemPublic {
         for p in &proposal_bundle.removals {
             let index = p.proposal.to_remove;
 
-            #[cfg(feature = "tree_index")]
-            {
-                // If this fails, it's not because the proposal is bad.
-                let old_leaf = self.nodes.blank_leaf_node(index)?;
+            self.apply_remove_lite(index, extensions, id_provider)
+                .await?;
+        }
 
-                let identity =
-                    identity(&old_leaf.signing_identity, id_provider, extensions).await?;
+        for p in &proposal_bundle.server_removes {
+            let index = p.proposal.to_remove;
 
-                self.index.remove(&old_leaf, &identity);
-            }
-
-            #[cfg(not(feature = "tree_index"))]
-            self.nodes.blank_leaf_node(index)?;
-
-            self.nodes.blank_direct_path(index)?;
+            self.apply_remove_lite(index, extensions, id_provider)
+                .await?;
         }
 
         // Apply adds
@@ -617,12 +661,20 @@ impl TreeKemPublic {
 
         self.nodes.trim();
 
-        let updated_leaves = proposal_bundle
+        let chained = proposal_bundle
             .remove_proposals()
             .iter()
             .map(|p| p.proposal.to_remove)
-            .chain(added.iter().copied())
-            .collect_vec();
+            .chain(added.iter().copied());
+
+        let chained = chained.chain(
+            proposal_bundle
+                .server_remove_proposals()
+                .iter()
+                .map(|p| p.proposal.to_remove),
+        );
+
+        let updated_leaves = chained.collect_vec();
 
         self.update_hashes(&updated_leaves, cipher_suite_provider)
             .await?;


### PR DESCRIPTION
Implementation of the server_remove proposal, corresponding to section 7.11.9 of the [GSMA RCS spec](https://www.gsma.com/solutions-and-impact/technologies/networks/wp-content/uploads/2025/03/RCC.16-v1.0.pdf). 

This proposal represents removal prompted by the server. A group member must still both propose and commit it (since the server is not a group member), but it signals that the removal was requested by the server. 

The server_remove is a proposal that has the following properties: 
* Extension Value: 0xF004
* Extension Name: server_remove
* External: Yes
* Path Required: Yes

It effectively has all of the same properties and behaves identically to the existing `Remove` proposal, except that multiple of them can be committed externally.