### PR TITLE
remove Debug implementation for secret values

### DIFF
--- a/mls-rs-core/src/crypto.rs
+++ b/mls-rs-core/src/crypto.rs
@@ -37,10 +37,7 @@ pub struct HpkeCiphertext {
 
 impl Debug for HpkeCiphertext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("HpkeCiphertext")
-            .field("kem_output", &crate::debug::pretty_bytes(&self.kem_output))
-            .field("ciphertext", &crate::debug::pretty_bytes(&self.ciphertext))
-            .finish()
+        f.debug_struct("HpkeCiphertext").finish()
     }
 }
 
@@ -109,9 +106,7 @@ pub struct HpkeSecretKey(
 
 impl Debug for HpkeSecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        crate::debug::pretty_bytes(&self.0)
-            .named("HpkeSecretKey")
-            .fmt(f)
+        f.debug_struct("HpkeSecretKey").finish()
     }
 }
 
@@ -254,9 +249,7 @@ pub struct SignatureSecretKey {
 
 impl Debug for SignatureSecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        crate::debug::pretty_bytes(&self.bytes)
-            .named("SignatureSecretKey")
-            .fmt(f)
+        f.debug_struct("SignatureSecretKey").finish()
     }
 }
 

--- a/mls-rs-core/src/group/group_state.rs
+++ b/mls-rs-core/src/group/group_state.rs
@@ -21,7 +21,6 @@ impl Debug for GroupState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GroupState")
             .field("id", &crate::debug::pretty_bytes(&self.id))
-            .field("data", &crate::debug::pretty_bytes(&self.data))
             .finish()
     }
 }
@@ -36,10 +35,7 @@ pub struct EpochRecord {
 
 impl Debug for EpochRecord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("EpochRecord")
-            .field("id", &self.id)
-            .field("data", &crate::debug::pretty_bytes(&self.data))
-            .finish()
+        f.debug_struct("EpochRecord").field("id", &self.id).finish()
     }
 }
 

--- a/mls-rs-core/src/psk.rs
+++ b/mls-rs-core/src/psk.rs
@@ -24,9 +24,7 @@ pub struct PreSharedKey(
 
 impl Debug for PreSharedKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        crate::debug::pretty_bytes(&self.0)
-            .named("PreSharedKey")
-            .fmt(f)
+        f.debug_struct("PreSharedKey").finish()
     }
 }
 

--- a/mls-rs-core/src/secret.rs
+++ b/mls-rs-core/src/secret.rs
@@ -19,7 +19,7 @@ pub struct Secret(Zeroizing<Vec<u8>>);
 
 impl Debug for Secret {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        crate::debug::pretty_bytes(&self.0).named("Secret").fmt(f)
+        f.debug_struct("Secret").finish()
     }
 }
 

--- a/mls-rs-crypto-hpke/src/context.rs
+++ b/mls-rs-crypto-hpke/src/context.rs
@@ -24,10 +24,6 @@ pub(super) struct Context<KDF: KdfType, AEAD: AeadType> {
 impl<KDF: KdfType + Debug, AEAD: AeadType + Debug> Debug for Context<KDF, AEAD> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Context")
-            .field(
-                "exporter_secret",
-                &mls_rs_core::debug::pretty_bytes(&self.exporter_secret),
-            )
             .field("encryption_context", &self.encryption_context)
             .field("kdf", &self.kdf)
             .finish()
@@ -153,10 +149,6 @@ impl<AEAD: AeadType + Debug> Debug for EncryptionContext<AEAD> {
             )
             .field("seq_number", &self.seq_number)
             .field("aead", &self.aead)
-            .field(
-                "aead_key",
-                &mls_rs_core::debug::pretty_bytes(&self.aead_key),
-            )
             .finish()
     }
 }

--- a/mls-rs-crypto-openssl/src/ec.rs
+++ b/mls-rs-crypto-openssl/src/ec.rs
@@ -57,7 +57,6 @@ impl Debug for KeyPair {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("KeyPair")
             .field("public", &mls_rs_core::debug::pretty_bytes(&self.public))
-            .field("secret", &mls_rs_core::debug::pretty_bytes(&self.secret))
             .finish()
     }
 }

