### PR TITLE
fix: enforce that HashMap keys are Ord for MlsEncode

### DIFF
--- a/mls-rs-codec-derive/Cargo.toml
+++ b/mls-rs-codec-derive/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0 OR MIT"
 proc-macro = true
 
 [dependencies]
-darling = "0.20.3"
+darling = "0.21"
 proc-macro2 = "1.0.54"
 quote = "1.0.26"
 syn = "2"

--- a/mls-rs-codec/Cargo.toml
+++ b/mls-rs-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-codec"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "TLS codec and MLS specific encoding used by mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -16,6 +16,7 @@ std = ["dep:thiserror"]
 [dependencies]
 mls-rs-codec-derive = { version = "0.2.0", path = "../mls-rs-codec-derive" }
 thiserror = { version = "2", optional = true }
+itertools = { version = "0.14.0", default-features = false, features = ["use_alloc"]}
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/mls-rs-codec/src/map.rs
+++ b/mls-rs-codec/src/map.rs
@@ -23,11 +23,12 @@ where
 #[cfg(feature = "std")]
 impl<K, V> MlsEncode for HashMap<K, V>
 where
-    K: MlsEncode,
+    K: MlsEncode + Ord,
     V: MlsEncode,
 {
     fn mls_encode(&self, writer: &mut Vec<u8>) -> Result<(), crate::Error> {
-        crate::iter::mls_encode(self.iter(), writer)
+        use itertools::Itertools;
+        crate::iter::mls_encode(self.iter().sorted_by_key(|(key, _)| *key), writer)
     }
 }
 

--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-core"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Core components and traits for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -25,7 +25,7 @@ post-quantum = []
 self_remove_proposal = []
 
 [dependencies]
-mls-rs-codec = { version = "0.6", path = "../mls-rs-codec", default-features = false}
+mls-rs-codec = { version = "0.7", path = "../mls-rs-codec", default-features = false}
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 arbitrary = { version = "1", features = ["derive"], optional = true }
 thiserror = { version = "2", optional = true }

--- a/mls-rs-crypto-awslc/Cargo.toml
+++ b/mls-rs-crypto-awslc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-awslc"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "AWS-LC based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -18,18 +18,18 @@ default = ["non-fips"]
 aws-lc-rs = { version = "=1.13.1", default-features = false, features = ["alloc"] }
 aws-lc-sys = { version = "=0.29", optional = true }
 aws-lc-fips-sys = { version = "=0.13", optional = true }
-mls-rs-core = { path = "../mls-rs-core", version = "0.23.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.16.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.17.0" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.17.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.24.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.17.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.18.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.18.0" }
 thiserror = "2"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.10"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.23.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.16.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.24.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.17.0", features = ["test_utils"] }
 futures-test = "0.3.25"
 serde = { version = "1.0", features = ["derive"] }
 hex = { version = "0.4", features = ["serde"] }

