### PR TITLE
Show `not_before` and `not_after` fields for `X509Error::ValidityError`

### DIFF
--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-rustcrypto"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "RustCrypto based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs-crypto-rustcrypto/src/x509.rs
+++ b/mls-rs-crypto-rustcrypto/src/x509.rs
@@ -4,6 +4,7 @@
 
 use std::net::AddrParseError;
 
+use mls_rs_core::time::MlsTime;
 use mls_rs_core::{crypto::CipherSuite, error::IntoAnyError};
 use mls_rs_identity_x509::SubjectAltName;
 use spki::{der::Tag, ObjectIdentifier};
@@ -62,9 +63,17 @@ pub enum X509Error {
     PinnedCertNotFound,
     #[cfg_attr(
         feature = "std",
-        error("Current (commit) timestamp {0} outside of the validity period of certificate {1}")
+        error("Current (commit) timestamp {} outside of the validity period ({} to {}) of certificate",
+              timestamp.seconds_since_epoch(),
+              not_before.seconds_since_epoch(),
+              not_after.seconds_since_epoch(),
+        )
     )]
-    ValidityError(u64, String),
+    ValidityError {
+        timestamp: MlsTime,
+        not_before: MlsTime,
+        not_after: MlsTime,
+    },
     #[cfg_attr(feature = "std", error("unsupported signing algorithm with OID {0}"))]
     UnsupportedAlgorithm(ObjectIdentifier),
     #[cfg_attr(feature = "std", error(transparent))]

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -25,7 +25,7 @@ by_ref_proposal = [ "mls-rs/by_ref_proposal" ]
 default = ["tree_index", "private_message", "prior_epoch", "out_of_order", "psk", "custom_proposal", "by_ref_proposal"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features = ["browser"], version = "0.16.0" }
+mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features = ["browser"], version = "0.17.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 mls-rs-crypto-openssl = { path = "../../mls-rs-crypto-openssl", version = "0.15.0"}


### PR DESCRIPTION
### Description of changes:

First discussed in #247: This avoids serializing the entire X.509 certificate on validation errors, thus avoiding including potential PII (Personally Identifiable Information), as well as making it feasible to use the errors for better reporting upstream.

### Call-outs:

This is not backwards compatible, so I bumped the version of mls-rs-crypto-rustcrypto. I would appreciate a new release soon after this is merged.

### Testing:

Existing tests were updated to check the included values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
