### PR TITLE
fix: add missing .await in SecretKeyRatchet::get_message_key

### DIFF
--- a/mls-rs/src/group/secret_tree.rs
+++ b/mls-rs/src/group/secret_tree.rs
@@ -463,7 +463,7 @@ impl SecretKeyRatchet {
 
         #[cfg(not(feature = "out_of_order"))]
         while self.generation < generation {
-            self.next_message_key(cipher_suite_provider)?;
+            self.next_message_key(cipher_suite_provider).await?;
         }
 
         #[cfg(feature = "out_of_order")]


### PR DESCRIPTION
### Description of changes:

`SecretKeyRatchet::get_message_key` called `next_message_key()` without `.await` inside the `#[cfg(not(feature = "out_of_order"))]` branch. Under `mls_build_async` the function returns a `Future`, so `?` alone is a compile error. Added `.await` to match the pattern already used in the `out_of_order` branch.

The bug is hidden by default features: `rfc_compliant` → `out_of_order` → the broken branch is excluded from compilation. It surfaces when building with `--no-default-features --features "std,private_message"` and `mls_build_async` active (e.g. targeting `wasm32-unknown-unknown`).

### Call-outs:

One-character change, no logic or API impact. The fix is consistent with the existing `out_of_order` branch which already had `.await?`.

### Testing:

The fix can be verified with:
```bash
cd mls-rs
RUSTFLAGS="--cfg mls_build_async" cargo check \
  -p mls-rs --no-default-features --features "std,private_message"
```
Before the fix this fails with `E0277`; after it compiles cleanly. No new tests added — the change restores correct async call syntax rather than altering behaviour.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
