### PR TITLE
Custom proposals support GSMA RCS encoding

### DIFF
--- a/mls-rs-core/Cargo.toml
+++ b/mls-rs-core/Cargo.toml
@@ -23,6 +23,7 @@ serde = ["dep:serde", "zeroize/serde", "hex/serde", "dep:serde_bytes"]
 last_resort_key_package_ext = []
 post-quantum = []
 self_remove_proposal = []
+gsma_rcs_e2ee_feature = []
 
 [dependencies]
 mls-rs-codec = { version = "0.7", path = "../mls-rs-codec", default-features = false}

--- a/mls-rs-core/src/group/proposal_type.rs
+++ b/mls-rs-core/src/group/proposal_type.rs
@@ -58,6 +58,8 @@ impl ProposalType {
     pub const GROUP_CONTEXT_EXTENSIONS: ProposalType = ProposalType(7);
     #[cfg(feature = "self_remove_proposal")]
     pub const SELF_REMOVE: ProposalType = ProposalType(0xF003);
+    pub const RFC_SIGNATURE: ProposalType = ProposalType::new(0xF002);
+    pub const RFC_SERVER_REMOVE: ProposalType = ProposalType::new(0xF004);
 
     /// Default proposal types defined
     /// in [RFC 9420](https://www.rfc-editor.org/rfc/rfc9420.html#name-leaf-node-contents)

--- a/mls-rs-core/src/group/proposal_type.rs
+++ b/mls-rs-core/src/group/proposal_type.rs
@@ -58,8 +58,9 @@ impl ProposalType {
     pub const GROUP_CONTEXT_EXTENSIONS: ProposalType = ProposalType(7);
     #[cfg(feature = "self_remove_proposal")]
     pub const SELF_REMOVE: ProposalType = ProposalType(0xF003);
-    pub const RFC_SIGNATURE: ProposalType = ProposalType::new(0xF002);
-    pub const RFC_SERVER_REMOVE: ProposalType = ProposalType::new(0xF004);
+    pub const RCS_END_MLS: ProposalType = ProposalType::new(0xf001);
+    pub const RCS_SIGNATURE: ProposalType = ProposalType::new(0xF002);
+    pub const RCS_SERVER_REMOVE: ProposalType = ProposalType::new(0xF004);
 
     /// Default proposal types defined
     /// in [RFC 9420](https://www.rfc-editor.org/rfc/rfc9420.html#name-leaf-node-contents)

--- a/mls-rs-core/src/group/proposal_type.rs
+++ b/mls-rs-core/src/group/proposal_type.rs
@@ -58,8 +58,11 @@ impl ProposalType {
     pub const GROUP_CONTEXT_EXTENSIONS: ProposalType = ProposalType(7);
     #[cfg(feature = "self_remove_proposal")]
     pub const SELF_REMOVE: ProposalType = ProposalType(0xF003);
+    #[cfg(feature = "gsma_rcs_e2ee_feature")]
     pub const RCS_END_MLS: ProposalType = ProposalType::new(0xf001);
+    #[cfg(feature = "gsma_rcs_e2ee_feature")]
     pub const RCS_SIGNATURE: ProposalType = ProposalType::new(0xF002);
+    #[cfg(feature = "gsma_rcs_e2ee_feature")]
     pub const RCS_SERVER_REMOVE: ProposalType = ProposalType::new(0xF004);
 
     /// Default proposal types defined

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -36,6 +36,7 @@ x509 = ["mls-rs-core/x509", "dep:mls-rs-identity-x509"]
 rfc_compliant = ["private_message", "custom_proposal", "out_of_order", "psk", "x509", "prior_epoch", "by_ref_proposal", "mls-rs-core/rfc_compliant"]
 last_resort_key_package_ext = ["mls-rs-core/last_resort_key_package_ext"]
 self_remove_proposal = ["mls-rs-core/self_remove_proposal"]
+gsma_rcs_e2ee_feature = ["mls-rs-core/gsma_rcs_e2ee_feature"]
 
 std = ["mls-rs-core/std", "mls-rs-codec/std", "mls-rs-identity-x509?/std", "hex/std", "futures/std", "itertools/use_std", "safer-ffi-gen?/std", "zeroize/std", "dep:debug_tree", "dep:thiserror", "serde?/std"]
 

--- a/mls-rs/src/group/proposal.rs
+++ b/mls-rs/src/group/proposal.rs
@@ -336,7 +336,9 @@ impl CustomDecoder for RfcCustomProposalDecoder {
         proposal_type: &ProposalType,
     ) -> Result<(), mls_rs_codec::Error> {
         match proposal_type {
-            &ProposalType::RFC_SIGNATURE | &ProposalType::RFC_SERVER_REMOVE => {
+            &ProposalType::RCS_SIGNATURE
+            | &ProposalType::RCS_SERVER_REMOVE
+            | &ProposalType::RCS_END_MLS => {
                 // directly extend with the serialized proposals; don't encode as a byte array
                 // as the length should not be included in the encoding
                 writer.extend(data);
@@ -350,8 +352,8 @@ impl CustomDecoder for RfcCustomProposalDecoder {
         proposal_type: &ProposalType,
     ) -> Result<Vec<u8>, mls_rs_codec::Error> {
         match proposal_type {
-            &ProposalType::RFC_SIGNATURE => Ok(Vec::new()), // empty struct
-            &ProposalType::RFC_SERVER_REMOVE => {
+            &ProposalType::RCS_SIGNATURE | &ProposalType::RCS_END_MLS => Ok(Vec::new()), // empty struct
+            &ProposalType::RCS_SERVER_REMOVE => {
                 let decoded = RemoveProposal::mls_decode(reader)?; // remove proposal
                 let mut writer = Vec::new();
                 RemoveProposal::mls_encode(&decoded, &mut writer)?;

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -120,6 +120,7 @@ impl ProposalBundle {
                 sender,
                 source,
             }),
+            Proposal::_PhantomVariant(_) => panic!("Not constructible"),
         }
     }
 

--- a/mls-rs/src/group/proposal_filter/bundle.rs
+++ b/mls-rs/src/group/proposal_filter/bundle.rs
@@ -120,7 +120,6 @@ impl ProposalBundle {
                 sender,
                 source,
             }),
-            Proposal::_PhantomVariant(_) => panic!("Not constructible"),
         }
     }
 


### PR DESCRIPTION
The current implementation of the CustomProposal is that all user-specified custom proposals are wrapped in the CustomProposal struct. The user-specified custom proposal is encoded into a byte vector field in CustomProposal.

```
struct CustomProposal {
    proposal_type: ProposalType,
    data: Vec<u8>, // this is the mls_encoded user-specified custom proposal
}
```

This is very elegant as it means we don't need to extend the Proposal enum for every new proposal kind. However it also means that the encoding of CustomProposal is always as a byte vector. This means it is not compatible with other implementations that have custom proposals encoded directly (as top-level in the Proposal variants).

To ensure compatibility with other implementations of the [GSMA RCS spec](https://www.gsma.com/solutions-and-impact/technologies/networks/wp-content/uploads/2025/03/RCC.16-v1.0.pdf), this PR:
* adds the GSMA RCS spec-specific custom proposals as built-in ProposalType variants
* adds a new trait `CustomDecoder` that implements mapping to/from the `data` field in `CustomProposal`. This maps from the ProposalType to the encoding/decoding. For the GSMA RCS-specific proposal types, it will not encode the length of the `data` field, as it's not encoded as a `Vec<u8>`, but rather it will encode/decode directly as the GSMA RCS-specific proposal shapes:
    * EndMls: empty struct
    * RcsSignature: empty struct
    * ServerRemove: `struct { u32 }`, the same shape as the `RemoveProposal`
* hides all of this behind a new feature flag `gsma_rcs_e2ee_feature`, so the original functionality is preserved by default
* \+ tests


