### PR TITLE
Enforce parent/leaf node index parity and odd length nodevec 

### DIFF
--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.55.1"
+version = "0.55.2"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -3579,6 +3579,100 @@ mod tests {
         assert_matches!(auth_content, Err(MlsError::UnexpectedMessageType));
     }
 
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn test_malformed_tree_not_accepted() {
+        use crate::tree_kem::parent_hash::ParentHash;
+
+        let mut alice = test_group_custom(
+            TEST_PROTOCOL_VERSION,
+            TEST_CIPHER_SUITE,
+            Default::default(),
+            None,
+            Some(
+                CommitOptions::new()
+                    .with_allow_external_commit(true)
+                    .with_ratchet_tree_extension(false),
+            ),
+        )
+        .await;
+        let (mut bob, _) = alice.join("bob").await;
+        let (mut carol, _) = alice.join("carol").await;
+        let (mut dan, _) = alice.join("dan").await;
+        let (mut frank, _) = alice.join("frank").await;
+        let (mut john, _) = alice.join("john").await;
+        let (mut kate, _) = alice.join("kate").await;
+
+        alice
+            .commit_builder()
+            .remove_member(5)
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        alice.apply_pending_commit().await.unwrap();
+        alice
+            .commit_builder()
+            .remove_member(3)
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        alice.apply_pending_commit().await.unwrap();
+
+        let (ethan_client, ethan_key_package) =
+            test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "ethan").await;
+
+        let commit_output = alice
+            .commit_builder()
+            .add_member(ethan_key_package)
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        alice.apply_pending_commit().unwrap();
+
+        let mut exported_tree = commit_output.ratchet_tree.unwrap();
+
+        let mut nodes = exported_tree.0.to_mut();
+        assert_eq!(nodes[10], None);
+
+        // now set this blank node to be a parent
+        nodes[10] = Some(Node::Parent(Parent {
+            public_key: alice.cipher_suite_provider().kem_generate().unwrap().1,
+            parent_hash: ParentHash::empty(),
+            unmerged_leaves: vec![],
+        }));
+
+        // Group from ethan's perspective
+        let (mut ethan_group, _) = Group::join(
+            &commit_output.welcome_messages[0],
+            Some(exported_tree),
+            ethan_client.config,
+            ethan_client.signer.unwrap(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(ethan_group.context().tree_hash, alice.context().tree_hash);
+
+        // but ethan has a group with an invalid node
+
+        let alice_tree = alice.export_tree();
+        let ethan_tree = ethan_group.export_tree();
+
+        let mismatched = alice_tree
+            .0
+            .iter()
+            .zip(ethan_tree.0.iter())
+            .any(|(a_n, e_n)| e_n.is_some() && a_n.is_none());
+        assert_eq!(mismatched, true);
+
+        // ethan can commit even with a messed up tree
+        ethan_group.commit_builder().build().await.unwrap();
+        ethan_group.apply_pending_commit().unwrap();
+    }
+
     #[cfg(all(feature = "prior_epoch", feature = "prior_epoch_membership_key"))]
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn test_messages_from_prior_epoch_aliased_key_not_processed() {

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -3629,7 +3629,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-        alice.apply_pending_commit().unwrap();
+        alice.apply_pending_commit().await.unwrap();
 
         let mut exported_tree = commit_output.ratchet_tree.unwrap();
 
@@ -3639,7 +3639,12 @@ mod tests {
         // now set this blank node to be a parent
         // this is illegal since even-numbered nodes are parents
         nodes[10] = Some(Node::Parent(Parent {
-            public_key: alice.cipher_suite_provider().kem_generate().unwrap().1,
+            public_key: alice
+                .cipher_suite_provider()
+                .kem_generate()
+                .await
+                .unwrap()
+                .1,
             parent_hash: ParentHash::empty(),
             unmerged_leaves: vec![],
         }));

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -3595,12 +3595,12 @@ mod tests {
             ),
         )
         .await;
-        let (mut bob, _) = alice.join("bob").await;
-        let (mut carol, _) = alice.join("carol").await;
-        let (mut dan, _) = alice.join("dan").await;
-        let (mut frank, _) = alice.join("frank").await;
-        let (mut john, _) = alice.join("john").await;
-        let (mut kate, _) = alice.join("kate").await;
+        let _ = alice.join("bob").await;
+        let _ = alice.join("carol").await;
+        let _ = alice.join("dan").await;
+        let _ = alice.join("frank").await;
+        let _ = alice.join("john").await;
+        let _ = alice.join("kate").await;
 
         alice
             .commit_builder()
@@ -3633,10 +3633,11 @@ mod tests {
 
         let mut exported_tree = commit_output.ratchet_tree.unwrap();
 
-        let mut nodes = exported_tree.0.to_mut();
+        let nodes = exported_tree.0.to_mut();
         assert_eq!(nodes[10], None);
 
         // now set this blank node to be a parent
+        // this is illegal since even-numbered nodes are parents
         nodes[10] = Some(Node::Parent(Parent {
             public_key: alice.cipher_suite_provider().kem_generate().unwrap().1,
             parent_hash: ParentHash::empty(),
@@ -3644,7 +3645,7 @@ mod tests {
         }));
 
         // Group from ethan's perspective
-        let (mut ethan_group, _) = Group::join(
+        let attempt_to_join = Group::join(
             &commit_output.welcome_messages[0],
             Some(exported_tree),
             ethan_client.config,
@@ -3652,25 +3653,9 @@ mod tests {
             None,
         )
         .await
-        .unwrap();
+        .map(|_| ());
 
-        assert_eq!(ethan_group.context().tree_hash, alice.context().tree_hash);
-
-        // but ethan has a group with an invalid node
-
-        let alice_tree = alice.export_tree();
-        let ethan_tree = ethan_group.export_tree();
-
-        let mismatched = alice_tree
-            .0
-            .iter()
-            .zip(ethan_tree.0.iter())
-            .any(|(a_n, e_n)| e_n.is_some() && a_n.is_none());
-        assert_eq!(mismatched, true);
-
-        // ethan can commit even with a messed up tree
-        ethan_group.commit_builder().build().await.unwrap();
-        ethan_group.apply_pending_commit().unwrap();
+        assert_matches!(attempt_to_join, Err(MlsError::ExpectedNode));
     }
 
     #[cfg(all(feature = "prior_epoch", feature = "prior_epoch_membership_key"))]

--- a/mls-rs/src/tree_kem/mod.rs
+++ b/mls-rs/src/tree_kem/mod.rs
@@ -37,6 +37,7 @@ use crate::group::proposal::SelfRemoveProposal;
 use crate::group::{proposal::RemoveProposal, proposal_filter::bundle::Proposable};
 
 use crate::group::proposal_filter::ProposalBundle;
+use crate::tree_kem::node::{Node, MAX_LEAF_INDEX};
 use crate::tree_kem::tree_hash::TreeHashes;
 
 mod capabilities;
@@ -102,6 +103,21 @@ impl TreeKemPublic {
     where
         IP: IdentityProvider,
     {
+        // RFC 9420 7.3: "Leaf nodes occupy the even-numbered indices, while parent nodes
+        // occupy the odd-numbered indices.". Validate this.
+        //
+        // Also validate odd length and the LeafIndex cap here.
+        if nodes.len() % 2 == 0 || nodes.len() > 2 * (MAX_LEAF_INDEX as usize) + 1 {
+            return Err(MlsError::InvalidTreeIndex);
+        }
+        if nodes.iter().enumerate().any(|(i, n)| {
+            matches!(
+                (i & 1, n),
+                (0, Some(Node::Parent(_))) | (1, Some(Node::Leaf(_)))
+            )
+        }) {
+            return Err(MlsError::ExpectedNode);
+        }
         let tree = TreeKemPublic {
             nodes,
             ..Default::default()


### PR DESCRIPTION
Prior to this PR, the `import_node_data` method would accept a tree that had a parent node where there should actually be a blank leaf. This is because `TreeValidator::validate` and `Node::next_empty_leaf` operate only on parent-at-even-index checks, so they do not validate that there isn't a parent in an odd index. 

This means someone can craft a tree that has an injected parent that passes all validations. It sadly even passes the tree hash check, because of the `.ok` [here](https://github.com/awslabs/mls-rs/blob/main/mls-rs/src/tree_kem/tree_hash.rs#L295). This means all recipients of this tree would see the tree hash matching that of the tree without the parent injected.

My fix here is to enforce the index parity for leaves/parents. 

*Note*: a repro example of a client processing the invalid tree is in the first commit in this PR.