### PR TITLE
Bug in parent hash validation: skipping sibling tree hash recomputation for blank ancestors of nodes with changed unmerged_leaves

### DIFF
--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -3943,6 +3943,54 @@ mod tests {
         let (_, _) = test_group.join("r").await;
     }
 
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn even_larger_group_fails_with_parent_hash_mismatch_blank_intermediate_nonblank_grandparent() {
+        let mut test_group = test_group_custom(
+            TEST_PROTOCOL_VERSION,
+            TEST_CIPHER_SUITE,
+            Default::default(),
+            None,
+            Some(CommitOptions::new().with_ratchet_tree_extension(true)),
+        )
+        .await;
+
+        let (_, _) = test_group.join("b").await;
+        let (_, _) = test_group.join("c").await;
+        let (_, _) = test_group.join("d").await;
+        let (_, _) = test_group.join("e").await;
+        let (_, _) = test_group.join("f").await;
+        let (_, _) = test_group.join("g").await;
+        test_group
+            .commit_builder()
+            .remove_member(1)
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        test_group.process_pending_commit().await.unwrap();
+        let (_, _) = test_group.join("h").await;
+        let (_, _) = test_group.join("i").await;
+        let (_, _) = test_group.join("j").await;
+        let (_, _) = test_group.join("k").await;
+        let (_, _) = test_group.join("l").await;
+        let (_, _) = test_group.join("m").await;
+        test_group
+            .commit_builder()
+            .remove_member(2)
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        test_group.process_pending_commit().await.unwrap();
+        let (_, _) = test_group.join("n").await;
+        let (_, _) = test_group.join("o").await;
+        let (_, _) = test_group.join("p").await;
+        let (_, _) = test_group.join("q").await;
+        let (_, _) = test_group.join("r").await;
+        let (_, _) = test_group.join("s").await;
+    }
+
     #[cfg(feature = "private_message")]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn member_can_see_sender_creds() {

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -3945,7 +3945,8 @@ mod tests {
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
-    async fn even_larger_group_fails_with_parent_hash_mismatch_blank_intermediate_nonblank_grandparent() {
+    async fn even_larger_group_fails_with_parent_hash_mismatch_blank_intermediate_nonblank_grandparent(
+    ) {
         let mut test_group = test_group_custom(
             TEST_PROTOCOL_VERSION,
             TEST_CIPHER_SUITE,

--- a/mls-rs/src/tree_kem/parent_hash.rs
+++ b/mls-rs/src/tree_kem/parent_hash.rs
@@ -190,8 +190,11 @@ impl TreeKemPublic {
             .non_empty_parents()
             .filter_map(|(node_index, node)| {
                 if node.parent_hash.is_empty() {
-                    None
+                dbg!("empty parent hash: {:?}", node_index);
+                None
                 } else {
+                    dbg!(node_index);
+                    dbg!(node);
                     Some(node_index)
                 }
             });
@@ -204,7 +207,9 @@ impl TreeKemPublic {
         let num_leaves = self.total_leaf_count();
 
         // For each leaf l, validate all non-blank nodes on the chain from l up the tree.
-        for (leaf_index, _) in self.nodes.non_empty_leaves() {
+        for (leaf_index, sad) in self.nodes.non_empty_leaves() {
+            dbg!("leaf_index: {:?}", leaf_index);
+            dbg!("sad: {:?}", sad);
             self.validate_chain(
                 leaf_index,
                 num_leaves,
@@ -219,6 +224,10 @@ impl TreeKemPublic {
         if nodes_to_validate.is_empty() {
             Ok(())
         } else {
+            dbg!("ew unvalidated");
+            for n in nodes_to_validate {
+                dbg!(n);
+            }
             Err(MlsError::ParentHashMismatch)
         }
     }
@@ -234,15 +243,19 @@ impl TreeKemPublic {
         #[cfg(not(feature = "std"))] nodes_to_validate: &mut BTreeSet<u32>,
     ) -> Result<(), MlsError> {
         let mut n = NodeIndex::from(leaf_index);
+        dbg!("validating: {:?}", n);
 
         while let Some(mut ps) = n.parent_sibling(&num_leaves) {
             // Find the first non-blank ancestor p of n and p's co-path child s.
             while self.nodes.is_blank(ps.parent)? {
                 // If we reached the root, we're done with this chain.
                 let Some(ps_parent) = ps.parent.parent_sibling(&num_leaves) else {
+                    dbg!("returning early: {?}", &ps);
+                    dbg!("returning early oh no: {:?}", ps.parent);
                     return Ok(());
                 };
 
+                dbg!("skipping blank: {:?}, taking {:?}", ps, &ps_parent);
                 ps = ps_parent;
             }
 
@@ -263,6 +276,9 @@ impl TreeKemPublic {
             )
             .await?;
 
+            dbg!("calculated: {:?}", &calculated);
+            dbg!("get_parent_hash: {:?}", n_node.get_parent_hash());
+            dbg!("n_node: {:?}", n_node);
             if n_node.get_parent_hash() == Some(calculated) {
                 // Check that "n is in the resolution of c, and the intersection of p's unmerged_leaves with the subtree
                 // under c is equal to the resolution of c with n removed".
@@ -307,6 +323,9 @@ impl TreeKemPublic {
                 } else {
                     return Err(MlsError::ParentHashMismatch);
                 }
+            } else if n_node.get_parent_hash().is_none() {
+                dbg!("empty parent hash bro: {:?}", n);
+                break;
             } else {
                 // If n's parent_hash field doesn't match, we're done with this chain.
                 break;

--- a/mls-rs/src/tree_kem/parent_hash.rs
+++ b/mls-rs/src/tree_kem/parent_hash.rs
@@ -205,6 +205,38 @@ impl TreeKemPublic {
         let mut nodes_to_validate = nodes_to_validate.collect::<BTreeSet<_>>();
 
         let num_leaves = self.total_leaf_count();
+        let total_nodes = if num_leaves == 0 { 0 } else { num_leaves * 2 - 1 };
+
+        println!("INCOMING TREE");
+        for i in 0..total_nodes {
+            let idx = NodeIndex::from(i);
+
+            // Get the parent index for context
+            let parent_str = match idx.parent_sibling(&num_leaves) {
+                Some(ps) => format!("{:?}", ps.parent),
+                None => "ROOT".to_string(),
+            };
+
+            match self.nodes.borrow_node(idx) {
+                Ok(Some(node)) => {
+                    let node_type = match node {
+                        Node::Parent(_) => "Parent",
+                        Node::Leaf(_) => "Leaf",
+                    };
+                    println!(
+                        "Node {:<3} (Parent: {:<4}) -> [{}]",
+                        i,
+                        parent_str,
+                        node_type,
+                        // node
+                    );
+                }
+                _ => {
+                    println!("Node {:<3} (Parent: {:<4}) -> BLANK", i, parent_str);
+                }
+            }
+        }
+        println!("DONE TREE");
 
         // For each leaf l, validate all non-blank nodes on the chain from l up the tree.
         for (leaf_index, sad) in self.nodes.non_empty_leaves() {
@@ -301,9 +333,15 @@ impl TreeKemPublic {
                     .map(|x| *x * 2);
 
                 #[cfg(feature = "std")]
-                let p_unmerged_in_c_subtree = p_unmerged_in_c_subtree.collect::<HashSet<_>>();
+                let mut p_unmerged_in_c_subtree = p_unmerged_in_c_subtree.collect::<HashSet<_>>();
                 #[cfg(not(feature = "std"))]
                 let p_unmerged_in_c_subtree = p_unmerged_in_c_subtree.collect::<BTreeSet<_>>();
+
+                if let Some(Node::Parent(c_parent)) = self.nodes.borrow_node(c)? {
+                    for l in &c_parent.unmerged_leaves {
+                        p_unmerged_in_c_subtree.remove(&NodeIndex::from(*l));
+                    }
+                }
 
                 // If p is validated for the second time, the check fails ("all non-blank parent nodes are covered by exactly one such chain").
                 if c_resolution.remove(&n) && c_resolution == p_unmerged_in_c_subtree {

--- a/mls-rs/src/tree_kem/parent_hash.rs
+++ b/mls-rs/src/tree_kem/parent_hash.rs
@@ -337,12 +337,6 @@ impl TreeKemPublic {
                 #[cfg(not(feature = "std"))]
                 let p_unmerged_in_c_subtree = p_unmerged_in_c_subtree.collect::<BTreeSet<_>>();
 
-                if let Some(Node::Parent(c_parent)) = self.nodes.borrow_node(c)? {
-                    for l in &c_parent.unmerged_leaves {
-                        p_unmerged_in_c_subtree.remove(&NodeIndex::from(*l));
-                    }
-                }
-
                 // If p is validated for the second time, the check fails ("all non-blank parent nodes are covered by exactly one such chain").
                 if c_resolution.remove(&n) && c_resolution == p_unmerged_in_c_subtree {
                     let removed = nodes_to_validate.remove(&ps.parent);

--- a/mls-rs/src/tree_kem/parent_hash.rs
+++ b/mls-rs/src/tree_kem/parent_hash.rs
@@ -190,11 +190,8 @@ impl TreeKemPublic {
             .non_empty_parents()
             .filter_map(|(node_index, node)| {
                 if node.parent_hash.is_empty() {
-                dbg!("empty parent hash: {:?}", node_index);
-                None
+                    None
                 } else {
-                    dbg!(node_index);
-                    dbg!(node);
                     Some(node_index)
                 }
             });
@@ -205,43 +202,9 @@ impl TreeKemPublic {
         let mut nodes_to_validate = nodes_to_validate.collect::<BTreeSet<_>>();
 
         let num_leaves = self.total_leaf_count();
-        let total_nodes = if num_leaves == 0 { 0 } else { num_leaves * 2 - 1 };
-
-        println!("INCOMING TREE");
-        for i in 0..total_nodes {
-            let idx = NodeIndex::from(i);
-
-            // Get the parent index for context
-            let parent_str = match idx.parent_sibling(&num_leaves) {
-                Some(ps) => format!("{:?}", ps.parent),
-                None => "ROOT".to_string(),
-            };
-
-            match self.nodes.borrow_node(idx) {
-                Ok(Some(node)) => {
-                    let node_type = match node {
-                        Node::Parent(_) => "Parent",
-                        Node::Leaf(_) => "Leaf",
-                    };
-                    println!(
-                        "Node {:<3} (Parent: {:<4}) -> [{}]",
-                        i,
-                        parent_str,
-                        node_type,
-                        // node
-                    );
-                }
-                _ => {
-                    println!("Node {:<3} (Parent: {:<4}) -> BLANK", i, parent_str);
-                }
-            }
-        }
-        println!("DONE TREE");
 
         // For each leaf l, validate all non-blank nodes on the chain from l up the tree.
-        for (leaf_index, sad) in self.nodes.non_empty_leaves() {
-            dbg!("leaf_index: {:?}", leaf_index);
-            dbg!("sad: {:?}", sad);
+        for (leaf_index, _) in self.nodes.non_empty_leaves() {
             self.validate_chain(
                 leaf_index,
                 num_leaves,
@@ -256,10 +219,6 @@ impl TreeKemPublic {
         if nodes_to_validate.is_empty() {
             Ok(())
         } else {
-            dbg!("ew unvalidated");
-            for n in nodes_to_validate {
-                dbg!(n);
-            }
             Err(MlsError::ParentHashMismatch)
         }
     }
@@ -275,19 +234,15 @@ impl TreeKemPublic {
         #[cfg(not(feature = "std"))] nodes_to_validate: &mut BTreeSet<u32>,
     ) -> Result<(), MlsError> {
         let mut n = NodeIndex::from(leaf_index);
-        dbg!("validating: {:?}", n);
 
         while let Some(mut ps) = n.parent_sibling(&num_leaves) {
             // Find the first non-blank ancestor p of n and p's co-path child s.
             while self.nodes.is_blank(ps.parent)? {
                 // If we reached the root, we're done with this chain.
                 let Some(ps_parent) = ps.parent.parent_sibling(&num_leaves) else {
-                    dbg!("returning early: {?}", &ps);
-                    dbg!("returning early oh no: {:?}", ps.parent);
                     return Ok(());
                 };
 
-                dbg!("skipping blank: {:?}, taking {:?}", ps, &ps_parent);
                 ps = ps_parent;
             }
 
@@ -308,9 +263,6 @@ impl TreeKemPublic {
             )
             .await?;
 
-            dbg!("calculated: {:?}", &calculated);
-            dbg!("get_parent_hash: {:?}", n_node.get_parent_hash());
-            dbg!("n_node: {:?}", n_node);
             if n_node.get_parent_hash() == Some(calculated) {
                 // Check that "n is in the resolution of c, and the intersection of p's unmerged_leaves with the subtree
                 // under c is equal to the resolution of c with n removed".
@@ -333,7 +285,7 @@ impl TreeKemPublic {
                     .map(|x| *x * 2);
 
                 #[cfg(feature = "std")]
-                let mut p_unmerged_in_c_subtree = p_unmerged_in_c_subtree.collect::<HashSet<_>>();
+                let p_unmerged_in_c_subtree = p_unmerged_in_c_subtree.collect::<HashSet<_>>();
                 #[cfg(not(feature = "std"))]
                 let p_unmerged_in_c_subtree = p_unmerged_in_c_subtree.collect::<BTreeSet<_>>();
 
@@ -355,9 +307,6 @@ impl TreeKemPublic {
                 } else {
                     return Err(MlsError::ParentHashMismatch);
                 }
-            } else if n_node.get_parent_hash().is_none() {
-                dbg!("empty parent hash bro: {:?}", n);
-                break;
             } else {
                 // If n's parent_hash field doesn't match, we're done with this chain.
                 break;

--- a/mls-rs/src/tree_kem/tree_hash.rs
+++ b/mls-rs/src/tree_kem/tree_hash.rs
@@ -163,11 +163,22 @@ impl TreeKemPublic {
         Ok(&unmerged[start..end])
     }
 
+    // "Does the descendant have an entry in unmerged_leaves that is not in the ancestor's unmerged_leaves?"
     fn different_unmerged(&self, ancestor: u32, descendant: u32) -> Result<bool, MlsError> {
-        Ok(!self.nodes.is_blank(ancestor)?
-            && !self.nodes.is_blank(descendant)?
-            && self.unmerged_in_subtree(ancestor, descendant)?
-                != self.nodes.borrow_as_parent(descendant)?.unmerged_leaves)
+        // A blank descendant has no unmerged_leaves, so there's nothing to compare.
+        if self.nodes.is_blank(descendant)? {
+            return Ok(false);
+        }
+
+        // `ancestor_unmerged` is the unmerged_leaves of the ancestor, or an empty list if the ancestor is blank.
+        let ancestor_unmerged = if self.nodes.is_blank(ancestor)? {
+            &[][..]
+        } else {
+            self.unmerged_in_subtree(ancestor, descendant)?
+        };
+
+        // If the descendant has unmerged leaves that are not inherited from the ancestor, return true.
+        Ok(ancestor_unmerged != self.nodes.borrow_as_parent(descendant)?.unmerged_leaves)
     }
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]


### PR DESCRIPTION
Bug: It is possible to construct a tree through sequential add/remove commits where the tree then fails to validate. This failure is in the parent hash validation, specifically in cases where during sibling tree hash computation, the sibling tree has a blank ancestor to a node that has a changed `unmerged_leaves` list.

It looks like the situation is as follows:
* on an incoming commit or join, the parent hashes must be validated
* as part of that validation, a set of original hashes is computed, to compare with. [here](https://github.com/awslabs/mls-rs/blob/main/mls-rs/src/tree_kem/parent_hash.rs#L186)
* during the computation of the original hashes, the hashes for a given subtree are only recomputed if the result of a helper function `different_unmerged` returns true [here](https://github.com/awslabs/mls-rs/blob/main/mls-rs/src/tree_kem/tree_hash.rs#L202)
* however, looking at `different_unmerged` [here](https://github.com/awslabs/mls-rs/blob/main/mls-rs/src/tree_kem/tree_hash.rs#L166), it appears there is a bug: if there is a subtree with a blank ancestor then the check will shortcircuit and return false. However, trees should be recomputed if there is a blank ancestor and a descendent  of that ancestor that has different `unmerged_leaves` .

@menonsamir isolated the bug and found the fix: thank you!! :pray: 

This PR contains @menonsamir 's bug fix, and a test that repro'd the previous validation failure (with `ParentHashMismatch`)