### PR TITLE
Delete report rows

### DIFF
--- a/mls-rs-ffi/Cargo.toml
+++ b/mls-rs-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-ffi"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Helper crate to generate FFI definitions for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -24,9 +24,9 @@ private_message = ["mls-rs/private_message"]
 secret_tree_access = ["mls-rs/secret_tree_access"]
 
 [dependencies]
-mls-rs = { path = "../mls-rs", version = "0.48.0", features = ["ffi"] }
+mls-rs = { path = "../mls-rs", version = "0.49.0", features = ["ffi"] }
 mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.16.0", optional = true }
 mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.17.0", optional = true }
-mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.17.0", default-features = false, optional = true }
+mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.18.0", default-features = false, optional = true }
 safer-ffi = { version = "0.1.7", default-features = false }
 safer-ffi-gen = { version = "0.9.2", default-features = false }

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -13,7 +13,7 @@ mls-rs-core = { path = "../mls-rs-core", version = "0.23.0" }
 thiserror = "2"
 wasm-bindgen = { version = "0.2", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }
-rusqlite = { version = "0.36", default-features = false }
+rusqlite = { version = "0.32", default-features = false }
 hex = { version = "0.4" }
 maybe-async = "0.2.10"
 async-trait = "0.1.74"

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-provider-sqlite"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "SQLite based state storage for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs-uniffi/Cargo.toml
+++ b/mls-rs-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-uniffi"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "An UniFFI-compatible implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -17,7 +17,7 @@ name = "mls_rs_uniffi"
 [dependencies]
 async-trait = "0.1.77"
 maybe-async = "0.2.10"
-mls-rs = { version = "0.48.0", path = "../mls-rs" }
+mls-rs = { version = "0.49.0", path = "../mls-rs" }
 mls-rs-core = { version = "0.23.0", path = "../mls-rs-core" }
 mls-rs-crypto-openssl = { version = "0.16.0", path = "../mls-rs-crypto-openssl" }
 thiserror = "1.0.57"

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -67,7 +67,7 @@ spin = { version = "0.10", default-features = false, features = ["mutex", "spin_
 maybe-async = { version = "0.2.10" }
 
 # Optional dependencies
-mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.17.0", default-features = false, optional = true }
+mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.18.0", default-features = false, optional = true }
 mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", optional = true, version = "0.16.0" }
 
 # TODO: https://github.com/GoogleChromeLabs/wasm-bindgen-rayon

--- a/mls-rs/fuzz/Cargo.toml
+++ b/mls-rs/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-mls-rs = { version = "0.48.0", path = "..", features = ["arbitrary", "fuzz_util"] }
+mls-rs = { version = "0.49.0", path = "..", features = ["arbitrary", "fuzz_util"] }
 futures = "0.3.25"
 libfuzzer-sys = "0.4"
 once_cell = "1.13.0"

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mls-rs = { version = "0.48.0", path = "..", default-features = false, features = ["std", "external_client"]}
+mls-rs = { version = "0.49.0", path = "..", default-features = false, features = ["std", "external_client"]}
 tonic = "0.10.2"
 prost = "0.12.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Similar to a recent change made that reports the number of rows changed on inserts, this now reports the number of rows changed on deletes. This allows callers to better manage and understand when duplicate actions are being performed to optimize on that.

Modified relevant tests to test this new functionality.

Also includes a downgrade of rusqlite, which was overbumped in a recent blanket upgrade, but this causes issues for consumers which also have sqlx as a dependency, as they don't support a recent enough version of a shared dependency `libsqlite3-sys`, rendering such a dependency conflict impossible

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
