### PR TITLE
fix: appending extensions should maintain extension type uniqueness

### DIFF
--- a/.github/workflows/benchmarks_merge.yml
+++ b/.github/workflows/benchmarks_merge.yml
@@ -12,7 +12,9 @@ jobs:
       deployments: write
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ''
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ''
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,9 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          rustflags: ''
           components: clippy, rustfmt
+          toolchain: stable, nightly
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/interop_tests.yml
+++ b/.github/workflows/interop_tests.yml
@@ -11,8 +11,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          rustflags: ''
           path: mls
       - name: Clone test runner
         uses: actions/checkout@v4

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -44,7 +44,7 @@ jobs:
         run: cargo install --force --locked bindgen-cli
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl:x64-windows-static-md sqlite3:x64-windows-static-md
+          vcpkg install openssl:x64-windows-md sqlcipher:x64-windows-md
         if: runner.os == 'Windows'
       - run: |
           sudo apt-get install -y libsqlite3-dev

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -44,7 +44,8 @@ jobs:
         run: cargo install --force --locked bindgen-cli
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl:x64-windows-static-md sqlcipher:x64-windows-static-md
+          echo "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          vcpkg install openssl:x64-windows sqlcipher:x64-windows
         if: runner.os == 'Windows'
       - run: |
           sudo apt-get install -y libsqlite3-dev
@@ -92,7 +93,8 @@ jobs:
         if: runner.os == 'Windows'
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl:x64-windows-static-md sqlite3:x64-windows-static-md
+          echo "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          vcpkg install openssl:x64-windows sqlite3:x64-windows
         if: runner.os == 'Windows'
       - name: Test Async Full RFC
         run: cargo test --lib --test '*' --verbose --features test_util -p mls-rs

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -44,7 +44,7 @@ jobs:
         run: cargo install --force --locked bindgen-cli
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl:x64-windows sqlcipher:x64-windows
+          vcpkg install openssl:x64-windows-static-md sqlcipher:x64-windows-static-md
         if: runner.os == 'Windows'
       - run: |
           sudo apt-get install -y libsqlite3-dev

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT/openssl_x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT/packages/openssl_x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows sqlcipher:x64-windows
         if: runner.os == 'Windows'
       - run: |
@@ -95,7 +95,7 @@ jobs:
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT/openssl_x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT/packages/openssl_x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows sqlite3:x64-windows
         if: runner.os == 'Windows'
       - name: Test Async Full RFC

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -41,8 +41,8 @@ jobs:
         run: cargo install --force --locked bindgen-cli
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl:x64-windows-static-md sqlite3:x64-windows-static-md
-          echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
+          vcpkg install openssl sqlite3:x64-windows-static-md
+          echo "OPENSSL_DIR=C:/vcpkg/packages/openssl" | Out-File -FilePath $env:GITHUB_ENV -Append
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -41,8 +41,8 @@ jobs:
         run: cargo install --force --locked bindgen-cli
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl sqlite3:x64-windows-static-md
-          echo "OPENSSL_DIR=C:/vcpkg/packages/openssl" | Out-File -FilePath $env:GITHUB_ENV -Append
+          vcpkg install openssl:x64-windows-static-md sqlite3:x64-windows-static-md
+          echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -45,10 +45,6 @@ jobs:
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows-static-md sqlite3:x64-windows-static-md
-          echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
-          curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
-          echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "RUSTFLAGS=`"-C link-arg=crypt32.lib`"" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - run: |
           sudo apt-get install -y libsqlite3-dev
@@ -72,8 +68,6 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    env:
-      RUSTFLAGS: '--cfg mls_build_async'
     steps:
       - uses: actions/checkout@v3
       - uses: arduino/setup-protoc@v2
@@ -82,7 +76,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          rustflags: ''
+          rustflags: '--cfg mls_build_async'
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -99,10 +93,6 @@ jobs:
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows-static-md sqlite3:x64-windows-static-md
-          echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
-          curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
-          echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "RUSTFLAGS=`"-C link-arg=crypt32.lib`"" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - name: Test Async Full RFC
         run: cargo test --lib --test '*' --verbose --features test_util -p mls-rs

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -47,6 +47,8 @@ jobs:
           echo "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT/packages/openssl_x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows sqlcipher:x64-windows
