### PR TITLE
Include timestamps in `MlsError::InvalidLifetime`

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -29,6 +29,7 @@ use mls_rs_core::extension::{ExtensionError, ExtensionList, ExtensionType};
 use mls_rs_core::group::{GroupStateStorage, ProposalType};
 use mls_rs_core::identity::{CredentialType, IdentityProvider, MemberValidationContext};
 use mls_rs_core::key_package::KeyPackageStorage;
+use mls_rs_core::time::MlsTime;
 
 use crate::group::external_commit::ExternalCommitBuilder;
 
@@ -191,8 +192,19 @@ pub enum MlsError {
     TimeOverflow,
     #[cfg_attr(feature = "std", error("invalid leaf_node_source"))]
     InvalidLeafNodeSource,
-    #[cfg_attr(feature = "std", error("key package has expired or is not valid yet"))]
-    InvalidLifetime,
+    #[cfg_attr(
+        feature = "std",
+        error("current time ({}) is not within key package lifetime ({} to {})",
+              timestamp.seconds_since_epoch(),
+              not_before.seconds_since_epoch(),
+              not_after.seconds_since_epoch(),
+        )
+    )]
+    InvalidLifetime {
+        not_before: MlsTime,
+        not_after: MlsTime,
+        timestamp: MlsTime,
+    },
     #[cfg_attr(feature = "std", error("required extension not found"))]
     RequiredExtensionNotFound(ExtensionType),
     #[cfg_attr(feature = "std", error("required proposal not found"))]

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -4520,7 +4520,11 @@ mod tests {
             .process_incoming_message_with_time(commit, future_time)
             .await;
 
-        assert_matches!(res, Err(MlsError::InvalidLifetime));
+        assert_matches!(
+            res,
+            Err(MlsError::InvalidLifetime { timestamp, .. })
+                if timestamp == future_time
+        );
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]


### PR DESCRIPTION
### Description of changes:

This makes it much easier to debug the error after the fact.

### Call-outs:

This is a breaking change, so I’m also bumping the mls-rs version number to reflect this. As always, we would appreciate a release soon after, if possible.

### Testing:

Existing tests were updated to assert on the new values (where possible: some values change with every test run since "now" isn't fixed).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
