### PR TITLE
fix: make VarInt inner field private

### DIFF
--- a/mls-rs-codec/src/byte_vec.rs
+++ b/mls-rs-codec/src/byte_vec.rs
@@ -13,7 +13,7 @@ where
 {
     fn slice_len(data: &[u8]) -> usize {
         let len = data.len();
-        let header_length = VarInt::try_from(len).unwrap_or(VarInt(0)).mls_encoded_len();
+        let header_length = VarInt::try_from(len).unwrap_or_default().mls_encoded_len();
 
         header_length + len
     }

--- a/mls-rs-codec/src/iter.rs
+++ b/mls-rs-codec/src/iter.rs
@@ -12,7 +12,7 @@ where
 {
     let len = iter.map(|x| x.mls_encoded_len()).sum::<usize>();
 
-    let header_length = VarInt::try_from(len).unwrap_or(VarInt(0)).mls_encoded_len();
+    let header_length = VarInt::try_from(len).unwrap_or_default().mls_encoded_len();
 
     header_length + len
 }
@@ -74,7 +74,7 @@ where
 pub fn mls_decode_split_on_collection<'b>(
     reader: &mut &'b [u8],
 ) -> Result<(&'b [u8], &'b [u8]), crate::Error> {
-    let len = VarInt::mls_decode(reader)?.0 as usize;
+    let len = u32::from(VarInt::mls_decode(reader)?) as usize;
 
     if len > reader.len() {
         return Err(crate::Error::UnexpectedEOF);

--- a/mls-rs-codec/src/varint.rs
+++ b/mls-rs-codec/src/varint.rs
@@ -5,8 +5,8 @@
 use crate::{Error, MlsDecode, MlsEncode, MlsSize};
 use alloc::vec::Vec;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct VarInt(pub u32);
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct VarInt(u32);
 
 impl VarInt {
     pub const MAX: VarInt = VarInt((1 << 30) - 1);


### PR DESCRIPTION
### Description of changes:

VarInt in mls-rs-codec was defined as VarInt(pub u32) which allowed you to construct it directly without sanitization. This was only used internally, so I was able to make it private and adjust as necessary.

### Testing:

Covered by existing tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