+          curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
+          echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - run: |
           sudo apt-get install -y libsqlite3-dev
@@ -97,6 +99,8 @@ jobs:
           echo "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT/packages/openssl_x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows sqlite3:x64-windows
+          curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
+          echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - name: Test Async Full RFC
         run: cargo test --lib --test '*' --verbose --features test_util -p mls-rs

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -46,7 +46,7 @@ jobs:
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT/packages/openssl_x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl:x64-windows sqlcipher:x64-windows
+          vcpkg install openssl:x64-windows sqlcipher:x64-windows sqlite:x64-windows
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -48,7 +48,7 @@ jobs:
           echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo 'RUSTFLAGS="-C link-arg=crypt32.lib"' | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo RUSTFLAGS=\"-C link-arg=crypt32.lib\" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - run: |
           sudo apt-get install -y libsqlite3-dev
@@ -102,7 +102,7 @@ jobs:
           echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo 'RUSTFLAGS="-C link-arg=crypt32.lib"' | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo RUSTFLAGS=\"-C link-arg=crypt32\" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - name: Test Async Full RFC
         run: cargo test --lib --test '*' --verbose --features test_util -p mls-rs

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -22,7 +22,10 @@ jobs:
         with:
           version: "25.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ''
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -72,7 +75,9 @@ jobs:
         with:
           version: "25.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ''
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -105,7 +110,10 @@ jobs:
         with:
           version: "25.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ''
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -133,7 +141,10 @@ jobs:
         with:
           version: "25.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ''
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -145,7 +156,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ''
+          toolchain: nightly
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -48,7 +48,7 @@ jobs:
           echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "RUSTFLAGS=\"-C link-arg=crypt32.lib\"" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "RUSTFLAGS=`"-C link-arg=crypt32.lib`"" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - run: |
           sudo apt-get install -y libsqlite3-dev
@@ -102,7 +102,7 @@ jobs:
           echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo RUSTFLAGS=\"-C link-arg=crypt32\" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "RUSTFLAGS=`"-C link-arg=crypt32.lib`"" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - name: Test Async Full RFC
         run: cargo test --lib --test '*' --verbose --features test_util -p mls-rs

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -45,6 +45,7 @@ jobs:
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT/openssl_x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows sqlcipher:x64-windows
         if: runner.os == 'Windows'
       - run: |
@@ -94,6 +95,7 @@ jobs:
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT/openssl_x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows sqlite3:x64-windows
         if: runner.os == 'Windows'
       - name: Test Async Full RFC

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -46,7 +46,7 @@ jobs:
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT/packages/openssl_x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl:x64-windows sqlcipher:x64-windows sqlite:x64-windows
+          vcpkg install openssl:x64-windows sqlcipher:x64-windows sqlite3:x64-windows
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
@@ -98,7 +98,7 @@ jobs:
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "VCPKGRS_DYNAMIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT/packages/openssl_x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl:x64-windows sqlite3:x64-windows
+          vcpkg install openssl:x64-windows sqlcipher:x64-windows sqlite3:x64-windows
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -44,7 +44,7 @@ jobs:
         run: cargo install --force --locked bindgen-cli
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl:x64-windows-md sqlcipher:x64-windows-md
+          vcpkg install openssl:x64-windows sqlcipher:x64-windows
         if: runner.os == 'Windows'
       - run: |
           sudo apt-get install -y libsqlite3-dev

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -48,7 +48,7 @@ jobs:
           echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo RUSTFLAGS=\"-C link-arg=crypt32.lib\" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "RUSTFLAGS=\"-C link-arg=crypt32.lib\"" | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - run: |
           sudo apt-get install -y libsqlite3-dev

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -48,7 +48,7 @@ jobs:
           echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo 'RUSTFLAGS="-l crypt32"' | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo 'RUSTFLAGS="-C link-arg=crypt32.lib"' | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - run: |
           sudo apt-get install -y libsqlite3-dev
@@ -102,7 +102,7 @@ jobs:
           echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo 'RUSTFLAGS="-l crypt32"' | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo 'RUSTFLAGS="-C link-arg=crypt32.lib"' | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - name: Test Async Full RFC
         run: cargo test --lib --test '*' --verbose --features test_util -p mls-rs

