### PR TITLE
Fix in external commit processing

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.50.0"
+version = "0.50.1"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2271,9 +2271,8 @@ where
             .applied_proposals
             .external_initializations
             .first()
-            .cloned()
         {
-            Some(ext_init) if self.pending_commit.is_none() => {
+            Some(ext_init) => {
                 self.key_schedule
                     .derive_for_external(&ext_init.proposal.kem_output, &self.cipher_suite_provider)
                     .await?


### PR DESCRIPTION
The added test fails in main in line 920 with InvalidConfirmationTag. I'm not sure what's the purpose of `if self.pending_commit.is_none()`, all tests pass so I think it may be just a bug.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
