### PR TITLE
fix: always use constant time comparisons for tag values

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -39,7 +39,7 @@ self_remove_proposal = ["mls-rs-core/self_remove_proposal"]
 export_key_generation = []
 gsma_rcs_e2ee_feature = ["mls-rs-core/gsma_rcs_e2ee_feature"]
 
-std = ["mls-rs-core/std", "mls-rs-codec/std", "mls-rs-identity-x509?/std", "hex/std", "futures/std", "itertools/use_std", "safer-ffi-gen?/std", "zeroize/std", "dep:debug_tree", "dep:thiserror", "serde?/std"]
+std = ["mls-rs-core/std", "mls-rs-codec/std", "mls-rs-identity-x509?/std", "hex/std", "futures/std", "itertools/use_std", "safer-ffi-gen?/std", "zeroize/std", "dep:debug_tree", "dep:thiserror", "serde?/std", "subtle/std"]
 
 ffi = ["dep:safer-ffi", "dep:safer-ffi-gen", "mls-rs-core/ffi"]
 
@@ -67,6 +67,7 @@ cfg-if = "1"
 debug_tree = { version = "0.4.0", optional = true }
 spin = { version = "0.10", default-features = false, features = ["mutex", "spin_mutex"] }
 maybe-async = { version = "0.2.10" }
+subtle = { version = "2.6.1", default-features = false, features = ["i128"] }
 
 # Optional dependencies
 mls-rs-provider-sqlite = { path = "../mls-rs-provider-sqlite", version = "0.19.0", default-features = false, optional = true }

--- a/mls-rs/src/group/confirmation_tag.rs
+++ b/mls-rs/src/group/confirmation_tag.rs
@@ -11,8 +11,9 @@ use core::{
 };
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
+use subtle::ConstantTimeEq;
 
-#[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode, Default)]
+#[derive(Clone, MlsSize, MlsEncode, MlsDecode, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfirmationTag(
@@ -20,6 +21,12 @@ pub struct ConfirmationTag(
     #[cfg_attr(feature = "serde", serde(with = "mls_rs_core::vec_serde"))]
     Vec<u8>,
 );
+
+impl PartialEq for ConfirmationTag {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.ct_eq(&other.0).into()
+    }
+}
 
 impl Debug for ConfirmationTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/mls-rs/src/group/membership_tag.rs
+++ b/mls-rs/src/group/membership_tag.rs
@@ -13,6 +13,7 @@ use core::{
 };
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
+use subtle::ConstantTimeEq;
 
 use super::message_signature::AuthenticatedContent;
 
@@ -38,9 +39,15 @@ impl<'a> AuthenticatedContentTBM<'a> {
     }
 }
 
-#[derive(Clone, PartialEq, MlsSize, MlsEncode, MlsDecode)]
+#[derive(Clone, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MembershipTag(#[mls_codec(with = "mls_rs_codec::byte_vec")] Vec<u8>);
+
+impl PartialEq for MembershipTag {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.ct_eq(&other.0).into()
+    }
+}
 
 impl Debug for MembershipTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
### Description of changes:

Since `confirmation_tag` and `membership_tag` are MAC values, we should use constant time comparisons for them in all cases. This behavior is covered everywhere by custom implementing PartialEq with the subtle crate's `ct_eq` function

### Testing:

Covered by existing tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