--- a/mls-rs-crypto-cryptokit/Cargo.toml
+++ b/mls-rs-crypto-cryptokit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-cryptokit"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "CryptoKit based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -20,12 +20,12 @@ serde_json = "1.0"
 [dev-dependencies]
 hex-literal = "1"
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.23.0", features = ["test_suite"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.24.0", features = ["test_suite"] }
 
 [dependencies]
 maybe-async = "0.2.10"
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.23.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.17.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.24.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.18.0" }
 thiserror = { version = "2", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 

--- a/mls-rs-crypto-hpke/Cargo.toml
+++ b/mls-rs-crypto-hpke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-hpke"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "HPKE implementation based on mls-rs-crypto-traits used by mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -15,8 +15,8 @@ std = ["mls-rs-core/std", "mls-rs-crypto-traits/std", "dep:thiserror", "zeroize/
 test_utils = ["mls-rs-core/test_suite"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.23.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.17.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.24.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.18.0" }
 thiserror = { version = "2", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 cfg-if = "^1"
@@ -28,7 +28,7 @@ serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
 mockall = "0.13"
 hex = { version = "^0.4.3", features = ["serde"] }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.17.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", features = ["mock"], version = "0.18.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3" }

--- a/mls-rs-crypto-openssl/Cargo.toml
+++ b/mls-rs-crypto-openssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-openssl"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "OpenSSL based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -14,10 +14,10 @@ default = ["x509"]
 
 [dependencies]
 openssl = { version = "0.10.40" }
-mls-rs-core = { path = "../mls-rs-core", version = "0.23.0" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.17.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.16.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.17.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.24.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.18.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.17.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", version = "0.18.0" }
 thiserror = "2"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.10"
@@ -27,8 +27,8 @@ hex = { version = "^0.4.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.23.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.16.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.24.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", version = "0.17.0", features = ["test_utils"] }
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"

--- a/mls-rs-crypto-rustcrypto/Cargo.toml
+++ b/mls-rs-crypto-rustcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-rustcrypto"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "RustCrypto based CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -29,9 +29,9 @@ std = [
 ]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.23.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.16.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.17.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.24.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.17.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, version = "0.18.0" }
 
 thiserror = { version = "2", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
@@ -59,7 +59,7 @@ ed25519-dalek = { version = "2", default-features = false, features = ["alloc", 
 sec1 = { version = "0.7", default-features = false, features = ["alloc"] }
 
 # X509 feature
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.17.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", optional = true, version = "0.18.0" }
 x509-cert = { version = "0.2", optional = true, features = ["std"] }
 spki = { version = "0.7", optional = true, features = ["std", "alloc"] }
 maybe-async = "0.2.10"
@@ -69,8 +69,8 @@ hex = { version = "^0.4.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 assert_matches = "1.5.0"
-mls-rs-core = { path = "../mls-rs-core", version = "0.23.0", features = ["test_suite"] }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.16.0", features = ["test_utils"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.24.0", features = ["test_suite"] }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, version = "0.17.0", features = ["test_utils"] }
 
 [target.'cfg(mls_build_async)'.dependencies]
 async-trait = "0.1.74"

--- a/mls-rs-crypto-traits/Cargo.toml
+++ b/mls-rs-crypto-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-traits"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Crypto traits required to create a CryptoProvider for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -14,7 +14,7 @@ std = ["mls-rs-core/std"]
 default = ["std"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "0.23.0", default-features = false }
+mls-rs-core = { path = "../mls-rs-core", version = "0.24.0", default-features = false }
 mockall = { version = "^0.11", optional = true }
 maybe-async = "0.2.10"
 

--- a/mls-rs-crypto-webcrypto/Cargo.toml
+++ b/mls-rs-crypto-webcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-crypto-webcrypto"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "SubtleCrypto based CryptoProvider for supporting mls-rs in a browser"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -9,9 +9,9 @@ keywords = ["mls", "mls-rs"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["std"], version = "0.23.0" }
-mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, features = ["std"], version = "0.16.0" }
-mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, features = ["std"], version = "0.17.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["std"], version = "0.24.0" }
+mls-rs-crypto-hpke = { path = "../mls-rs-crypto-hpke", default-features = false, features = ["std"], version = "0.17.0" }
+mls-rs-crypto-traits = { path = "../mls-rs-crypto-traits", default-features = false, features = ["std"], version = "0.18.0" }
 thiserror = "2"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 maybe-async = "0.2.10"
@@ -26,7 +26,7 @@ web-sys = { version = "0.3.64", features = ["Window", "CryptoKey", "CryptoKeyPai
 const-oid = { version = "0.9", features = ["db"] }
 
 [dev-dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "0.23.0", features = ["test_suite"] }
+mls-rs-core = { path = "../mls-rs-core", version = "0.24.0", features = ["test_suite"] }
 wasm-bindgen-test = { version = "0.3" }
 futures-test = "0.3.25"
 serde_json = "^1.0"

--- a/mls-rs-ffi/Cargo.toml
+++ b/mls-rs-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-ffi"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Helper crate to generate FFI definitions for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -24,9 +24,9 @@ private_message = ["mls-rs/private_message"]
 secret_tree_access = ["mls-rs/secret_tree_access"]
 
 [dependencies]
-mls-rs = { path = "../mls-rs", version = "0.49.0", features = ["ffi"] }
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.16.0", optional = true }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.17.0", optional = true }
-mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.18.0", default-features = false, optional = true }
+mls-rs = { path = "../mls-rs", version = "0.50.0", features = ["ffi"] }
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.17.0", optional = true }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", version = "0.18.0", optional = true }
+mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.19.0", default-features = false, optional = true }
 safer-ffi = { version = "0.1.7", default-features = false }
 safer-ffi-gen = { version = "0.9.2", default-features = false }

--- a/mls-rs-identity-x509/Cargo.toml
+++ b/mls-rs-identity-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-identity-x509"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "X509 Identity utilities for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -13,7 +13,7 @@ default = ["std"]
 std = ["mls-rs-core/std", "dep:thiserror"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["x509"], version = "0.23.0" }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, features = ["x509"], version = "0.24.0" }
 maybe-async = "0.2.10"
 thiserror = { version = "2", optional = true }
 

--- a/mls-rs-provider-sqlite/Cargo.toml
+++ b/mls-rs-provider-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-provider-sqlite"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "SQLite based state storage for mls-rs"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -9,7 +9,7 @@ keywords = ["mls", "mls-rs"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", version = "0.23.0" }
+mls-rs-core = { path = "../mls-rs-core", version = "0.24.0" }
 thiserror = "2"
 wasm-bindgen = { version = "0.2", optional = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }

--- a/mls-rs-uniffi/Cargo.toml
+++ b/mls-rs-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs-uniffi"
-version = "0.7.0"
+version = "0.9.0"
 edition = "2021"
 description = "An UniFFI-compatible implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -17,10 +17,10 @@ name = "mls_rs_uniffi"
 [dependencies]
 async-trait = "0.1.77"
 maybe-async = "0.2.10"
-mls-rs = { version = "0.49.0", path = "../mls-rs" }
-mls-rs-core = { version = "0.23.0", path = "../mls-rs-core" }
-mls-rs-crypto-openssl = { version = "0.16.0", path = "../mls-rs-crypto-openssl" }
-thiserror = "1.0.57"
+mls-rs = { version = "0.50.0", path = "../mls-rs" }
+mls-rs-core = { version = "0.24.0", path = "../mls-rs-core" }
+mls-rs-crypto-openssl = { version = "0.17.0", path = "../mls-rs-crypto-openssl" }
+thiserror = "2"
 uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "eeb785c", version = "0.27.0" }
 
 [target.'cfg(mls_build_async)'.dependencies]

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"
@@ -55,10 +55,10 @@ benchmark_pq_crypto = ["mls-rs-crypto-awslc/post-quantum"]
 fuzz_util = ["test_util", "default", "dep:once_cell", "dep:mls-rs-crypto-openssl"]
 
 [dependencies]
-mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.23.0" }
-mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", default-features = false, version = "0.17.0", optional = true }
+mls-rs-core = { path = "../mls-rs-core", default-features = false, version = "0.24.0" }
+mls-rs-identity-x509 = { path = "../mls-rs-identity-x509", default-features = false, version = "0.18.0", optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
-mls-rs-codec = { version = "0.6", path = "../mls-rs-codec", default-features = false}
+mls-rs-codec = { version = "0.7", path = "../mls-rs-codec", default-features = false}
 thiserror = { version = "2", optional = true }
 itertools = { version = "0.14.0", default-features = false, features = ["use_alloc"]}
 cfg-if = "1"
@@ -67,8 +67,8 @@ spin = { version = "0.10", default-features = false, features = ["mutex", "spin_
 maybe-async = { version = "0.2.10" }
 
 # Optional dependencies
-mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.18.0", default-features = false, optional = true }
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", optional = true, version = "0.16.0" }
+mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.19.0", default-features = false, optional = true }
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", optional = true, version = "0.17.0" }
 
 # TODO: https://github.com/GoogleChromeLabs/wasm-bindgen-rayon
 rayon = { version = "1", optional = true }
@@ -80,7 +80,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 hex = { version = "^0.4.3", default-features = false, features = ["serde", "alloc"], optional = true }
 
 # Only for benchmarks
-mls-rs-crypto-awslc = { path = "../mls-rs-crypto-awslc", optional = true, version = "0.18" }
+mls-rs-crypto-awslc = { path = "../mls-rs-crypto-awslc", optional = true, version = "0.19" }
 
 # Async mode dependencies
 [target.'cfg(mls_build_async)'.dependencies]
@@ -110,11 +110,10 @@ rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3" }
-mls-rs-crypto-webcrypto = { path = "../mls-rs-crypto-webcrypto", version = "0.10.0" }
+mls-rs-crypto-webcrypto = { path = "../mls-rs-crypto-webcrypto", version = "0.11.0" }
 criterion = { version = "0.6", default-features = false, features = ["plotters", "cargo_bench_support", "async_futures", "html_reports"] }
-
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.16.0"}
+mls-rs-crypto-openssl = { path = "../mls-rs-crypto-openssl", version = "0.17.0"}
 criterion = { version = "0.6", features = ["async_futures", "html_reports"] }
 
 [lints.rust]

--- a/mls-rs/fuzz/Cargo.toml
+++ b/mls-rs/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-mls-rs = { version = "0.49.0", path = "..", features = ["arbitrary", "fuzz_util"] }
+mls-rs = { version = "0.50.0", path = "..", features = ["arbitrary", "fuzz_util"] }
 futures = "0.3.25"
 libfuzzer-sys = "0.4"
 once_cell = "1.13.0"

--- a/mls-rs/src/group/message_hash.rs
+++ b/mls-rs/src/group/message_hash.rs
@@ -7,7 +7,7 @@ use mls_rs_core::crypto::CipherSuiteProvider;
 
 use crate::{client::MlsError, error::IntoAnyError, MlsMessage};
 
-#[derive(Clone, PartialEq, Eq, MlsEncode, MlsDecode, MlsSize, Hash)]
+#[derive(Clone, PartialEq, Eq, MlsEncode, MlsDecode, MlsSize, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct MessageHash(
     #[mls_codec(with = "mls_rs_codec::byte_vec")]

--- a/mls-rs/src/map.rs
+++ b/mls-rs/src/map.rs
@@ -19,7 +19,7 @@ mod map_impl {
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    pub struct SmallMap<K: Hash + Eq, V>(pub(super) HashMap<K, V>);
+    pub struct SmallMap<K: Hash + Eq + Ord, V>(pub(super) HashMap<K, V>);
 
     pub type LargeMap<K, V> = SmallMap<K, V>;
     pub(super) type SmallMapInner<K, V> = HashMap<K, V>;
@@ -67,13 +67,13 @@ mod map_impl {
     }
 }
 
-impl<K: Hash + Eq, V> Default for SmallMap<K, V> {
+impl<K: Hash + Eq + Ord, V> Default for SmallMap<K, V> {
     fn default() -> Self {
         Self(SmallMapInner::new())
     }
 }
 
-impl<K: Hash + Eq, V> Deref for SmallMap<K, V> {
+impl<K: Hash + Eq + Ord, V> Deref for SmallMap<K, V> {
     type Target = SmallMapInner<K, V>;
 
     fn deref(&self) -> &Self::Target {
@@ -81,7 +81,7 @@ impl<K: Hash + Eq, V> Deref for SmallMap<K, V> {
     }
 }
 
-impl<K: Hash + Eq, V> DerefMut for SmallMap<K, V> {
+impl<K: Hash + Eq + Ord, V> DerefMut for SmallMap<K, V> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -89,7 +89,7 @@ impl<K: Hash + Eq, V> DerefMut for SmallMap<K, V> {
 
 impl<K, V> MlsDecode for SmallMap<K, V>
 where
-    K: Hash + Eq + MlsEncode + MlsDecode + MlsSize,
+    K: Hash + Eq + Ord + MlsEncode + MlsDecode + MlsSize,
     V: MlsEncode + MlsDecode + MlsSize,
 {
     fn mls_decode(reader: &mut &[u8]) -> Result<Self, mls_rs_codec::Error> {
@@ -99,7 +99,7 @@ where
 
 impl<K, V> MlsSize for SmallMap<K, V>
 where
-    K: Hash + Eq + MlsEncode + MlsDecode + MlsSize,
+    K: Hash + Eq + Ord + MlsEncode + MlsDecode + MlsSize,
     V: MlsEncode + MlsDecode + MlsSize,
 {
     fn mls_encoded_len(&self) -> usize {
@@ -109,7 +109,7 @@ where
 
 impl<K, V> MlsEncode for SmallMap<K, V>
 where
-    K: Hash + Eq + MlsEncode + MlsDecode + MlsSize,
+    K: Hash + Eq + Ord + MlsEncode + MlsDecode + MlsSize,
     V: MlsEncode + MlsDecode + MlsSize,
 {
     fn mls_encode(&self, writer: &mut Vec<u8>) -> Result<(), mls_rs_codec::Error> {

--- a/mls-rs/test_harness_integration/Cargo.toml
+++ b/mls-rs/test_harness_integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-mls-rs = { version = "0.49.0", path = "..", default-features = false, features = ["std", "external_client"]}
+mls-rs = { version = "0.50.0", path = "..", default-features = false, features = ["std", "external_client"]}
 tonic = "0.10.2"
 prost = "0.12.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
@@ -25,10 +25,10 @@ by_ref_proposal = [ "mls-rs/by_ref_proposal" ]
 default = ["tree_index", "private_message", "prior_epoch", "out_of_order", "psk", "custom_proposal", "by_ref_proposal"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features = ["browser"], version = "0.17.0" }
+mls-rs-crypto-rustcrypto = { path = "../../mls-rs-crypto-rustcrypto", features = ["browser"], version = "0.18.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-mls-rs-crypto-openssl = { path = "../../mls-rs-crypto-openssl", version = "0.16.0"}
+mls-rs-crypto-openssl = { path = "../../mls-rs-crypto-openssl", version = "0.17.0"}
 
 [build-dependencies]
 tonic-build = "0.10.2"


### PR DESCRIPTION
### Issues:

Resolves #295 

### Description of changes:

HashMap values serialized with mls-rs-codec were not sorted based on the value of the keys when serialized into a `Vec<(K,V)>` for transport. This results in inconsistent wire data with multiple rounds of encoding + decoding and will break hash calculations. 

* Enforce Ord constraint on K for `HashMap<K,V>` `MlsEncode`
* Bump all dependencies in prep for next release

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