--- a/mls-rs-crypto-rustcrypto/src/ec.rs
+++ b/mls-rs-crypto-rustcrypto/src/ec.rs
@@ -332,7 +332,6 @@ impl Debug for KeyPair {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("KeyPair")
             .field("public", &mls_rs_core::debug::pretty_bytes(&self.public))
-            .field("secret", &mls_rs_core::debug::pretty_bytes(&self.secret))
             .finish()
     }
 }

--- a/mls-rs-crypto-traits/src/kem.rs
+++ b/mls-rs-crypto-traits/src/kem.rs
@@ -2,6 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+use core::fmt::Debug;
+
 use mls_rs_core::{
     crypto::{CipherSuite, HpkePublicKey, HpkeSecretKey},
     error::IntoAnyError,
@@ -49,11 +51,17 @@ pub trait KemType: Send + Sync + Sized {
 }
 
 /// Struct to represent the output of the kem [encap](KemType::encap) function
-#[derive(Clone, Debug, MlsDecode, MlsEncode, MlsSize, ZeroizeOnDrop)]
+#[derive(Clone, MlsDecode, MlsEncode, MlsSize, ZeroizeOnDrop)]
 pub struct KemResult {
     pub shared_secret: Vec<u8>,
     #[zeroize(skip)]
     pub enc: Vec<u8>,
+}
+
+impl Debug for KemResult {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KemResult").finish()
+    }
 }
 
 impl KemResult {

--- a/mls-rs/src/client_builder.rs
+++ b/mls-rs/src/client_builder.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 use alloc::vec::Vec;
-use core::time::Duration;
+use core::{fmt::Debug, time::Duration};
 
 #[cfg(feature = "sqlite")]
 use mls_rs_provider_sqlite::{
@@ -173,8 +173,13 @@ pub type BaseSqlConfig = Config<
 /// }
 ///
 /// ```
-#[derive(Debug)]
 pub struct ClientBuilder<C>(C);
+
+impl<C> Debug for ClientBuilder<C> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("ClientBuilder").finish()
+    }
+}
 
 impl Default for ClientBuilder<BaseConfig> {
     fn default() -> Self {

--- a/mls-rs/src/external_client/builder.rs
+++ b/mls-rs/src/external_client/builder.rs
@@ -94,8 +94,13 @@ pub type ExternalBaseConfig = Config<Missing, DefaultMlsRules, Missing>;
 /// }
 ///
 /// ```
-#[derive(Debug)]
 pub struct ExternalClientBuilder<C>(C);
+
+impl<C> Debug for ExternalClientBuilder<C> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("ExternalClientBuilder").finish()
+    }
+}
 
 impl Default for ExternalClientBuilder<ExternalBaseConfig> {
     fn default() -> Self {

--- a/mls-rs/src/group/ciphertext_processor/sender_data_key.rs
+++ b/mls-rs/src/group/ciphertext_processor/sender_data_key.rs
@@ -53,11 +53,7 @@ pub(crate) struct SenderDataKey<'a, CP: CipherSuiteProvider> {
 
 impl<CP: CipherSuiteProvider + Debug> Debug for SenderDataKey<'_, CP> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SenderDataKey")
-            .field("key", &mls_rs_core::debug::pretty_bytes(&self.key))
-            .field("nonce", &mls_rs_core::debug::pretty_bytes(&self.nonce))
-            .field("cipher_suite_provider", self.cipher_suite_provider)
-            .finish()
+        f.debug_struct("SenderDataKey").finish()
     }
 }
 

--- a/mls-rs/src/group/epoch.rs
+++ b/mls-rs/src/group/epoch.rs
@@ -88,9 +88,7 @@ pub(crate) struct SenderDataSecret(
 
 impl Debug for SenderDataSecret {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        mls_rs_core::debug::pretty_bytes(&self.0)
-            .named("SenderDataSecret")
-            .fmt(f)
+        f.debug_struct("SenderDataSecret").finish()
     }
 }
 

