### PR TITLE
feat: Add public API for examining ratchet trees

### DIFF
--- a/mls-rs-crypto-openssl/src/ec.rs
+++ b/mls-rs-crypto-openssl/src/ec.rs
@@ -152,7 +152,7 @@ fn private_key_from_bytes_nist(
     let mut pk_val = EcPoint::new(&group)?;
 
     if with_public {
-        pk_val.mul_generator(&group, &sk_val, &ctx)?;
+        pk_val.mul_generator2(&group, &sk_val, &mut ctx)?;
     }
 
     let key = EcKey::from_private_components(&group, &sk_val, &pk_val)?;

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.55.0"
+version = "0.55.1"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/src/group/exported_tree.rs
+++ b/mls-rs/src/group/exported_tree.rs
@@ -5,7 +5,13 @@
 use alloc::{borrow::Cow, vec::Vec};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 
-use crate::{client::MlsError, tree_kem::node::NodeVec};
+use crate::{
+    client::MlsError,
+    tree_kem::{
+        leaf_node::LeafNode,
+        node::{LeafIndex, Node, NodeIndex, NodeVec, Parent},
+    },
+};
 
 use super::Roster;
 
@@ -38,6 +44,72 @@ impl<'a> ExportedTree<'a> {
             public_tree: &self.0,
         }
     }
+
+    /// Returns a reference to the underlying vector of nodes in the tree.
+    ///
+    /// Each element is `None` for a blank node, or `Some(Node)` for an
+    /// occupied leaf or parent node. Nodes are indexed by `NodeIndex` where
+    /// even indices are leaves and odd indices are parent nodes.
+    pub fn nodes(&self) -> &[Option<Node>] {
+        &self.0
+    }
+
+    /// Returns the filtered direct path for a given leaf index as a vector
+    /// of `Option<&Parent>` nodes.
+    ///
+    /// Per RFC 9420 Section 8.4, the filtered direct path removes all nodes
+    /// whose child on the copath has an empty resolution. Each entry is `None`
+    /// if the parent node at that position is blank, or `Some(&Parent)` if
+    /// it is populated.
+    pub fn filtered_direct_path(&self, index: LeafIndex) -> Result<Vec<Option<&Parent>>, MlsError> {
+        let direct_copath = self.0.direct_copath(index);
+        let filtered = self.0.filtered(index)?;
+
+        let path = direct_copath
+            .into_iter()
+            .zip(filtered)
+            .filter_map(|(cp, is_filtered)| {
+                (!is_filtered).then(|| {
+                    self.0
+                        .get(cp.path as usize)
+                        .and_then(Option::as_ref)
+                        .and_then(|n| match n {
+                            Node::Parent(p) => Some(p),
+                            Node::Leaf(_) => None,
+                        })
+                })
+            })
+            .collect();
+
+        Ok(path)
+    }
+
+    /// Returns the parent node at the given `NodeIndex`, or `None` if the
+    /// node is blank or is a leaf node. Returns an error if the index is
+    /// out of range.
+    pub fn get_parent(&self, index: NodeIndex) -> Result<Option<&Parent>, MlsError> {
+        let parent = self.0.borrow_node(index)?.as_ref().and_then(|n| match n {
+            Node::Parent(p) => Some(p),
+            Node::Leaf(_) => None,
+        });
+
+        Ok(parent)
+    }
+
+    /// Returns the leaf node at the given `LeafIndex`, or `None` if the
+    /// leaf slot is blank. Returns an error if the index is out of range.
+    pub fn get_leaf(&self, index: LeafIndex) -> Result<Option<&LeafNode>, MlsError> {
+        let leaf = self
+            .0
+            .borrow_node(index.into())?
+            .as_ref()
+            .and_then(|n| match n {
+                Node::Leaf(l) => Some(l),
+                Node::Parent(_) => None,
+            });
+
+        Ok(leaf)
+    }
 }
 
 impl ExportedTree<'static> {
