### PR TITLE
Validate that sender from prior epoch is still in the tree; do not return aliased sender if leaf index is reused

### DIFF
--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1453,7 +1453,6 @@ where
                 )
                 .await?;
 
-                #[cfg(feature = "prior_epoch_membership_key")]
                 validate_sender_signature_key_from_prior_epoch(
                     &self.state.public_tree,
                     &epoch.signature_public_keys,
@@ -1609,7 +1608,6 @@ where
                 )
                 .await?;
 
-                #[cfg(feature = "prior_epoch_membership_key")]
                 validate_sender_signature_key_from_prior_epoch(
                     &self.state.public_tree,
                     &epoch.signature_public_keys,

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1452,6 +1452,12 @@ where
                     SignaturePublicKeysContainer::List(&epoch.signature_public_keys),
                 )
                 .await?;
+                validate_sender_signature_key_from_prior_epoch(
+                    &self.state.public_tree,
+                    &epoch.signature_public_keys,
+                    &auth_content.content.sender,
+                )
+                .await?;
 
                 Ok(auth_content)
             }
@@ -1598,6 +1604,14 @@ where
                     &content,
                     #[cfg(feature = "by_ref_proposal")]
                     &[],
+                )
+                .await?;
+
+                #[cfg(feature = "prior_epoch_membership_key")]
+                validate_sender_signature_key_from_prior_epoch(
+                    &self.state.public_tree,
+                    &epoch.signature_public_keys,
+                    &content.content.sender,
                 )
                 .await?;
 
@@ -3563,6 +3577,49 @@ mod tests {
 
         let auth_content = bob.validate_public_message(&res).await;
         assert_matches!(auth_content, Err(MlsError::UnexpectedMessageType));
+    }
+
+    #[cfg(all(feature = "prior_epoch", feature = "prior_epoch_membership_key"))]
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn test_messages_from_prior_epoch_aliased_key_not_processed() {
+        let mut alice = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
+        let (mut bob, _) = alice.join("bob").await;
+
+        let encrypted_message = bob
+            .encrypt_application_message(b"test", vec![])
+            .await
+            .unwrap();
+
+        let custom_proposal = CustomProposal::new(TEST_CUSTOM_PROPOSAL_TYPE, vec![0, 1, 2]);
+        let proposal = bob
+            .propose_custom(custom_proposal.clone(), vec![1, 2, 3])
+            .await
+            .unwrap();
+
+        // now remove bob and add carol
+        alice
+            .commit_builder()
+            .remove_member(1)
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        alice.apply_pending_commit().await.unwrap();
+
+        alice.join("carol").await;
+
+        // test that alice can no longer process the message
+        // from bob
+        let decrypt_result = alice.process_incoming_message(encrypted_message).await;
+        assert_matches!(decrypt_result, Err(MlsError::MemberNotFound));
+
+        let validate_custom_proposal_result = alice
+            .validate_custom_proposal(&proposal, Some(TEST_CUSTOM_PROPOSAL_TYPE))
+            .await;
+        assert_matches!(
+            validate_custom_proposal_result,
+            Err(MlsError::MemberNotFound)
+        );
     }
 
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -1452,6 +1452,8 @@ where
                     SignaturePublicKeysContainer::List(&epoch.signature_public_keys),
                 )
                 .await?;
+
+                #[cfg(feature = "prior_epoch_membership_key")]
                 validate_sender_signature_key_from_prior_epoch(
                     &self.state.public_tree,
                     &epoch.signature_public_keys,

--- a/mls-rs/src/group/util.rs
+++ b/mls-rs/src/group/util.rs
@@ -226,7 +226,7 @@ pub(crate) async fn find_key_package_generation<'a, K: KeyPackageStorage>(
 // Since PriorEpoch doesn't store old credentials we don't know who
 // sent this. Reject the message instead of mis-attributing it to whoever
 // has the sender's original index.
-#[cfg(feature = "prior_epoch_membership_key")]
+#[cfg(feature = "prior_epoch")]
 #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
 pub(crate) async fn validate_sender_signature_key_from_prior_epoch(
     public_tree: &TreeKemPublic,

--- a/mls-rs/src/group/util.rs
+++ b/mls-rs/src/group/util.rs
@@ -220,6 +220,35 @@ pub(crate) async fn find_key_package_generation<'a, K: KeyPackageStorage>(
     Err(MlsError::WelcomeKeyPackageNotFound)
 }
 
+// Check the signature key of the prior sender: if it is not the same
+// as the message sender then it means the leaf index got reused and
+// the original sender isn't in the group anymore.
+// Since PriorEpoch doesn't store old credentials we don't know who
+// sent this. Reject the message instead of mis-attributing it to whoever
+// has the sender's original index.
+#[cfg(feature = "prior_epoch_membership_key")]
+#[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+pub(crate) async fn validate_sender_signature_key_from_prior_epoch(
+    public_tree: &TreeKemPublic,
+    prior_epoch_signature_keys: &[Option<crate::crypto::SignaturePublicKey>],
+    sender: &Sender,
+) -> Result<(), MlsError> {
+    if let Sender::Member(i) = sender {
+        let old_pk = prior_epoch_signature_keys
+            .get(*i as usize)
+            .cloned()
+            .flatten();
+        let cur_pk = LeafIndex::try_from(*i)
+            .ok()
+            .and_then(|li| public_tree.get_leaf_node(li).ok())
+            .map(|l| l.signing_identity.signature_key.clone());
+        if old_pk != cur_pk {
+            return Err(MlsError::MemberNotFound);
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn cipher_suite_provider<P>(
     crypto: P,
     cipher_suite: CipherSuite,


### PR DESCRIPTION
Prior to this PR, in a scenario where a client's leaf index is reused in the group (client is removed, a new client is added) then application message decryption and custom proposal validation incorrectly attribute the message as being sent from the new, aliased leaf.

With this change, we now:
- check the signing identity of the sender
- check the signing identity of the sender's leaf index in the current tree
- if these don't match, return a `MemberNotFound` because it means the member is no longer in the current tree

The test I added in this PR shows the new behaviour, where it now returns a `MemberNotFound` error, prior to this change it would attribute the messages in the test to Carol.

**Note**: a more invasive fix would be to change PriorEpoch to store the signing identities, but both for storage size reasons and for simplicity I decided to just return this error instead. LMK what you think. 