### PR TITLE
make arbitrary for LeafIndex constrain the underlying integer properly

### DIFF
--- a/mls-rs/src/tree_kem/node.rs
+++ b/mls-rs/src/tree_kem/node.rs
@@ -29,9 +29,16 @@ pub(crate) struct Parent {
 }
 
 #[derive(Clone, Copy, Debug, Ord, PartialEq, PartialOrd, Hash, Eq, MlsSize, MlsEncode)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct LeafIndex(u32);
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for LeafIndex {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let value = u.int_in_range(0..=MAX_LEAF_INDEX)?;
+        Ok(LeafIndex(value))
+    }
+}
 
 impl TryFrom<u32> for LeafIndex {
     type Error = MlsError;


### PR DESCRIPTION
### Description of changes:

Fixes a random error in fuzz testing due to the fuzz tester generating a LeafIndex that is out of bounds. This was happening because we constrain the integer in the MLS codec deserialization, which is not called during fuzzing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