@@ -49,5 +121,76 @@ impl ExportedTree<'static> {
 impl From<ExportedTree<'_>> for NodeVec {
     fn from(value: ExportedTree) -> Self {
         value.0.into_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree_kem::node::{test_utils::get_test_node_vec, NodeTypeResolver};
+
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn test_exported_tree_accessors() {
+        // The test tree (7 nodes, 4 leaf slots):
+        //
+        //        3
+        //       / \
+        //      1   5
+        //     / \ / \
+        //    0  2 4  6
+        //    A  _  C  D
+        //
+        // Node 0: Leaf "A"
+        // Node 1: None (blank parent)
+        // Node 2: None (blank leaf)
+        // Node 3: None (blank root)
+        // Node 4: Leaf "C"
+        // Node 5: Parent { key: "CD", unmerged_leaves: [2] }
+        // Node 6: Leaf "D"
+        let nodes = get_test_node_vec().await;
+        let tree = ExportedTree::new(nodes.clone());
+
+        assert_eq!(tree.nodes().len(), nodes.len());
+
+        let leaf_a = tree.get_leaf(LeafIndex::unchecked(0)).unwrap().unwrap();
+        assert_eq!(leaf_a, nodes[0].as_leaf().unwrap());
+
+        // get_leaf for blank leaf
+        let leaf_b = tree.get_leaf(LeafIndex::unchecked(1)).unwrap();
+        assert!(leaf_b.is_none());
+
+        // get_parent for occupied parent (node index 5)
+        let parent = tree.get_parent(5).unwrap().unwrap();
+        assert_eq!(parent, nodes[5].as_parent().unwrap());
+
+        // get_parent for blank parent (node index 1)
+        let blank_parent = tree.get_parent(1).unwrap();
+        assert!(blank_parent.is_none());
+
+        // get_parent on a leaf node returns None
+        let not_parent = tree.get_parent(0).unwrap();
+        assert!(not_parent.is_none());
+
+        // filtered_direct_path for leaf 0:
+        // Direct path is [1, 3], copath is [2, 5].
+        // Node at index 1 is filtered out (copath node 2 has empty resolution).
+        // Node at index 3 is kept (copath node 5 has non-empty resolution).
+        // Node 3 is blank, so result is [None].
+        let fdp = tree.filtered_direct_path(LeafIndex::unchecked(0)).unwrap();
+        assert_eq!(fdp.len(), 1);
+        assert!(fdp[0].is_none()); // node 3 is blank
+
+        // filtered_direct_path for leaf 2 (node index 4, leaf "C"):
+        // Direct path is [5, 3], copath is [6, 1].
+        // Node 6 is leaf "D" (non-empty resolution) → node 5 kept.
+        // Node 1 is blank, but leaf 0 "A" is in resolution of subtree → check.
+        // Actually copath of node 3 is node 1, resolution of node 1 is [0] (leaf A).
+        // So node 3 is NOT filtered. Both path nodes kept.
+        let fdp2 = tree.filtered_direct_path(LeafIndex::unchecked(2)).unwrap();
+        assert_eq!(fdp2.len(), 2);
+        // Node 5 is the occupied parent
+        assert_eq!(fdp2[0].unwrap().public_key.as_ref(), b"CD");
+        // Node 3 is blank
+        assert!(fdp2[1].is_none());
     }
 }

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -30,9 +30,7 @@ use crate::psk::PreSharedKeyID;
 use crate::signer::Signable;
 use crate::tree_kem::hpke_encryption::HpkeEncryptable;
 use crate::tree_kem::kem::TreeKem;
-use crate::tree_kem::leaf_node::LeafNode;
 use crate::tree_kem::leaf_node_validator::{LeafNodeValidator, ValidationContext};
-use crate::tree_kem::node::LeafIndex;
 use crate::tree_kem::path_secret::PathSecret;
 pub use crate::tree_kem::Capabilities;
 use crate::tree_kem::{math as tree_math, ValidatedUpdatePath};
@@ -163,6 +161,8 @@ mod interop_test_vectors;
 
 mod exported_tree;
 
+pub use crate::tree_kem::leaf_node::LeafNode;
+pub use crate::tree_kem::node::{LeafIndex, Node, NodeIndex, NodeVec, Parent};
 pub use exported_tree::ExportedTree;
 
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]

--- a/mls-rs/src/tree_kem/node.rs
+++ b/mls-rs/src/tree_kem/node.rs
@@ -22,7 +22,7 @@ pub(crate) const MAX_LEAF_INDEX: u32 = (1 << 24) - 1;
 
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub(crate) struct Parent {
+pub struct Parent {
     pub public_key: HpkePublicKey,
     pub parent_hash: ParentHash,
     pub unmerged_leaves: Vec<LeafIndex>,
@@ -105,14 +105,14 @@ impl<'de> serde::Deserialize<'de> for LeafIndex {
     }
 }
 
-pub(crate) type NodeIndex = u32;
+pub type NodeIndex = u32;
 
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
 #[allow(clippy::large_enum_variant)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 //TODO: Research if this should actually be a Box<Leaf> for memory / performance reasons
-pub(crate) enum Node {
+pub enum Node {
     Leaf(LeafNode) = 1u8,
     Parent(Parent) = 2u8,
 }
@@ -202,7 +202,7 @@ impl NodeTypeResolver for Option<Node> {
 
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub(crate) struct NodeVec(Vec<Option<Node>>);
+pub struct NodeVec(Vec<Option<Node>>);
 
 impl From<Vec<Option<Node>>> for NodeVec {
     fn from(x: Vec<Option<Node>>) -> Self {


### PR DESCRIPTION
This allows applications to optimize MLS's performance by making decisions based on the structure of the ratchet tree. For example, a committer can be chosen as the group member with most blanks on their direct path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