--- a/mls-rs/src/group/key_schedule.rs
+++ b/mls-rs/src/group/key_schedule.rs
@@ -46,25 +46,7 @@ pub struct KeySchedule {
 
 impl Debug for KeySchedule {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("KeySchedule")
-            .field(
-                "exporter_secret",
-                &mls_rs_core::debug::pretty_bytes(&self.exporter_secret),
-            )
-            .field(
-                "authentication_secret",
-                &mls_rs_core::debug::pretty_bytes(&self.authentication_secret),
-            )
-            .field(
-                "external_secret",
-                &mls_rs_core::debug::pretty_bytes(&self.external_secret),
-            )
-            .field(
-                "membership_key",
-                &mls_rs_core::debug::pretty_bytes(&self.membership_key),
-            )
-            .field("init_secret", &self.init_secret)
-            .finish()
+        f.debug_struct("KeySchedule").finish()
     }
 }
 
@@ -341,9 +323,7 @@ pub(crate) struct JoinerSecret(#[mls_codec(with = "mls_rs_codec::byte_vec")] Zer
 
 impl Debug for JoinerSecret {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        mls_rs_core::debug::pretty_bytes(&self.0)
-            .named("JoinerSecret")
-            .fmt(f)
+        f.debug_struct("JoinerSecret").finish()
     }
 }
 
@@ -399,9 +379,7 @@ pub struct InitSecret(
 
 impl Debug for InitSecret {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        mls_rs_core::debug::pretty_bytes(&self.0)
-            .named("InitSecret")
-            .fmt(f)
+        f.debug_struct("InitSecret").finish()
     }
 }
 

--- a/mls-rs/src/group/proposal.rs
+++ b/mls-rs/src/group/proposal.rs
@@ -231,12 +231,7 @@ pub struct ExternalInit {
 
 impl Debug for ExternalInit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ExternalInit")
-            .field(
-                "kem_output",
-                &mls_rs_core::debug::pretty_bytes(&self.kem_output),
-            )
-            .finish()
+        f.debug_struct("ExternalInit").finish()
     }
 }
 

--- a/mls-rs/src/group/secret_tree.rs
+++ b/mls-rs/src/group/secret_tree.rs
@@ -47,9 +47,7 @@ struct TreeSecret(
 
 impl Debug for TreeSecret {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        mls_rs_core::debug::pretty_bytes(&self.0)
-            .named("TreeSecret")
-            .fmt(f)
+        f.debug_struct("TreeSecret").finish()
     }
 }
 
@@ -334,8 +332,6 @@ pub struct MessageKeyData {
 impl Debug for MessageKeyData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MessageKeyData")
-            .field("nonce", &mls_rs_core::debug::pretty_bytes(&self.nonce))
-            .field("key", &mls_rs_core::debug::pretty_bytes(&self.key))
             .field("generation", &self.generation)
             .finish()
     }

--- a/mls-rs/src/psk/secret.rs
+++ b/mls-rs/src/psk/secret.rs
@@ -36,9 +36,7 @@ pub(crate) struct PskSecret(Zeroizing<Vec<u8>>);
 
 impl Debug for PskSecret {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        mls_rs_core::debug::pretty_bytes(&self.0)
-            .named("PskSecret")
-            .fmt(f)
+        f.debug_struct("PskSecret").finish()
     }
 }
 
@@ -112,6 +110,7 @@ impl PskSecret {
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
+    use core::fmt::Debug;
     #[cfg(not(mls_build_async))]
     use core::iter;
     use serde::{Deserialize, Serialize};
@@ -131,7 +130,7 @@ mod tests {
 
     use super::{PskSecret, PskSecretInput};
 
-    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
     struct PskInfo {
         #[serde(with = "hex::serde")]
         id: Vec<u8>,

--- a/mls-rs/src/tree_kem/path_secret.rs
+++ b/mls-rs/src/tree_kem/path_secret.rs
@@ -27,9 +27,7 @@ pub struct PathSecret(
 
 impl Debug for PathSecret {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        mls_rs_core::debug::pretty_bytes(&self.0)
-            .named("PathSecret")
-            .fmt(f)
+        f.debug_struct("PathSecret").finish()
     }
 }
 


### PR DESCRIPTION
### Description of changes:

The pretty_bytes function allows for a user to specify raw byte output, which a user can accidentally use to log secret values. This PR removes the pretty_bytes function from structs or fields that contain secrets

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
