### PR TITLE
Adding custom time through commit builder and various explicit inputs

### DIFF
--- a/mls-rs-uniffi/src/lib.rs
+++ b/mls-rs-uniffi/src/lib.rs
@@ -384,7 +384,7 @@ impl Client {
     pub async fn generate_key_package_message(&self) -> Result<Message, Error> {
         let message = self
             .inner
-            .generate_key_package_message(Default::default(), Default::default())
+            .generate_key_package_message(Default::default(), Default::default(), None)
             .await?;
         Ok(message.into())
     }
@@ -406,12 +406,12 @@ impl Client {
         let inner = match group_id {
             Some(group_id) => {
                 self.inner
-                    .create_group_with_id(group_id, extensions, Default::default())
+                    .create_group_with_id(group_id, extensions, Default::default(), None)
                     .await?
             }
             None => {
                 self.inner
-                    .create_group(extensions, Default::default())
+                    .create_group(extensions, Default::default(), None)
                     .await?
             }
         };

--- a/mls-rs/examples/basic_usage.rs
+++ b/mls-rs/examples/basic_usage.rs
@@ -44,11 +44,11 @@ fn main() -> Result<(), MlsError> {
     let bob = make_client(crypto_provider.clone(), "bob")?;
 
     // Alice creates a new group.
-    let mut alice_group = alice.create_group(ExtensionList::default(), Default::default())?;
+    let mut alice_group = alice.create_group(ExtensionList::default(), Default::default(), None)?;
 
     // Bob generates a key package that Alice needs to add Bob to the group.
     let bob_key_package =
-        bob.generate_key_package_message(Default::default(), Default::default())?;
+        bob.generate_key_package_message(Default::default(), Default::default(), None)?;
 
     // Alice issues a commit that adds Bob to the group.
     let alice_commit = alice_group

--- a/mls-rs/examples/custom.rs
+++ b/mls-rs/examples/custom.rs
@@ -377,12 +377,15 @@ fn main() -> Result<(), CustomError> {
     context_extensions.set_from(RosterExtension { roster })?;
 
     let mut alice_tablet_group =
-        make_client(alice_tablet)?.create_group(context_extensions, Default::default())?;
+        make_client(alice_tablet)?.create_group(context_extensions, Default::default(), None)?;
 
     // Alice can add her other device
     let alice_pc_client = make_client(alice_pc)?;
-    let key_package =
-        alice_pc_client.generate_key_package_message(Default::default(), Default::default())?;
+    let key_package = alice_pc_client.generate_key_package_message(
+        Default::default(),
+        Default::default(),
+        None,
+    )?;
 
     let welcome = alice_tablet_group
         .commit_builder()
@@ -396,8 +399,11 @@ fn main() -> Result<(), CustomError> {
 
     // Alice cannot add bob's devices yet
     let bob_tablet_client = make_client(bob_tablet)?;
-    let key_package =
-        bob_tablet_client.generate_key_package_message(Default::default(), Default::default())?;
+    let key_package = bob_tablet_client.generate_key_package_message(
+        Default::default(),
+        Default::default(),
+        None,
+    )?;
 
     let res = alice_tablet_group
         .commit_builder()

--- a/mls-rs/examples/large_group.rs
+++ b/mls-rs/examples/large_group.rs
@@ -58,7 +58,7 @@ fn make_groups_best_case<P: CryptoProvider + Clone>(
 ) -> Result<Vec<Group<impl MlsConfig>>, MlsError> {
     let bob_client = make_client(crypto_provider.clone(), &make_name(0))?;
 
-    let bob_group = bob_client.create_group(Default::default(), Default::default())?;
+    let bob_group = bob_client.create_group(Default::default(), Default::default(), None)?;
 
     let mut groups = vec![bob_group];
 
@@ -66,8 +66,11 @@ fn make_groups_best_case<P: CryptoProvider + Clone>(
         let bob_client = make_client(crypto_provider.clone(), &make_name(i + 1))?;
 
         // The new client generates a key package.
-        let bob_kpkg =
-            bob_client.generate_key_package_message(Default::default(), Default::default())?;
+        let bob_kpkg = bob_client.generate_key_package_message(
+            Default::default(),
+            Default::default(),
+            None,
+        )?;
 
         // Last group sends a commit adding the new client to the group.
         let commit = groups
@@ -101,7 +104,8 @@ fn make_groups_worst_case<P: CryptoProvider + Clone>(
 ) -> Result<Vec<Group<impl MlsConfig>>, MlsError> {
     let alice_client = make_client(crypto_provider.clone(), &make_name(0))?;
 
-    let mut alice_group = alice_client.create_group(Default::default(), Default::default())?;
+    let mut alice_group =
+        alice_client.create_group(Default::default(), Default::default(), None)?;
 
     let bob_clients = (0..(num_groups - 1))
         .map(|i| make_client(crypto_provider.clone(), &make_name(i + 1)))
@@ -111,8 +115,11 @@ fn make_groups_worst_case<P: CryptoProvider + Clone>(
     let mut commit_builder = alice_group.commit_builder();
 
     for bob_client in &bob_clients {
-        let bob_kpkg =
-            bob_client.generate_key_package_message(Default::default(), Default::default())?;
+        let bob_kpkg = bob_client.generate_key_package_message(
+            Default::default(),
+            Default::default(),
+            None,
+        )?;
         commit_builder = commit_builder.add_member(bob_kpkg)?;
     }
 

--- a/mls-rs/examples/x509.rs
+++ b/mls-rs/examples/x509.rs
@@ -32,7 +32,7 @@ fn main() {
         .build();
 
     let mut alice_group = alice_client
-        .create_group(Default::default(), Default::default())
+        .create_group(Default::default(), Default::default(), None)
         .unwrap();
 
     alice_group.commit(Vec::new()).unwrap();

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -20,6 +20,7 @@ use crate::group::{
 use crate::identity::SigningIdentity;
 use crate::key_package::{KeyPackageGeneration, KeyPackageGenerator};
 use crate::protocol_version::ProtocolVersion;
+use crate::time::MlsTime;
 use crate::tree_kem::node::NodeIndex;
 use alloc::vec::Vec;
 use mls_rs_codec::MlsDecode;
@@ -410,12 +411,13 @@ where
     }
 
     #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
-    pub fn to_builder(&self) -> ClientBuilder<MakeConfig<C>> {
+    pub fn to_builder(&self, maybe_now_time: Option<MlsTime>) -> ClientBuilder<MakeConfig<C>> {
         ClientBuilder::from_config(recreate_config(
             self.config.clone(),
             self.signer.clone(),
             self.signing_identity.clone(),
             self.version,
+            maybe_now_time,
         ))
     }
 
@@ -433,13 +435,15 @@ where
     ///
     /// A key package message may only be used once.
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
     pub async fn generate_key_package_message(
         &self,
         key_package_extensions: ExtensionList,
         leaf_node_extensions: ExtensionList,
+        maybe_now_time: Option<MlsTime>,
     ) -> Result<MlsMessage, MlsError> {
         Ok(self
-            .generate_key_package(key_package_extensions, leaf_node_extensions)
+            .generate_key_package(key_package_extensions, leaf_node_extensions, maybe_now_time)
             .await?
             .key_package_message())
     }
@@ -449,6 +453,7 @@ where
         &self,
         key_package_extensions: ExtensionList,
         leaf_node_extensions: ExtensionList,
+        maybe_now_time: Option<MlsTime>,
     ) -> Result<KeyPackageGeneration, MlsError> {
         let (signing_identity, cipher_suite) = self.signing_identity()?;
 
@@ -467,7 +472,7 @@ where
 
         let key_pkg_gen = key_package_generator
             .generate(
-                self.config.lifetime(),
+                self.config.lifetime(maybe_now_time),
                 self.config.capabilities(),
                 key_package_extensions,
                 leaf_node_extensions,
@@ -497,11 +502,13 @@ where
     /// instead of this function because it guarantees that group_id values
     /// are globally unique.
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
     pub async fn create_group_with_id(
         &self,
         group_id: Vec<u8>,
         group_context_extensions: ExtensionList,
         leaf_node_extensions: ExtensionList,
+        maybe_now_time: Option<MlsTime>,
     ) -> Result<Group<C>, MlsError> {
         let (signing_identity, cipher_suite) = self.signing_identity()?;
 
@@ -514,6 +521,7 @@ where
             group_context_extensions,
             leaf_node_extensions,
             self.signer()?.clone(),
+            maybe_now_time,
         )
         .await
     }
@@ -524,10 +532,12 @@ where
     /// [CipherSuiteProvider](crate::CipherSuiteProvider)
     /// that was used to build the client.
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    #[cfg_attr(all(feature = "ffi", not(test)), safer_ffi_gen::safer_ffi_gen_ignore)]
     pub async fn create_group(
         &self,
         group_context_extensions: ExtensionList,
         leaf_node_extensions: ExtensionList,
+        maybe_now_time: Option<MlsTime>,
     ) -> Result<Group<C>, MlsError> {
         let (signing_identity, cipher_suite) = self.signing_identity()?;
 
@@ -540,6 +550,7 @@ where
             group_context_extensions,
             leaf_node_extensions,
             self.signer()?.clone(),
+            maybe_now_time,
         )
         .await
     }
@@ -724,6 +735,7 @@ where
         authenticated_data: Vec<u8>,
         key_package_extensions: ExtensionList,
         leaf_node_extensions: ExtensionList,
+        maybe_now_time: Option<MlsTime>,
     ) -> Result<MlsMessage, MlsError> {
         let protocol_version = group_info.version;
 
@@ -753,7 +765,7 @@ where
         .await?;
 
         let key_package = self
-            .generate_key_package(key_package_extensions, leaf_node_extensions)
+            .generate_key_package(key_package_extensions, leaf_node_extensions, maybe_now_time)
             .await?
             .key_package;
 
@@ -875,7 +887,7 @@ pub(crate) mod test_utils {
         config(&mut client.config);
 
         let key_package = client
-            .generate_key_package_message(key_package_extensions, leaf_node_extensions)
+            .generate_key_package_message(key_package_extensions, leaf_node_extensions, None)
             .await
             .unwrap();
 
@@ -925,7 +937,7 @@ mod tests {
 
             // TODO: Tests around extensions
             let key_package = client
-                .generate_key_package_message(Default::default(), Default::default())
+                .generate_key_package_message(Default::default(), Default::default(), None)
                 .await
                 .unwrap();
 
@@ -945,7 +957,7 @@ mod tests {
             let capabilities = key_package.leaf_node.ungreased_capabilities();
             assert_eq!(capabilities, client.config.capabilities());
 
-            let client_lifetime = client.config.lifetime();
+            let client_lifetime = client.config.lifetime(None);
             assert_matches!(key_package.leaf_node.leaf_node_source, LeafNodeSource::KeyPackage(lifetime) if (lifetime.not_after - lifetime.not_before) == (client_lifetime.not_after - client_lifetime.not_before));
         }
     }
@@ -968,6 +980,7 @@ mod tests {
                 vec![],
                 Default::default(),
                 Default::default(),
+                None,
             )
             .await
             .unwrap();
@@ -1114,7 +1127,7 @@ mod tests {
             .build();
 
         let msg = alice
-            .generate_key_package_message(Default::default(), Default::default())
+            .generate_key_package_message(Default::default(), Default::default(), None)
             .await
             .unwrap();
         let res = alice.commit_external(msg).await.map(|_| ());
@@ -1159,7 +1172,7 @@ mod tests {
         let alice = TestClientBuilder::new_for_test()
             .extension_type(33.into())
             .build();
-        let bob = alice.to_builder().extension_type(34.into()).build();
+        let bob = alice.to_builder(None).extension_type(34.into()).build();
         assert_eq!(bob.config.supported_extensions(), [33, 34].map(Into::into));
     }
 

--- a/mls-rs/src/client_builder.rs
+++ b/mls-rs/src/client_builder.rs
@@ -683,12 +683,18 @@ where
         self.crypto_provider.clone()
     }
 
-    fn lifetime(&self) -> Lifetime {
+    fn lifetime(&self, maybe_now_time: Option<MlsTime>) -> Lifetime {
         #[cfg(feature = "std")]
         let now_timestamp = MlsTime::now().seconds_since_epoch();
 
         #[cfg(not(feature = "std"))]
         let now_timestamp = 0;
+
+        let now_timestamp = if let Some(now_time) = maybe_now_time {
+            now_time.seconds_since_epoch()
+        } else {
+            now_timestamp
+        };
 
         #[cfg(test)]
         let now_timestamp = self
@@ -782,8 +788,8 @@ impl<T: MlsConfig> ClientConfig for T {
         self.get().crypto_provider()
     }
 
-    fn lifetime(&self) -> Lifetime {
-        self.get().lifetime()
+    fn lifetime(&self, maybe_now_time: Option<MlsTime>) -> Lifetime {
+        self.get().lifetime(maybe_now_time)
     }
 
     fn capabilities(&self) -> Capabilities {
@@ -827,6 +833,7 @@ pub(crate) fn recreate_config<T: ClientConfig>(
     signer: Option<SignatureSecretKey>,
     signing_identity: Option<(SigningIdentity, CipherSuite)>,
     version: ProtocolVersion,
+    maybe_now_time: Option<MlsTime>,
 ) -> MakeConfig<T> {
     Config(ConfigInner {
         settings: Settings {
@@ -834,7 +841,7 @@ pub(crate) fn recreate_config<T: ClientConfig>(
             protocol_versions: c.supported_protocol_versions(),
             custom_proposal_types: c.supported_custom_proposals(),
             lifetime_in_s: {
-                let l = c.lifetime();
+                let l = c.lifetime(maybe_now_time);
                 l.not_after - l.not_before
             },
             #[cfg(any(test, feature = "test_util"))]

--- a/mls-rs/src/client_config.rs
+++ b/mls-rs/src/client_config.rs
@@ -7,6 +7,7 @@ use crate::{
     group::{mls_rules::MlsRules, proposal::ProposalType},
     identity::CredentialType,
     protocol_version::ProtocolVersion,
+    time::MlsTime,
     tree_kem::{leaf_node::ConfigProperties, Capabilities, Lifetime},
     ExtensionList,
 };
@@ -37,7 +38,7 @@ pub trait ClientConfig: Send + Sync + Clone {
     fn identity_provider(&self) -> Self::IdentityProvider;
     fn crypto_provider(&self) -> Self::CryptoProvider;
 
-    fn lifetime(&self) -> Lifetime;
+    fn lifetime(&self, maybe_now_time: Option<MlsTime>) -> Lifetime;
 
     fn capabilities(&self) -> Capabilities {
         Capabilities {

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -17,6 +17,7 @@ use crate::{
     identity::SigningIdentity,
     protocol_version::ProtocolVersion,
     signer::Signable,
+    time::MlsTime,
     tree_kem::{
         kem::TreeKem, node::LeafIndex, path_secret::PathSecret, TreeKemPrivate, UpdatePath,
     },
@@ -186,6 +187,7 @@ where
     new_signer: Option<SignatureSecretKey>,
     new_signing_identity: Option<SigningIdentity>,
     new_leaf_node_extensions: Option<ExtensionList>,
+    commit_time: Option<MlsTime>,
 }
 
 impl<'a, C> CommitBuilder<'a, C>
@@ -342,6 +344,14 @@ where
         }
     }
 
+    /// Add a time to associate with the commit creation.
+    pub fn commit_time(self, commit_time: MlsTime) -> Self {
+        Self {
+            commit_time: Some(commit_time),
+            ..self
+        }
+    }
+
     /// Finalize the commit to send.
     ///
     /// # Errors
@@ -362,6 +372,7 @@ where
                 self.new_signer,
                 self.new_signing_identity,
                 self.new_leaf_node_extensions,
+                self.commit_time,
             )
             .await?;
 
@@ -386,6 +397,7 @@ where
                 self.new_signer,
                 self.new_signing_identity,
                 self.new_leaf_node_extensions,
+                self.commit_time,
             )
             .await?;
 
@@ -476,6 +488,7 @@ where
             new_signer: Default::default(),
             new_signing_identity: Default::default(),
             new_leaf_node_extensions: Default::default(),
+            commit_time: None,
         }
     }
 
@@ -492,6 +505,7 @@ where
         new_signer: Option<SignatureSecretKey>,
         new_signing_identity: Option<SigningIdentity>,
         new_leaf_node_extensions: Option<ExtensionList>,
+        commit_time: Option<MlsTime>,
     ) -> Result<(CommitOutput, PendingCommit), MlsError> {
         if !self.pending_commit.is_none() {
             return Err(MlsError::ExistingPendingCommit);
@@ -522,6 +536,12 @@ where
 
         #[cfg(not(feature = "std"))]
         let time = None;
+
+        let time = if commit_time.is_some() {
+            commit_time
+        } else {
+            time
+        };
 
         #[cfg(feature = "by_ref_proposal")]
         let proposals = self.state.proposals.prepare_commit(sender, proposals);
@@ -1554,13 +1574,13 @@ mod tests {
     async fn member_identity_is_validated_against_new_extensions() {
         let alice = client_with_test_extension(b"alice").await;
         let mut alice = alice
-            .create_group(ExtensionList::new(), Default::default())
+            .create_group(ExtensionList::new(), Default::default(), None)
             .await
             .unwrap();
 
         let bob = client_with_test_extension(b"bob").await;
         let bob_kp = bob
-            .generate_key_package_message(Default::default(), Default::default())
+            .generate_key_package_message(Default::default(), Default::default(), None)
             .await
             .unwrap();
 
@@ -1584,7 +1604,7 @@ mod tests {
         alice
             .commit_builder()
             .add_member(
-                alex.generate_key_package_message(Default::default(), Default::default())
+                alex.generate_key_package_message(Default::default(), Default::default(), None)
                     .await
                     .unwrap(),
             )
@@ -1601,7 +1621,7 @@ mod tests {
     async fn server_identity_is_validated_against_new_extensions() {
         let alice = client_with_test_extension(b"alice").await;
         let mut alice = alice
-            .create_group(ExtensionList::new(), Default::default())
+            .create_group(ExtensionList::new(), Default::default(), None)
             .await
             .unwrap();
 

--- a/mls-rs/src/group/external_commit.rs
+++ b/mls-rs/src/group/external_commit.rs
@@ -15,6 +15,7 @@ use crate::{
         proposal::{ExternalInit, Proposal, RemoveProposal},
         EpochSecrets, ExternalPubExt, LeafIndex, LeafNode, MlsError, TreeKemPrivate,
     },
+    time::MlsTime,
     Group, MlsMessage,
 };
 
@@ -59,6 +60,7 @@ pub struct ExternalCommitBuilder<C: ClientConfig> {
     custom_proposals: Vec<Proposal>,
     #[cfg(feature = "custom_proposal")]
     received_custom_proposals: Vec<MlsMessage>,
+    commit_time: Option<MlsTime>,
 }
 
 impl<C: ClientConfig> ExternalCommitBuilder<C> {
@@ -81,6 +83,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             custom_proposals: Vec::new(),
             #[cfg(feature = "custom_proposal")]
             received_custom_proposals: Vec::new(),
+            commit_time: None,
         }
     }
 
@@ -152,6 +155,14 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
         }
     }
 
+    /// Add a time to associate with the commit creation.
+    pub fn commit_time(self, commit_time: MlsTime) -> Self {
+        Self {
+            commit_time: Some(commit_time),
+            ..self
+        }
+    }
+
     /// Build the external commit using a GroupInfo message provided by an existing group member.
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn build(self, group_info: MlsMessage) -> Result<(Group<C>, MlsMessage), MlsError> {
@@ -189,7 +200,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
             self.config.leaf_properties(self.leaf_node_extensions),
             self.signing_identity,
             &self.signer,
-            self.config.lifetime(),
+            self.config.lifetime(self.commit_time),
         )
         .await?;
 
@@ -274,6 +285,7 @@ impl<C: ClientConfig> ExternalCommitBuilder<C> {
                 None,
                 None,
                 None,
+                self.commit_time,
             )
             .await?;
 

--- a/mls-rs/src/group/interop_test_vectors/framing.rs
+++ b/mls-rs/src/group/interop_test_vectors/framing.rs
@@ -452,7 +452,7 @@ async fn process_message<P: CipherSuiteProvider>(
     // Enabling encryption doesn't matter for processing
     let mut group = make_group(test_case, false, true, cs).await;
     let message = MlsMessage::mls_decode(&mut &*message).unwrap();
-    let evt_or_cont = group.get_event_from_incoming_message(message);
+    let evt_or_cont = group.get_event_from_incoming_message(message, None);
 
     match evt_or_cont.await.unwrap() {
         EventOrContent::Content(content) => content.content.content,

--- a/mls-rs/src/group/interop_test_vectors/passive_client.rs
+++ b/mls-rs/src/group/interop_test_vectors/passive_client.rs
@@ -251,7 +251,7 @@ async fn invite_passive_client<P: CipherSuiteProvider>(
         .build();
 
     let key_pckg = client
-        .generate_key_package_message(Default::default(), Default::default())
+        .generate_key_package_message(Default::default(), Default::default(), None)
         .await
         .unwrap();
 
@@ -493,7 +493,7 @@ async fn create_key_package(cs: CipherSuite) -> MlsMessage {
     .await;
 
     client
-        .generate_key_package_message(Default::default(), Default::default())
+        .generate_key_package_message(Default::default(), Default::default(), None)
         .await
         .unwrap()
 }
@@ -561,7 +561,7 @@ pub async fn generate_passive_client_random_tests() -> Vec<TestCase> {
                 .await;
 
         let creator_group = creator
-            .create_group(Default::default(), Default::default())
+            .create_group(Default::default(), Default::default(), None)
             .await
             .unwrap();
 
@@ -656,7 +656,7 @@ pub async fn add_random_members<C: MlsConfig>(
 
     for client in &clients {
         let key_package = client
-            .generate_key_package_message(Default::default(), Default::default())
+            .generate_key_package_message(Default::default(), Default::default(), None)
             .await
             .unwrap();
         key_packages.push(key_package);

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -300,6 +300,7 @@ where
         group_context_extensions: ExtensionList,
         leaf_node_extensions: ExtensionList,
         signer: SignatureSecretKey,
+        maybe_now_time: Option<MlsTime>,
     ) -> Result<Self, MlsError> {
         let cipher_suite_provider = cipher_suite_provider(config.crypto_provider(), cipher_suite)?;
 
@@ -308,7 +309,7 @@ where
             config.leaf_properties(leaf_node_extensions),
             signing_identity,
             &signer,
-            config.lifetime(),
+            config.lifetime(maybe_now_time),
         )
         .await?;
 
@@ -3221,6 +3222,7 @@ mod tests {
             .create_group(
                 core::iter::once(required_caps.into_extension().unwrap()).collect(),
                 Default::default(),
+                None,
             )
             .await
     }
@@ -3287,7 +3289,11 @@ mod tests {
             test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "alice")
                 .await
                 .0
-                .create_group(core::iter::once(ext_senders).collect(), Default::default())
+                .create_group(
+                    core::iter::once(ext_senders).collect(),
+                    Default::default(),
+                    None,
+                )
                 .await
                 .map(|_| ());
 
@@ -3693,12 +3699,12 @@ mod tests {
             Some((bob_identity, TEST_CIPHER_SUITE)),
             TEST_PROTOCOL_VERSION,
         )
-        .generate_key_package_message(Default::default(), Default::default())
+        .generate_key_package_message(Default::default(), Default::default(), None)
         .await
         .unwrap();
 
         let (mut alice_sub_group, welcome) = alice
-            .branch(b"subgroup".to_vec(), vec![new_key_pkg])
+            .branch(b"subgroup".to_vec(), vec![new_key_pkg], None)
             .await
             .unwrap();
 
@@ -4212,7 +4218,7 @@ mod tests {
             .with_random_signing_identity("alice", TEST_CIPHER_SUITE)
             .await
             .build()
-            .create_group(vec![ext_senders].into(), Default::default())
+            .create_group(vec![ext_senders].into(), Default::default(), None)
             .await
             .unwrap();
 
@@ -4226,7 +4232,7 @@ mod tests {
             .build();
 
         let kp = bob
-            .generate_key_package_message(Default::default(), Default::default())
+            .generate_key_package_message(Default::default(), Default::default(), None)
             .await
             .unwrap();
 
@@ -4277,7 +4283,11 @@ mod tests {
             .with_random_signing_identity("alice", TEST_CIPHER_SUITE)
             .await
             .build()
-            .create_group(core::iter::once(ext_senders).collect(), Default::default())
+            .create_group(
+                core::iter::once(ext_senders).collect(),
+                Default::default(),
+                None,
+            )
             .await
             .unwrap();
 
@@ -4309,7 +4319,7 @@ mod tests {
             .with_random_signing_identity("alice", TEST_CIPHER_SUITE)
             .await
             .build()
-            .create_group(Default::default(), Default::default())
+            .create_group(Default::default(), Default::default(), None)
             .await
             .unwrap();
 
@@ -4697,7 +4707,7 @@ mod tests {
             .await
             .extension_type(EXTENSION_TYPE)
             .build()
-            .create_group(group_extensions.clone(), Default::default())
+            .create_group(group_extensions.clone(), Default::default(), None)
             .await
             .unwrap();
 
@@ -4730,21 +4740,21 @@ mod tests {
             .commit_builder()
             .add_member(
                 bob_client
-                    .generate_key_package_message(Default::default(), Default::default())
+                    .generate_key_package_message(Default::default(), Default::default(), None)
                     .await
                     .unwrap(),
             )
             .unwrap()
             .add_member(
                 carol_client
-                    .generate_key_package_message(Default::default(), Default::default())
+                    .generate_key_package_message(Default::default(), Default::default(), None)
                     .await
                     .unwrap(),
             )
             .unwrap()
             .add_member(
                 dave_client
-                    .generate_key_package_message(Default::default(), Default::default())
+                    .generate_key_package_message(Default::default(), Default::default(), None)
                     .await
                     .unwrap(),
             )
@@ -4852,7 +4862,7 @@ mod tests {
             .await
             .custom_proposal_type(ProposalType::SELF_REMOVE)
             .build()
-            .create_group(ExtensionList::new(), Default::default())
+            .create_group(ExtensionList::new(), Default::default(), None)
             .await
             .unwrap();
 
@@ -4881,7 +4891,7 @@ mod tests {
             .commit_builder()
             .add_member(
                 carol_client
-                    .generate_key_package_message(Default::default(), Default::default())
+                    .generate_key_package_message(Default::default(), Default::default(), None)
                     .await
                     .unwrap(),
             )
@@ -4996,7 +5006,7 @@ mod tests {
             .commit_builder()
             .add_member(
                 carol_client
-                    .generate_key_package_message(Default::default(), Default::default())
+                    .generate_key_package_message(Default::default(), Default::default(), None)
                     .await
                     .unwrap(),
             )
@@ -5059,7 +5069,7 @@ mod tests {
             .commit_builder()
             .add_member(
                 carol_client
-                    .generate_key_package_message(Default::default(), Default::default())
+                    .generate_key_package_message(Default::default(), Default::default(), None)
                     .await
                     .unwrap(),
             )
@@ -5160,7 +5170,7 @@ mod tests {
             .commit_builder()
             .add_member(
                 carol_client
-                    .generate_key_package_message(Default::default(), Default::default())
+                    .generate_key_package_message(Default::default(), Default::default(), None)
                     .await
                     .unwrap(),
             )
@@ -5234,7 +5244,7 @@ mod tests {
             .commit_builder()
             .add_member(
                 carol_client
-                    .generate_key_package_message(Default::default(), Default::default())
+                    .generate_key_package_message(Default::default(), Default::default(), None)
                     .await
                     .unwrap(),
             )
@@ -5329,7 +5339,7 @@ mod tests {
 
         let mut alice = client_with_custom_rules(b"alice", mls_rules.clone())
             .await
-            .create_group(Default::default(), Default::default())
+            .create_group(Default::default(), Default::default(), None)
             .await
             .unwrap();
 
@@ -5337,7 +5347,7 @@ mod tests {
 
         let kp = client_with_custom_rules(b"bob", mls_rules)
             .await
-            .generate_key_package_message(Default::default(), Default::default())
+            .generate_key_package_message(Default::default(), Default::default(), None)
             .await
             .unwrap();
 
@@ -5383,7 +5393,7 @@ mod tests {
 
         let mut alice = client_with_custom_rules(b"alice", mls_rules.clone())
             .await
-            .create_group(Default::default(), Default::default())
+            .create_group(Default::default(), Default::default(), None)
             .await
             .unwrap();
 
@@ -5418,7 +5428,7 @@ mod tests {
 
         let mut alice = client_with_custom_rules(b"alice", mls_rules.clone())
             .await
-            .create_group(Default::default(), Default::default())
+            .create_group(Default::default(), Default::default(), None)
             .await
             .unwrap();
 
@@ -5572,7 +5582,7 @@ mod tests {
 
         let mut alice = TestGroup {
             group: alice
-                .create_group(Default::default(), Default::default())
+                .create_group(Default::default(), Default::default(), None)
                 .await
                 .unwrap(),
         };

--- a/mls-rs/src/group/proposal_cache.rs
+++ b/mls-rs/src/group/proposal_cache.rs
@@ -3042,7 +3042,7 @@ mod tests {
                 properties,
                 signing_identity,
                 &signature_key,
-                Lifetime::years(1).unwrap(),
+                Lifetime::years(1, None).unwrap(),
             )
             .await
             .unwrap();
@@ -3611,7 +3611,7 @@ mod tests {
 
         generator
             .generate(
-                Lifetime::years(1).unwrap(),
+                Lifetime::years(1, None).unwrap(),
                 Capabilities {
                     credentials: vec![42.into()],
                     ..Default::default()

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -203,7 +203,7 @@ pub(crate) fn group_extensions() -> ExtensionList {
 }
 
 pub(crate) fn lifetime() -> Lifetime {
-    Lifetime::years(1).unwrap()
+    Lifetime::years(1, None).unwrap()
 }
 
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
@@ -253,7 +253,12 @@ pub(crate) async fn test_group_custom(
         .used_protocol_version(protocol_version)
         .signing_identity(signing_identity.clone(), secret_key, cipher_suite)
         .build()
-        .create_group_with_id(TEST_GROUP.to_vec(), group_extensions(), leaf_extensions)
+        .create_group_with_id(
+            TEST_GROUP.to_vec(),
+            group_extensions(),
+            leaf_extensions,
+            None,
+        )
         .await
         .unwrap();
 
@@ -291,7 +296,12 @@ where
     let group = custom(client_builder)
         .signing_identity(signing_identity.clone(), secret_key, cipher_suite)
         .build()
-        .create_group_with_id(TEST_GROUP.to_vec(), group_extensions(), Default::default())
+        .create_group_with_id(
+            TEST_GROUP.to_vec(),
+            group_extensions(),
+            Default::default(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -352,7 +362,12 @@ pub(crate) async fn get_test_groups_with_features(
     }
 
     let group = clients[0]
-        .create_group_with_id(b"TEST GROUP".to_vec(), extensions, leaf_extensions.clone())
+        .create_group_with_id(
+            b"TEST GROUP".to_vec(),
+            extensions,
+            leaf_extensions.clone(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -360,7 +375,7 @@ pub(crate) async fn get_test_groups_with_features(
 
     for client in clients.iter().skip(1) {
         let key_package = client
-            .generate_key_package_message(Default::default(), leaf_extensions.clone())
+            .generate_key_package_message(Default::default(), leaf_extensions.clone(), None)
             .await
             .unwrap();
 

--- a/mls-rs/src/key_package/generator.rs
+++ b/mls-rs/src/key_package/generator.rs
@@ -172,7 +172,7 @@ mod tests {
     }
 
     fn test_lifetime() -> Lifetime {
-        Lifetime::years(1).unwrap()
+        Lifetime::years(1, None).unwrap()
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]

--- a/mls-rs/src/key_package/mod.rs
+++ b/mls-rs/src/key_package/mod.rs
@@ -209,7 +209,7 @@ pub(crate) mod test_utils {
 
         let key_package = generator
             .generate(
-                Lifetime::years(1).unwrap(),
+                Lifetime::years(1, None).unwrap(),
                 get_test_capabilities(),
                 ExtensionList::default(),
                 ExtensionList::default(),

--- a/mls-rs/src/test_utils/mod.rs
+++ b/mls-rs/src/test_utils/mod.rs
@@ -122,7 +122,7 @@ pub async fn get_test_groups<C: CryptoProvider + Clone>(
     .await;
 
     let mut creator_group = creator
-        .create_group(Default::default(), Default::default())
+        .create_group(Default::default(), Default::default(), None)
         .await
         .unwrap();
 
@@ -141,7 +141,7 @@ pub async fn get_test_groups<C: CryptoProvider + Clone>(
         )
         .await;
         let kp = client
-            .generate_key_package_message(Default::default(), Default::default())
+            .generate_key_package_message(Default::default(), Default::default(), None)
             .await
             .unwrap();
 

--- a/mls-rs/src/tree_kem/leaf_node.rs
+++ b/mls-rs/src/tree_kem/leaf_node.rs
@@ -296,7 +296,7 @@ pub(crate) mod test_utils {
             secret,
             capabilities.unwrap_or_else(get_test_capabilities),
             extensions.unwrap_or_default(),
-            Lifetime::years(1).unwrap(),
+            Lifetime::years(1, None).unwrap(),
         )
         .await
     }
@@ -357,7 +357,7 @@ pub(crate) mod test_utils {
             },
             signing_identity,
             &signature_key,
-            Lifetime::years(1).unwrap(),
+            Lifetime::years(1, None).unwrap(),
         )
         .await
         .map(|(leaf, hpke_secret_key)| (leaf, hpke_secret_key, signature_key))
@@ -421,7 +421,7 @@ mod tests {
     async fn test_node_generation() {
         let capabilities = get_test_capabilities();
         let extensions = get_test_extensions();
-        let lifetime = Lifetime::years(1).unwrap();
+        let lifetime = Lifetime::years(1, None).unwrap();
 
         for cipher_suite in TestCryptoProvider::all_supported_cipher_suites() {
             let (signing_identity, secret) = get_test_signing_identity(cipher_suite, b"foo").await;

--- a/mls-rs/src/tree_kem/lifetime.rs
+++ b/mls-rs/src/tree_kem/lifetime.rs
@@ -22,12 +22,18 @@ impl Lifetime {
         }
     }
 
-    pub fn seconds(s: u64) -> Result<Self, MlsError> {
+    pub fn seconds(s: u64, maybe_not_before: Option<MlsTime>) -> Result<Self, MlsError> {
         #[cfg(feature = "std")]
         let not_before = MlsTime::now().seconds_since_epoch();
         #[cfg(not(feature = "std"))]
         // There is no clock on no_std, this is here just so that we can run tests.
         let not_before = 3600u64;
+
+        let not_before = if let Some(not_before_time) = maybe_not_before {
+            not_before_time.seconds_since_epoch()
+        } else {
+            not_before
+        };
 
         let not_after = not_before.checked_add(s).ok_or(MlsError::TimeOverflow)?;
 
@@ -38,12 +44,12 @@ impl Lifetime {
         })
     }
 
-    pub fn days(d: u32) -> Result<Self, MlsError> {
-        Self::seconds((d * 86400) as u64)
+    pub fn days(d: u32, maybe_not_before: Option<MlsTime>) -> Result<Self, MlsError> {
+        Self::seconds((d * 86400) as u64, maybe_not_before)
     }
 
-    pub fn years(y: u8) -> Result<Self, MlsError> {
-        Self::days(365 * y as u32)
+    pub fn years(y: u8, maybe_not_before: Option<MlsTime>) -> Result<Self, MlsError> {
+        Self::days(365 * y as u32, maybe_not_before)
     }
 
     pub(crate) fn within_lifetime(&self, time: MlsTime) -> bool {
@@ -61,21 +67,21 @@ mod tests {
 
     #[test]
     fn test_lifetime_overflow() {
-        let res = Lifetime::seconds(u64::MAX);
+        let res = Lifetime::seconds(u64::MAX, None);
         assert_matches!(res, Err(MlsError::TimeOverflow))
     }
 
     #[test]
     fn test_seconds() {
         let seconds = 10;
-        let lifetime = Lifetime::seconds(seconds).unwrap();
+        let lifetime = Lifetime::seconds(seconds, None).unwrap();
         assert_eq!(lifetime.not_after - lifetime.not_before, 3610);
     }
 
     #[test]
     fn test_days() {
         let days = 2;
-        let lifetime = Lifetime::days(days).unwrap();
+        let lifetime = Lifetime::days(days, None).unwrap();
 
         assert_eq!(
             lifetime.not_after - lifetime.not_before,
@@ -86,7 +92,7 @@ mod tests {
     #[test]
     fn test_years() {
         let years = 2;
-        let lifetime = Lifetime::years(years).unwrap();
+        let lifetime = Lifetime::years(years, None).unwrap();
 
         assert_eq!(
             lifetime.not_after - lifetime.not_before,

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -985,7 +985,7 @@ pub(crate) mod test_utils {
             properties,
             signing_identity,
             &signature_key,
-            Lifetime::years(1).unwrap(),
+            Lifetime::years(1, None).unwrap(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
Refactoring https://github.com/awslabs/mls-rs/pull/273 to use `CommitBuilder` and explicit inputs instead of the time trait.  Making another branch and separate PR because it's cleaner than redoing the previous branch; will close both PRs when one is resolved.

Thanks for the recommended changes!