--- a/.github/workflows/native_build.yml
+++ b/.github/workflows/native_build.yml
@@ -36,6 +36,9 @@ jobs:
           go-version: '>=1.18'
       - uses: seanmiddleditch/gha-setup-ninja@master
         if: runner.os == 'Windows'
+      - name: Setup MSVC linker
+        uses: microsoft/setup-msbuild@v2
+        if: runner.os == 'Windows'
       # TODO remove after AWS-LC FIPS bindings for Kyber are fixed
       - name: Install bindgen-cli
         run: cargo install --force --locked bindgen-cli
@@ -45,11 +48,13 @@ jobs:
           echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo 'RUSTFLAGS="-l crypt32"' | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - run: |
           sudo apt-get install -y libsqlite3-dev
         if: runner.os == 'Linux'
       - name: Test Full RFC Compliance
+        
         # Don't test AWS LC on all features as it makes it build both FIPS and non-FIPS versions
         run: cargo test --all-features --verbose --workspace --exclude mls-rs-crypto-aws-lc
       - name: Test AWS-LC provider
@@ -88,12 +93,16 @@ jobs:
           go-version: '>=1.18'
       - uses: seanmiddleditch/gha-setup-ninja@master
         if: runner.os == 'Windows'
+      - name: Setup MSVC linker
+        uses: microsoft/setup-msbuild@v2
+        if: runner.os == 'Windows'
       - run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           vcpkg install openssl:x64-windows-static-md sqlite3:x64-windows-static-md
           echo "OPENSSL_DIR=C:/vcpkg/packages/openssl_x64-windows-static-md" | Out-File -FilePath $env:GITHUB_ENV -Append
           curl -o C:/cacert.pem https://curl.se/ca/cacert.pem
           echo "SSL_CERT_FILE=C:/cacert.pem" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo 'RUSTFLAGS="-l crypt32"' | Out-File -FilePath $env:GITHUB_ENV -Append
         if: runner.os == 'Windows'
       - name: Test Async Full RFC
         run: cargo test --lib --test '*' --verbose --features test_util -p mls-rs

--- a/.github/workflows/no_std_build.yml
+++ b/.github/workflows/no_std_build.yml
@@ -7,10 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@stable
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        targets: thumbv6m-none-eabi
+        rustflags: ''
+        toolchain: stable,nightly
+        target: thumbv6m-none-eabi
         components: clippy
     - uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        rustflags: ''
     - uses: nanasess/setup-chromedriver@v2
     - uses: jetli/wasm-pack-action@v0.3.0
       with:

--- a/mls-rs-core/src/extension/list.rs
+++ b/mls-rs-core/src/extension/list.rs
@@ -162,7 +162,7 @@ impl ExtensionList {
     /// If there is already an entry in the list for the same extension type,
     /// then the existing value is removed.
     pub fn append(&mut self, others: Self) {
-        self.0.extend(others.0);
+        self.extend(others.0);
     }
 }
 
@@ -336,6 +336,29 @@ mod tests {
             TestExtensionB(vec![36]).into_extension().unwrap(),
             TestExtensionA(37).into_extension().unwrap(),
         ]);
+
+        let expected = ExtensionList(vec![
+            TestExtensionA(37).into_extension().unwrap(),
+            TestExtensionB(vec![36]).into_extension().unwrap(),
+            TestExtensionC(34).into_extension().unwrap(),
+        ]);
+
+        assert_eq!(list, expected);
+    }
+
+    #[test]
+    fn appending_extension_list_maintains_extension_uniqueness() {
+        let mut list = ExtensionList::new();
+        list.set_from(TestExtensionA(33)).unwrap();
+        list.set_from(TestExtensionC(34)).unwrap();
+
+        let to_append = ExtensionList::from_iter([
+            TestExtensionA(35).into_extension().unwrap(),
+            TestExtensionB(vec![36]).into_extension().unwrap(),
+            TestExtensionA(37).into_extension().unwrap(),
+        ]);
+
+        list.append(to_append);
 
         let expected = ExtensionList(vec![
             TestExtensionA(37).into_extension().unwrap(),


### PR DESCRIPTION
### Description of changes:

`ExtensionList` has an implementation of `Extend` that calls `set` under the hood to ensure that the final list only has one extension of each type. The `append` method did not call the same underlying logic. 

### Testing:
 
Added a unit test to cover this case

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
