### PR TITLE
mls-rs-crypto-webcrypto: support WorkerGlobalScope (use globalThis.crypto)

### DIFF
--- a/mls-rs-crypto-webcrypto/src/lib.rs
+++ b/mls-rs-crypto-webcrypto/src/lib.rs
@@ -25,7 +25,7 @@ use mls_rs_crypto_hpke::{
 
 use mls_rs_crypto_traits::{AeadType, KdfType, KemId};
 
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{JsCast, JsValue};
 use web_sys::SubtleCrypto;
 use zeroize::Zeroizing;
 
@@ -43,8 +43,8 @@ pub enum CryptoError {
     JsValue(String),
     #[error("Key has wrong length for cipher suite")]
     WrongKeyLength,
-    #[error("Window not found")]
-    WindowNotFound,
+    #[error("WebCrypto API unavailable in this context")]
+    WebCryptoUnavailable,
     #[error("Invalid signature")]
     InvalidSignature,
     #[error("Der encoding error {0}")]
@@ -61,12 +61,23 @@ impl From<JsValue> for CryptoError {
     }
 }
 
+// Read `globalThis.crypto` and dyn-cast to `web_sys::Crypto`. This works in
+// `Window`, `DedicatedWorkerGlobalScope`, `SharedWorkerGlobalScope`, and
+// `ServiceWorkerGlobalScope` per the W3C Web Cryptography API spec, without
+// branching on the global type.
+#[inline]
+fn crypto() -> Result<web_sys::Crypto, CryptoError> {
+    let global = js_sys::global();
+    let crypto_value = js_sys::Reflect::get(&global, &JsValue::from_str("crypto"))
+        .map_err(|_| CryptoError::WebCryptoUnavailable)?;
+    crypto_value
+        .dyn_into::<web_sys::Crypto>()
+        .map_err(|_| CryptoError::WebCryptoUnavailable)
+}
+
 #[inline]
 pub(crate) fn get_crypto() -> Result<SubtleCrypto, CryptoError> {
-    Ok(web_sys::window()
-        .ok_or(CryptoError::WindowNotFound)?
-        .crypto()?
-        .subtle())
+    Ok(crypto()?.subtle())
 }
 
 #[derive(Clone, Default, Debug)]
@@ -302,10 +313,7 @@ impl CipherSuiteProvider for WebCryptoCipherSuite {
     }
 
     fn random_bytes(&self, out: &mut [u8]) -> Result<(), Self::Error> {
-        web_sys::window()
-            .ok_or(CryptoError::WindowNotFound)?
-            .crypto()?
-            .get_random_values_with_u8_array(out)?;
+        crypto()?.get_random_values_with_u8_array(out)?;
 
         Ok(())
     }

--- a/mls-rs-crypto-webcrypto/tests/worker.rs
+++ b/mls-rs-crypto-webcrypto/tests/worker.rs
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright by contributors to this project.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#![cfg(all(mls_build_async, target_arch = "wasm32"))]
+
+use mls_rs_core::crypto::{CipherSuite, CipherSuiteProvider, CryptoProvider};
+use mls_rs_crypto_webcrypto::WebCryptoProvider;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+// Verifies that the WebCrypto provider works inside a `DedicatedWorkerGlobalScope`,
+// where `web_sys::window()` returns `None` but `globalThis.crypto.subtle` is defined.
+#[wasm_bindgen_test]
+async fn provider_works_inside_dedicated_worker() {
+    let provider = WebCryptoProvider::default();
+    let cs = provider
+        .cipher_suite_provider(CipherSuite::P256_AES128)
+        .expect("cipher suite must be available in worker context");
+
+    let (_secret, public) = cs
+        .signature_key_generate()
+        .await
+        .expect("signature_key_generate must succeed in worker context");
+    assert!(!public.as_ref().is_empty());
+
+    let mut bytes = [0u8; 32];
+    cs.random_bytes(&mut bytes)
+        .expect("random_bytes must succeed in worker context");
+    assert!(bytes.iter().any(|b| *b != 0));
+}


### PR DESCRIPTION
## Summary

The WebCrypto provider currently hard-codes `web_sys::window()` in `get_crypto()` and `random_bytes()`, which returns `None` inside any Worker context. `SubtleCrypto` and `Crypto` are defined on `WorkerGlobalScope` and its subtypes (`DedicatedWorker`, `SharedWorker`, `ServiceWorker`) per the W3C Web Cryptography API spec, so the provider fails unnecessarily when callers want to keep MLS state inside a Worker for XSS-against-keys hardening.

## Change

This PR resolves crypto via `globalThis.crypto` (read through `js_sys::global()` + `Reflect::get` + `dyn_into::<web_sys::Crypto>`), which works identically in `Window`, `DedicatedWorkerGlobalScope`, `SharedWorkerGlobalScope`, and `ServiceWorkerGlobalScope` without branching on the global type.

- No new feature flags
- No `Cargo.toml` change (`Window` and `Crypto` web-sys features already cover what is needed)
- The error variant `CryptoError::WindowNotFound` is renamed to `CryptoError::WebCryptoUnavailable` since the failure now describes the actual condition. If maintainers prefer backwards compatibility, happy to keep `WindowNotFound` as a `#[deprecated]` alias - just say the word and I will push a follow-up commit.

## Test

Added a `wasm_bindgen_test_configure!(run_in_dedicated_worker)` integration test (`mls-rs-crypto-webcrypto/tests/worker.rs`) that exercises `signature_key_generate` and `random_bytes` inside a `DedicatedWorkerGlobalScope`, validating the new code path. Existing `Window`-context tests pass unchanged. The existing CI workflow (`wasm_build.yml`) picks the new test up automatically via `wasm-pack test --headless --chrome --release`.

## Motivation

Building an MLS-encrypted advice channel for a regulated NZ financial services PWA, with the protocol state kept inside a `DedicatedWorker` so a successful XSS in the page does not become a sign/decrypt oracle. Discovered the issue via two-tab end-to-end smoke testing of mls-rs 0.55 + mls-rs-crypto-webcrypto 0.15 in WASM and would prefer to land this upstream rather than ship a perma-fork.

## References

- [SubtleCrypto on MDN](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto) - exposed on both `Window` and `WorkerGlobalScope`
- [W3C Web Cryptography API](https://www.w3.org/TR/WebCryptoAPI/) §2

## Test plan

- [x] `cargo build --target wasm32-unknown-unknown --release` (with `RUSTFLAGS=\"--cfg mls_build_async\"`) compiles clean
- [x] No remaining `web_sys::window()` references in the crate
- [ ] CI WASM workflow passes (`wasm_build.yml` runs the new worker integration test in headless Chrome)