### PR TITLE
feat: implement fluent GroupBuilder for group creation

### DIFF
--- a/mls-rs-codec-derive/src/lib.rs
+++ b/mls-rs-codec-derive/src/lib.rs
@@ -152,7 +152,7 @@ fn discriminant_for_variant(
         let str = format!(
             "{}{}",
             lit_int.base10_digits(),
-            &repr_ident.clone().expect("Expected a repr(u*) to be provided or for the variant's discriminant to be defined with suffixed literals.")
+            repr_ident.clone().expect("Expected a repr(u*) to be provided or for the variant's discriminant to be defined with suffixed literals.")
         );
         Literal::from_str(&str)
             .map(|l| quote! {#l})

--- a/mls-rs-crypto-cryptokit/build.rs
+++ b/mls-rs-crypto-cryptokit/build.rs
@@ -42,7 +42,7 @@ mod swift {
     fn get_target_info() -> SwiftTarget {
         let target = get_target_triple();
         let swift_target_info_str = Command::new("swift")
-            .args(["-print-target-info", &format!("--target={}", &target)])
+            .args(["-print-target-info", &format!("--target={}", target)])
             .output()
             .unwrap()
             .stdout;

--- a/mls-rs-crypto-openssl/src/ec.rs
+++ b/mls-rs-crypto-openssl/src/ec.rs
@@ -454,7 +454,8 @@ mod tests {
             {
                 println!(
                     "Mismatched curve public key import : key curve {:?}, import curve {:?}",
-                    &curve, &other_curve
+                    curve,
+                    other_curve
                 );
 
                 let public_key = get_test_public_keys().get_key_from_curve(curve);

--- a/mls-rs-crypto-openssl/src/ec.rs
+++ b/mls-rs-crypto-openssl/src/ec.rs
@@ -454,8 +454,7 @@ mod tests {
             {
                 println!(
                     "Mismatched curve public key import : key curve {:?}, import curve {:?}",
-                    curve,
-                    other_curve
+                    curve, other_curve
                 );
 
                 let public_key = get_test_public_keys().get_key_from_curve(curve);

--- a/mls-rs/Cargo.toml
+++ b/mls-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mls-rs"
-version = "0.55.2"
+version = "0.55.3"
 edition = "2021"
 description = "An implementation of Messaging Layer Security (RFC 9420)"
 homepage = "https://github.com/awslabs/mls-rs"

--- a/mls-rs/examples/basic_usage.rs
+++ b/mls-rs/examples/basic_usage.rs
@@ -9,7 +9,7 @@ use mls_rs::{
         basic::{BasicCredential, BasicIdentityProvider},
         SigningIdentity,
     },
-    CipherSuite, CipherSuiteProvider, Client, CryptoProvider, ExtensionList,
+    CipherSuite, CipherSuiteProvider, Client, CryptoProvider,
 };
 
 const CIPHERSUITE: CipherSuite = CipherSuite::CURVE25519_AES128;
@@ -44,7 +44,7 @@ fn main() -> Result<(), MlsError> {
     let bob = make_client(crypto_provider.clone(), "bob")?;
 
     // Alice creates a new group.
-    let mut alice_group = alice.create_group(ExtensionList::default(), Default::default(), None)?;
+    let mut alice_group = alice.group_builder()?.build()?;
 
     // Bob generates a key package that Alice needs to add Bob to the group.
     let bob_key_package =

--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -7,7 +7,7 @@ use crate::client_builder::{recreate_config, BaseConfig, ClientBuilder, MakeConf
 use crate::client_config::ClientConfig;
 use crate::group::framing::MlsMessage;
 
-use crate::group::{cipher_suite_provider, validate_group_info_joiner, GroupInfo};
+use crate::group::{cipher_suite_provider, validate_group_info_joiner, GroupBuilder, GroupInfo};
 use crate::group::{
     framing::MlsMessagePayload, snapshot::Snapshot, ExportedTree, Group, NewMemberInfo,
 };
@@ -507,11 +507,24 @@ where
         Ok(key_pkg_gen)
     }
 
+    /// Create a [`GroupBuilder`] pre-filled with this client's cipher suite,
+    /// signing identity, and signer. Use the builder's `with_*` methods to
+    /// customize the group before calling [`GroupBuilder::build`].
+    pub fn group_builder(&self) -> Result<GroupBuilder<C>, MlsError> {
+        let (signing_identity, cipher_suite) = self.signing_identity()?;
+
+        Ok(GroupBuilder::new(
+            self.config.clone(),
+            cipher_suite,
+            signing_identity.clone(),
+            self.signer()?.clone(),
+        ))
+    }
+
     /// Create a group with a specific group_id.
     ///
-    /// This function behaves the same way as
-    /// [create_group](Client::create_group) except that it
-    /// specifies a specific unique group identifier to be used.
+    /// This is a convenience wrapper around [`group_builder`](Client::group_builder).
+    /// For more control over group parameters, use the builder directly.
     ///
     /// # Warning
     ///
@@ -526,27 +539,25 @@ where
         leaf_node_extensions: ExtensionList,
         timestamp: Option<MlsTime>,
     ) -> Result<Group<C>, MlsError> {
-        let (signing_identity, cipher_suite) = self.signing_identity()?;
+        let mut builder = self
+            .group_builder()?
+            .with_group_id(group_id)
+            .with_group_context_extensions(group_context_extensions)
+            .with_leaf_node_extensions(leaf_node_extensions);
 
-        Group::new(
-            self.config.clone(),
-            Some(group_id),
-            cipher_suite,
-            self.version,
-            signing_identity.clone(),
-            group_context_extensions,
-            leaf_node_extensions,
-            self.signer()?.clone(),
-            timestamp,
-        )
-        .await
+        if let Some(time) = timestamp {
+            builder = builder.with_now_time(time)
+        }
+
+        builder.build().await
     }
 
-    /// Create a MLS group.
+    /// Create an MLS group with a random group ID.
     ///
-    /// The `cipher_suite` provided must be supported by the
-    /// [CipherSuiteProvider](crate::CipherSuiteProvider)
-    /// that was used to build the client.
+    /// This is a convenience wrapper around [`group_builder`](Client::group_builder).
+    /// For more control over group parameters, use the builder directly.
+    ///
+    /// The cipher suite used is the one configured on this client.
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub async fn create_group(
         &self,
@@ -554,20 +565,16 @@ where
         leaf_node_extensions: ExtensionList,
         timestamp: Option<MlsTime>,
     ) -> Result<Group<C>, MlsError> {
-        let (signing_identity, cipher_suite) = self.signing_identity()?;
+        let mut builder = self
+            .group_builder()?
+            .with_group_context_extensions(group_context_extensions)
+            .with_leaf_node_extensions(leaf_node_extensions);
 
-        Group::new(
-            self.config.clone(),
-            None,
-            cipher_suite,
-            self.version,
-            signing_identity.clone(),
-            group_context_extensions,
-            leaf_node_extensions,
-            self.signer()?.clone(),
-            timestamp,
-        )
-        .await
+        if let Some(time) = timestamp {
+            builder = builder.with_now_time(time)
+        }
+
+        builder.build().await
     }
 
     /// Join a MLS group via a welcome message created by a

--- a/mls-rs/src/group/builder.rs
+++ b/mls-rs/src/group/builder.rs
@@ -2,6 +2,8 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+use alloc::{vec, vec::Vec};
+
 use mls_rs_core::{
     crypto::{CipherSuite, CipherSuiteProvider, SignatureSecretKey},
     error::IntoAnyError,
@@ -53,7 +55,7 @@ impl<C> GroupBuilder<C> {
     ///
     /// Most callers should use [`Client::group_builder`](crate::Client::group_builder) instead,
     /// which fills these from the client's configuration.
-    pub fn new(
+    pub(crate) fn new(
         config: C,
         cipher_suite: CipherSuite,
         signing_identity: SigningIdentity,

--- a/mls-rs/src/group/builder.rs
+++ b/mls-rs/src/group/builder.rs
@@ -1,0 +1,228 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright by contributors to this project.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+use mls_rs_core::{
+    crypto::{CipherSuite, CipherSuiteProvider, SignatureSecretKey},
+    error::IntoAnyError,
+    extension::{Extension, ExtensionList},
+    group::GroupContext,
+    identity::{MemberValidationContext, SigningIdentity},
+    protocol_version::ProtocolVersion,
+    time::MlsTime,
+};
+
+use crate::{
+    client_config::ClientConfig,
+    error::MlsError,
+    group::{
+        cipher_suite_provider, confirmation_tag::ConfirmationTag, key_schedule::KeySchedule,
+        state_repo::GroupStateRepository, transcript_hash::InterimTranscriptHash, GroupState,
+        LeafIndex, LeafNode,
+    },
+    tree_kem::{
+        leaf_node_validator::{LeafNodeValidator, ValidationContext},
+        TreeKemPublic,
+    },
+    Group,
+};
+
+/// Builder for creating a new MLS [`Group`] with customizable parameters.
+///
+/// A `GroupBuilder` is typically obtained via [`Client::group_builder`](crate::Client::group_builder),
+/// which pre-fills the cipher suite, signing identity, and signer from the client configuration.
+/// Optional parameters such as group ID, extensions, and protocol version can then be set
+/// using the `with_*` methods before calling [`build`](GroupBuilder::build) to finalize the group.
+///
+/// If no group ID is provided, a random one is generated. The protocol version defaults
+/// to MLS 1.0.
+pub struct GroupBuilder<C> {
+    pub(crate) group_id: Option<Vec<u8>>,
+    pub(crate) protocol_version: ProtocolVersion,
+    pub(crate) group_context_extensions: ExtensionList,
+    pub(crate) leaf_node_extensions: ExtensionList,
+    pub(crate) now_time: Option<MlsTime>,
+    pub(crate) config: C,
+    pub(crate) cipher_suite: CipherSuite,
+    pub(crate) signing_identity: SigningIdentity,
+    pub(crate) signer: SignatureSecretKey,
+}
+
+impl<C> GroupBuilder<C> {
+    /// Create a new `GroupBuilder` with the required parameters.
+    ///
+    /// Most callers should use [`Client::group_builder`](crate::Client::group_builder) instead,
+    /// which fills these from the client's configuration.
+    pub fn new(
+        config: C,
+        cipher_suite: CipherSuite,
+        signing_identity: SigningIdentity,
+        signer: SignatureSecretKey,
+    ) -> Self {
+        Self {
+            group_id: None,
+            protocol_version: ProtocolVersion::MLS_10,
+            group_context_extensions: Default::default(),
+            leaf_node_extensions: Default::default(),
+            now_time: None,
+            config,
+            cipher_suite,
+            signing_identity,
+            signer,
+        }
+    }
+
+    /// Set a specific group ID. If not called, a random group ID is generated
+    /// during [`build`](GroupBuilder::build).
+    pub fn with_group_id(mut self, group_id: Vec<u8>) -> Self {
+        self.group_id = Some(group_id);
+        self
+    }
+
+    /// Set the MLS protocol version. Defaults to [`ProtocolVersion::MLS_10`].
+    pub fn with_protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
+        self.protocol_version = protocol_version;
+        self
+    }
+
+    /// Set extensions to include in the group context.
+    pub fn with_group_context_extensions(mut self, extensions: ExtensionList) -> Self {
+        self.group_context_extensions = extensions;
+        self
+    }
+
+    /// Add extension to include in the group context.
+    pub fn with_group_context_extension(mut self, extension: Extension) -> Self {
+        self.group_context_extensions.set(extension);
+        self
+    }
+
+    /// Set extensions to include in the creator's leaf node.
+    pub fn with_leaf_node_extensions(mut self, extensions: ExtensionList) -> Self {
+        self.leaf_node_extensions = extensions;
+        self
+    }
+
+    /// Add extension to include in the creator's leaf node.
+    pub fn with_leaf_node_extension(mut self, extension: Extension) -> Self {
+        self.leaf_node_extensions.set(extension);
+        self
+    }
+
+    /// Set the current time used for leaf node lifetime validation.
+    pub fn with_now_time(mut self, now_time: MlsTime) -> Self {
+        self.now_time = Some(now_time);
+        self
+    }
+}
+
+impl<C: ClientConfig + Clone> GroupBuilder<C> {
+    /// Consume the builder and create the new [`Group`].
+    ///
+    /// This generates the initial ratchet tree, key schedule, and group context
+    /// for epoch 0 of the group.
+    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
+    pub async fn build(self) -> Result<Group<C>, MlsError> {
+        let cipher_suite_provider =
+            cipher_suite_provider(self.config.crypto_provider(), self.cipher_suite)?;
+
+        let (leaf_node, leaf_node_secret) = LeafNode::generate(
+            &cipher_suite_provider,
+            self.config.leaf_properties(self.leaf_node_extensions),
+            self.signing_identity,
+            &self.signer,
+            self.config.lifetime(self.now_time),
+        )
+        .await?;
+
+        let (mut public_tree, private_tree) = TreeKemPublic::derive(
+            leaf_node,
+            leaf_node_secret,
+            &self.config.identity_provider(),
+            &self.group_context_extensions,
+        )
+        .await?;
+
+        let tree_hash = public_tree.tree_hash(&cipher_suite_provider).await?;
+
+        let group_id = self.group_id.map(Ok).unwrap_or_else(|| {
+            cipher_suite_provider
+                .random_bytes_vec(cipher_suite_provider.kdf_extract_size())
+                .map_err(|e| MlsError::CryptoProviderError(e.into_any_error()))
+        })?;
+
+        let context = GroupContext::new(
+            self.protocol_version,
+            self.cipher_suite,
+            group_id,
+            tree_hash,
+            self.group_context_extensions,
+        );
+
+        let identity_provider = self.config.identity_provider();
+
+        let member_validation_context = MemberValidationContext::ForNewGroup {
+            current_context: &context,
+        };
+
+        let leaf_node_validator = LeafNodeValidator::new(
+            &cipher_suite_provider,
+            &identity_provider,
+            member_validation_context,
+        );
+
+        leaf_node_validator
+            .check_if_valid(
+                public_tree.get_leaf_node(LeafIndex::unchecked(0))?,
+                ValidationContext::Add(self.now_time),
+            )
+            .await?;
+
+        let state_repo = GroupStateRepository::new(
+            #[cfg(feature = "prior_epoch")]
+            context.group_id.clone(),
+            self.config.group_state_storage(),
+            self.config.key_package_repo(),
+            None,
+        )?;
+
+        let key_schedule_result = KeySchedule::from_random_epoch_secret(
+            &cipher_suite_provider,
+            #[cfg(any(feature = "secret_tree_access", feature = "private_message"))]
+            public_tree.total_leaf_count(),
+        )
+        .await?;
+
+        let confirmation_tag = ConfirmationTag::create(
+            &key_schedule_result.confirmation_key,
+            &vec![].into(),
+            &cipher_suite_provider,
+        )
+        .await?;
+
+        let interim_hash = InterimTranscriptHash::create(
+            &cipher_suite_provider,
+            &vec![].into(),
+            &confirmation_tag,
+        )
+        .await?;
+
+        Ok(Group {
+            config: self.config,
+            state: GroupState::new(context, public_tree, interim_hash, confirmation_tag),
+            private_tree,
+            key_schedule: key_schedule_result.key_schedule,
+            #[cfg(feature = "by_ref_proposal")]
+            pending_updates: Default::default(),
+            pending_commit: Default::default(),
+            epoch_secrets: key_schedule_result.epoch_secrets,
+            state_repo,
+            cipher_suite_provider,
+            #[cfg(feature = "psk")]
+            previous_psk: None,
+            signer: self.signer,
+            #[cfg(test)]
+            commit_modifiers: Default::default(),
+        })
+    }
+}

--- a/mls-rs/src/group/commit.rs
+++ b/mls-rs/src/group/commit.rs
@@ -1583,10 +1583,7 @@ mod tests {
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn member_identity_is_validated_against_new_extensions() {
         let alice = client_with_test_extension(b"alice").await;
-        let mut alice = alice
-            .create_group(ExtensionList::new(), Default::default(), None)
-            .await
-            .unwrap();
+        let mut alice = alice.group_builder().unwrap().build().await.unwrap();
 
         let bob = client_with_test_extension(b"bob").await;
         let bob_kp = bob
@@ -1630,10 +1627,7 @@ mod tests {
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
     async fn server_identity_is_validated_against_new_extensions() {
         let alice = client_with_test_extension(b"alice").await;
-        let mut alice = alice
-            .create_group(ExtensionList::new(), Default::default(), None)
-            .await
-            .unwrap();
+        let mut alice = alice.group_builder().unwrap().build().await.unwrap();
 
         let mut extension_list = ExtensionList::new();
         let extension = TestExtension { foo: b'a' };

--- a/mls-rs/src/group/interop_test_vectors/passive_client.rs
+++ b/mls-rs/src/group/interop_test_vectors/passive_client.rs
@@ -569,13 +569,8 @@ pub async fn generate_passive_client_random_tests() -> Vec<TestCase> {
         )
         .await;
 
-        let creator_group = creator
-            .create_group(Default::default(), Default::default(), None)
-            .await
-            .unwrap();
-
+        let creator_group = creator.group_builder().unwrap().build().await.unwrap();
         let mut groups = vec![creator_group];
-
         let mut new_clients = Vec::new();
 
         for i in 0..10 {

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2,7 +2,6 @@
 // Copyright by contributors to this project.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -9,7 +9,6 @@ use mls_rs_codec::{MlsDecode, MlsEncode, MlsSize};
 use mls_rs_core::error::IntoAnyError;
 #[cfg(feature = "last_resort_key_package_ext")]
 use mls_rs_core::extension::MlsExtension;
-use mls_rs_core::identity::MemberValidationContext;
 use mls_rs_core::secret::Secret;
 use mls_rs_core::time::MlsTime;
 use snapshot::PendingCommitSnapshot;
@@ -30,7 +29,6 @@ use crate::psk::PreSharedKeyID;
 use crate::signer::Signable;
 use crate::tree_kem::hpke_encryption::HpkeEncryptable;
 use crate::tree_kem::kem::TreeKem;
-use crate::tree_kem::leaf_node_validator::{LeafNodeValidator, ValidationContext};
 use crate::tree_kem::path_secret::PathSecret;
 pub use crate::tree_kem::Capabilities;
 use crate::tree_kem::{math as tree_math, ValidatedUpdatePath};
@@ -110,6 +108,7 @@ pub use self::message_processor::CachedProposal;
 #[cfg(feature = "private_message")]
 mod ciphertext_processor;
 
+mod builder;
 mod commit;
 pub mod component_operation;
 pub(crate) mod confirmation_tag;
@@ -163,6 +162,7 @@ mod exported_tree;
 
 pub use crate::tree_kem::leaf_node::LeafNode;
 pub use crate::tree_kem::node::{LeafIndex, Node, NodeIndex, NodeVec, Parent};
+pub use builder::GroupBuilder;
 pub use exported_tree::ExportedTree;
 
 #[derive(Clone, Debug, PartialEq, MlsSize, MlsEncode, MlsDecode)]
@@ -282,121 +282,6 @@ impl<C> Group<C>
 where
     C: ClientConfig + Clone,
 {
-    #[allow(clippy::too_many_arguments)]
-    #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
-    pub(crate) async fn new(
-        config: C,
-        group_id: Option<Vec<u8>>,
-        cipher_suite: CipherSuite,
-        protocol_version: ProtocolVersion,
-        signing_identity: SigningIdentity,
-        group_context_extensions: ExtensionList,
-        leaf_node_extensions: ExtensionList,
-        signer: SignatureSecretKey,
-        maybe_now_time: Option<MlsTime>,
-    ) -> Result<Self, MlsError> {
-        let cipher_suite_provider = cipher_suite_provider(config.crypto_provider(), cipher_suite)?;
-
-        let (leaf_node, leaf_node_secret) = LeafNode::generate(
-            &cipher_suite_provider,
-            config.leaf_properties(leaf_node_extensions),
-            signing_identity,
-            &signer,
-            config.lifetime(maybe_now_time),
-        )
-        .await?;
-
-        let (mut public_tree, private_tree) = TreeKemPublic::derive(
-            leaf_node,
-            leaf_node_secret,
-            &config.identity_provider(),
-            &group_context_extensions,
-        )
-        .await?;
-
-        let tree_hash = public_tree.tree_hash(&cipher_suite_provider).await?;
-
-        let group_id = group_id.map(Ok).unwrap_or_else(|| {
-            cipher_suite_provider
-                .random_bytes_vec(cipher_suite_provider.kdf_extract_size())
-                .map_err(|e| MlsError::CryptoProviderError(e.into_any_error()))
-        })?;
-
-        let context = GroupContext::new(
-            protocol_version,
-            cipher_suite,
-            group_id,
-            tree_hash,
-            group_context_extensions,
-        );
-
-        let identity_provider = config.identity_provider();
-
-        let member_validation_context = MemberValidationContext::ForNewGroup {
-            current_context: &context,
-        };
-
-        let leaf_node_validator = LeafNodeValidator::new(
-            &cipher_suite_provider,
-            &identity_provider,
-            member_validation_context,
-        );
-
-        leaf_node_validator
-            .check_if_valid(
-                public_tree.get_leaf_node(LeafIndex::unchecked(0))?,
-                ValidationContext::Add(maybe_now_time),
-            )
-            .await?;
-
-        let state_repo = GroupStateRepository::new(
-            #[cfg(feature = "prior_epoch")]
-            context.group_id.clone(),
-            config.group_state_storage(),
-            config.key_package_repo(),
-            None,
-        )?;
-
-        let key_schedule_result = KeySchedule::from_random_epoch_secret(
-            &cipher_suite_provider,
-            #[cfg(any(feature = "secret_tree_access", feature = "private_message"))]
-            public_tree.total_leaf_count(),
-        )
-        .await?;
-
-        let confirmation_tag = ConfirmationTag::create(
-            &key_schedule_result.confirmation_key,
-            &vec![].into(),
-            &cipher_suite_provider,
-        )
-        .await?;
-
-        let interim_hash = InterimTranscriptHash::create(
-            &cipher_suite_provider,
-            &vec![].into(),
-            &confirmation_tag,
-        )
-        .await?;
-
-        Ok(Self {
-            config,
-            state: GroupState::new(context, public_tree, interim_hash, confirmation_tag),
-            private_tree,
-            key_schedule: key_schedule_result.key_schedule,
-            #[cfg(feature = "by_ref_proposal")]
-            pending_updates: Default::default(),
-            pending_commit: Default::default(),
-            #[cfg(test)]
-            commit_modifiers: Default::default(),
-            epoch_secrets: key_schedule_result.epoch_secrets,
-            state_repo,
-            cipher_suite_provider,
-            #[cfg(feature = "psk")]
-            previous_psk: None,
-            signer,
-        })
-    }
-
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     pub(crate) async fn join(
         welcome: &MlsMessage,
@@ -3954,11 +3839,10 @@ mod tests {
         test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "alice")
             .await
             .0
-            .create_group(
-                core::iter::once(required_caps.into_extension().unwrap()).collect(),
-                Default::default(),
-                None,
-            )
+            .group_builder()
+            .unwrap()
+            .with_group_context_extensions(vec![required_caps.into_extension().unwrap()].into())
+            .build()
             .await
     }
 
@@ -4024,11 +3908,10 @@ mod tests {
             test_client_with_key_pkg(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "alice")
                 .await
                 .0
-                .create_group(
-                    core::iter::once(ext_senders).collect(),
-                    Default::default(),
-                    None,
-                )
+                .group_builder()
+                .unwrap()
+                .with_group_context_extension(ext_senders)
+                .build()
                 .await
                 .map(|_| ());
 
@@ -5297,7 +5180,10 @@ mod tests {
             .with_random_signing_identity("alice", TEST_CIPHER_SUITE)
             .await
             .build()
-            .create_group(vec![ext_senders].into(), Default::default(), None)
+            .group_builder()
+            .unwrap()
+            .with_group_context_extension(ext_senders)
+            .build()
             .await
             .unwrap();
 
@@ -5362,11 +5248,10 @@ mod tests {
             .with_random_signing_identity("alice", TEST_CIPHER_SUITE)
             .await
             .build()
-            .create_group(
-                core::iter::once(ext_senders).collect(),
-                Default::default(),
-                None,
-            )
+            .group_builder()
+            .unwrap()
+            .with_group_context_extension(ext_senders)
+            .build()
             .await
             .unwrap();
 
@@ -5398,7 +5283,9 @@ mod tests {
             .with_random_signing_identity("alice", TEST_CIPHER_SUITE)
             .await
             .build()
-            .create_group(Default::default(), Default::default(), None)
+            .group_builder()
+            .unwrap()
+            .build()
             .await
             .unwrap();
 
@@ -5909,12 +5796,12 @@ mod tests {
     async fn invalid_update_does_not_prevent_other_updates() {
         const EXTENSION_TYPE: ExtensionType = ExtensionType::new(33);
 
-        let group_extensions = ExtensionList::from(vec![RequiredCapabilitiesExt {
+        let group_extension = RequiredCapabilitiesExt {
             extensions: vec![EXTENSION_TYPE],
             ..Default::default()
         }
         .into_extension()
-        .unwrap()]);
+        .unwrap();
 
         // Alice creates a group requiring support for an extension
         let mut alice = TestClientBuilder::new_for_test()
@@ -5922,7 +5809,10 @@ mod tests {
             .await
             .extension_type(EXTENSION_TYPE)
             .build()
-            .create_group(group_extensions.clone(), Default::default(), None)
+            .group_builder()
+            .unwrap()
+            .with_group_context_extension(group_extension)
+            .build()
             .await
             .unwrap();
 
@@ -6557,11 +6447,10 @@ mod tests {
         current_time += 10;
 
         let mut alice_group = alice
-            .create_group(
-                Default::default(),
-                Default::default(),
-                Some(current_time.into()),
-            )
+            .group_builder()
+            .unwrap()
+            .with_now_time(current_time.into())
+            .build()
             .await
             .unwrap();
 
@@ -6617,7 +6506,9 @@ mod tests {
 
         let mut alice = client_with_custom_rules(b"alice", mls_rules.clone())
             .await
-            .create_group(Default::default(), Default::default(), None)
+            .group_builder()
+            .unwrap()
+            .build()
             .await
             .unwrap();
 
@@ -6652,7 +6543,9 @@ mod tests {
 
         let mut alice = client_with_custom_rules(b"alice", mls_rules.clone())
             .await
-            .create_group(Default::default(), Default::default(), None)
+            .group_builder()
+            .unwrap()
+            .build()
             .await
             .unwrap();
 
@@ -6805,10 +6698,7 @@ mod tests {
         .await;
 
         let mut alice = TestGroup {
-            group: alice
-                .create_group(Default::default(), Default::default(), None)
-                .await
-                .unwrap(),
+            group: alice.group_builder().unwrap().build().await.unwrap(),
         };
 
         let mut bob = alice.join("bob").await.0;
@@ -7060,20 +6950,16 @@ mod tests {
             .signing_identity(signing_identity, secret_key, TEST_CIPHER_SUITE)
             .build();
 
-        let mut group = client
-            .create_group(Default::default(), Default::default(), None)
-            .await
-            .unwrap();
-
+        let mut group = client.group_builder().unwrap().build().await.unwrap();
         let group_id = group.group_id().to_vec();
-
         let proposal = CustomProposal::new(test_proposal_type, vec![]);
-        let res = group
+
+        group
             .commit_builder()
             .custom_proposal(proposal)
             .build()
-            .await;
-        assert!(res.is_err());
+            .await
+            .unwrap_err();
 
         group.write_to_storage().await.unwrap();
 
@@ -7088,12 +6974,12 @@ mod tests {
         group.apply_pending_commit().await.unwrap();
 
         let proposal = CustomProposal::new(test_proposal_type, vec![]);
-        let res = group
+
+        group
             .commit_builder()
             .custom_proposal(proposal)
             .build()
-            .await;
-
-        assert!(res.is_ok());
+            .await
+            .unwrap();
     }
 }

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -46,6 +46,8 @@ use self::mls_rules::{EncryptionOptions, MlsRules};
 
 #[cfg(feature = "psk")]
 pub use self::resumption::ReinitClient;
+#[cfg(feature = "psk")]
+use alloc::vec;
 
 #[cfg(feature = "psk")]
 use crate::psk::{

--- a/mls-rs/src/group/mod.rs
+++ b/mls-rs/src/group/mod.rs
@@ -2472,6 +2472,8 @@ pub(crate) mod test_utils;
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use crate::{
         client::test_utils::{
             test_client_with_key_pkg, TestClientBuilder, TEST_CIPHER_SUITE, TEST_PROTOCOL_VERSION,

--- a/mls-rs/src/group/resumption.rs
+++ b/mls-rs/src/group/resumption.rs
@@ -37,11 +37,11 @@ impl<C> Group<C>
 where
     C: ClientConfig + Clone,
 {
-    fn branch_group_creator(
+    fn branch_group_builder(
         &self,
         timestamp: Option<MlsTime>,
         group_id: Vec<u8>,
-    ) -> Result<GroupCreator<C>, MlsError> {
+    ) -> Result<ResumptionGroupBuilder<C>, MlsError> {
         let mut builder = GroupBuilder::new(
             self.config.clone(),
             self.cipher_suite(),
@@ -56,7 +56,7 @@ where
             builder = builder.with_now_time(time);
         }
 
-        Ok(GroupCreator {
+        Ok(ResumptionGroupBuilder {
             builder,
             psk_input: self.resumption_psk_input(ResumptionPSKUsage::Branch)?,
             typ: GroupCreationType::Branch,
@@ -80,7 +80,7 @@ where
         new_key_packages: Vec<MlsMessage>,
         timestamp: Option<MlsTime>,
     ) -> Result<(Group<C>, Vec<MlsMessage>), MlsError> {
-        self.branch_group_creator(timestamp, sub_group_id)?
+        self.branch_group_builder(timestamp, sub_group_id)?
             .create(
                 new_key_packages,
                 self.current_user_leaf_node()?.ungreased_extensions(),
@@ -97,7 +97,7 @@ where
         tree_data: Option<ExportedTree<'_>>,
         timestamp: Option<MlsTime>,
     ) -> Result<(Group<C>, NewMemberInfo), MlsError> {
-        self.branch_group_creator(timestamp, vec![])?
+        self.branch_group_builder(timestamp, vec![])?
             .join(welcome, tree_data, false, self.roster())
             .await
     }
@@ -179,7 +179,7 @@ impl<C: ClientConfig + Clone> ReinitClient<C> {
             .await
     }
 
-    fn group_creator(self, timestamp: Option<MlsTime>) -> GroupCreator<C> {
+    fn group_builder(self, timestamp: Option<MlsTime>) -> ResumptionGroupBuilder<C> {
         let mut builder = GroupBuilder::new(
             self.client.config,
             self.reinit.cipher_suite,
@@ -194,7 +194,7 @@ impl<C: ClientConfig + Clone> ReinitClient<C> {
             builder = builder.with_now_time(time);
         }
 
-        GroupCreator {
+        ResumptionGroupBuilder {
             builder,
             psk_input: self.psk_input,
             typ: GroupCreationType::Reinit,
@@ -217,7 +217,7 @@ impl<C: ClientConfig + Clone> ReinitClient<C> {
     ) -> Result<(Group<C>, Vec<MlsMessage>), MlsError> {
         let old_public_tree = core::mem::take(&mut self.old_public_tree);
 
-        self.group_creator(timestamp)
+        self.group_builder(timestamp)
             .create(
                 new_key_packages,
                 new_leaf_node_extensions,
@@ -236,19 +236,19 @@ impl<C: ClientConfig + Clone> ReinitClient<C> {
     ) -> Result<(Group<C>, NewMemberInfo), MlsError> {
         let old_public_tree = core::mem::take(&mut self.old_public_tree);
 
-        self.group_creator(timestamp)
+        self.group_builder(timestamp)
             .join(welcome, tree_data, true, old_public_tree.roster())
             .await
     }
 }
 
-struct GroupCreator<C> {
+struct ResumptionGroupBuilder<C> {
     builder: GroupBuilder<C>,
     psk_input: PskSecretInput,
     typ: GroupCreationType,
 }
 
-impl<C: ClientConfig + Clone> GroupCreator<C> {
+impl<C: ClientConfig + Clone> ResumptionGroupBuilder<C> {
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     async fn create(
         self,

--- a/mls-rs/src/group/resumption.rs
+++ b/mls-rs/src/group/resumption.rs
@@ -11,19 +11,19 @@ use futures::{stream::FuturesUnordered, TryStreamExt};
 use alloc::{vec, vec::Vec};
 
 use mls_rs_core::{
-    crypto::{CipherSuite, SignatureSecretKey},
+    crypto::SignatureSecretKey,
     error::IntoAnyError,
     extension::ExtensionList,
     identity::{IdentityProvider, SigningIdentity},
-    protocol_version::ProtocolVersion,
 };
 
 use crate::{client::MlsError, tree_kem::TreeKemPublic, Client, Group, MlsMessage};
 use crate::{group::Roster, time::MlsTime};
 
 use super::{
-    proposal::ReInitProposal, ClientConfig, ExportedTree, JustPreSharedKeyID, MessageProcessor,
-    NewMemberInfo, PreSharedKeyID, PskGroupId, PskSecretInput, ResumptionPSKUsage, ResumptionPsk,
+    builder::GroupBuilder, proposal::ReInitProposal, ClientConfig, ExportedTree,
+    JustPreSharedKeyID, MessageProcessor, NewMemberInfo, PreSharedKeyID, PskGroupId,
+    PskSecretInput, ResumptionPSKUsage, ResumptionPsk,
 };
 
 pub struct ReinitClient<C: ClientConfig + Clone> {
@@ -42,15 +42,23 @@ where
         timestamp: Option<MlsTime>,
         group_id: Vec<u8>,
     ) -> Result<GroupCreator<C>, MlsError> {
+        let mut builder = GroupBuilder::new(
+            self.config.clone(),
+            self.cipher_suite(),
+            self.current_member_signing_identity()?.clone(),
+            self.signer.clone(),
+        )
+        .with_group_id(group_id)
+        .with_protocol_version(self.protocol_version())
+        .with_group_context_extensions(self.group_state().context.extensions.clone());
+
+        if let Some(time) = timestamp {
+            builder = builder.with_now_time(time);
+        }
+
         Ok(GroupCreator {
-            group_id,
-            cipher_suite: self.cipher_suite(),
-            version: self.protocol_version(),
-            extensions: self.group_state().context.extensions.clone(),
+            builder,
             psk_input: self.resumption_psk_input(ResumptionPSKUsage::Branch)?,
-            timestamp,
-            signer: self.signer.clone(),
-            config: self.config.clone(),
             typ: GroupCreationType::Branch,
         })
     }
@@ -75,8 +83,6 @@ where
         self.branch_group_creator(timestamp, sub_group_id)?
             .create(
                 new_key_packages,
-                // TODO investigate if it's worth updating your own signing identity here
-                self.current_member_signing_identity()?.clone(),
                 self.current_user_leaf_node()?.ungreased_extensions(),
                 self.roster(),
             )
@@ -174,15 +180,23 @@ impl<C: ClientConfig + Clone> ReinitClient<C> {
     }
 
     fn group_creator(self, timestamp: Option<MlsTime>) -> GroupCreator<C> {
+        let mut builder = GroupBuilder::new(
+            self.client.config,
+            self.reinit.cipher_suite,
+            self.client.signing_identity.unwrap().0,
+            self.client.signer.unwrap(),
+        )
+        .with_group_id(self.reinit.group_id)
+        .with_protocol_version(self.reinit.version)
+        .with_group_context_extensions(self.reinit.extensions);
+
+        if let Some(time) = timestamp {
+            builder = builder.with_now_time(time);
+        }
+
         GroupCreator {
-            group_id: self.reinit.group_id,
-            cipher_suite: self.reinit.cipher_suite,
-            version: self.reinit.version,
-            extensions: self.reinit.extensions,
+            builder,
             psk_input: self.psk_input,
-            timestamp,
-            signer: self.client.signer.unwrap(),
-            config: self.client.config,
             typ: GroupCreationType::Reinit,
         }
     }
@@ -201,14 +215,11 @@ impl<C: ClientConfig + Clone> ReinitClient<C> {
         new_leaf_node_extensions: ExtensionList,
         timestamp: Option<MlsTime>,
     ) -> Result<(Group<C>, Vec<MlsMessage>), MlsError> {
-        let signing_identity = self.client.signing_identity.take();
         let old_public_tree = core::mem::take(&mut self.old_public_tree);
 
         self.group_creator(timestamp)
             .create(
                 new_key_packages,
-                // These private fields are created with `Some(x)` by `get_reinit_client`
-                signing_identity.unwrap().0,
                 new_leaf_node_extensions,
                 old_public_tree.roster(),
             )
@@ -232,39 +243,25 @@ impl<C: ClientConfig + Clone> ReinitClient<C> {
 }
 
 struct GroupCreator<C> {
-    group_id: Vec<u8>,
-    cipher_suite: CipherSuite,
-    version: ProtocolVersion,
-    extensions: ExtensionList,
+    builder: GroupBuilder<C>,
     psk_input: PskSecretInput,
-    timestamp: Option<MlsTime>,
-    signer: SignatureSecretKey,
-    config: C,
     typ: GroupCreationType,
 }
 
-impl<C: ClientConfig> GroupCreator<C> {
+impl<C: ClientConfig + Clone> GroupCreator<C> {
     #[cfg_attr(not(mls_build_async), maybe_async::must_be_sync)]
     async fn create(
         self,
         new_key_packages: Vec<MlsMessage>,
-        signing_identity: SigningIdentity,
         leaf_node_extensions: ExtensionList,
         old_roster: Roster<'_>,
     ) -> Result<(Group<C>, Vec<MlsMessage>), MlsError> {
         // Create a new group with new parameters
-        let mut group = Group::new(
-            self.config,
-            Some(self.group_id),
-            self.cipher_suite,
-            self.version,
-            signing_identity,
-            self.extensions.clone(),
-            leaf_node_extensions,
-            self.signer,
-            self.timestamp,
-        )
-        .await?;
+        let mut group = self
+            .builder
+            .with_leaf_node_extensions(leaf_node_extensions)
+            .build()
+            .await?;
 
         // Install the resumption psk in the new group
         group.previous_psk = Some(self.psk_input);
@@ -295,13 +292,18 @@ impl<C: ClientConfig> GroupCreator<C> {
         verify_group_id: bool,
         old_roster: Roster<'_>,
     ) -> Result<(Group<C>, NewMemberInfo), MlsError> {
+        let expected_version = self.builder.protocol_version;
+        let expected_cipher_suite = self.builder.cipher_suite;
+        let expected_group_id = self.builder.group_id;
+        let expected_extensions = self.builder.group_context_extensions;
+
         let (group, new_member_info) = Group::from_welcome_message(
             welcome,
             tree_data,
-            self.config,
-            self.signer,
+            self.builder.config,
+            self.builder.signer,
             Some(self.psk_input),
-            self.timestamp,
+            self.builder.now_time,
         )
         .await?;
 
@@ -309,17 +311,19 @@ impl<C: ClientConfig> GroupCreator<C> {
 
         // The version and cipher_suite values in the Welcome message are the same as those used
         // by the old group.
-        if group.protocol_version() != self.version {
+        if group.protocol_version() != expected_version {
             Err(MlsError::ProtocolVersionMismatch)
-        } else if group.cipher_suite() != self.cipher_suite {
+        } else if group.cipher_suite() != expected_cipher_suite {
             Err(MlsError::CipherSuiteMismatch)
         }
         // The epoch in the Welcome message MUST be 1.
         else if group.current_epoch() != 1 {
             Err(MlsError::InitialEpochNotOne)
-        } else if verify_group_id && group.group_id() != self.group_id {
+        } else if verify_group_id
+            && group.group_id() != expected_group_id.as_deref().unwrap_or_default()
+        {
             Err(MlsError::GroupIdMismatch)
-        } else if group.group_state().context.extensions != self.extensions {
+        } else if group.group_state().context.extensions != expected_extensions {
             Err(MlsError::ReInitExtensionsMismatch)
         } else {
             Ok((group, new_member_info))

--- a/mls-rs/src/group/test_utils.rs
+++ b/mls-rs/src/group/test_utils.rs
@@ -5,6 +5,7 @@
 use core::ops::{Deref, DerefMut};
 
 use alloc::format;
+use alloc::vec;
 use rand::RngCore;
 
 use super::*;

--- a/mls-rs/src/test_utils/mod.rs
+++ b/mls-rs/src/test_utils/mod.rs
@@ -121,11 +121,7 @@ pub async fn get_test_groups<C: CryptoProvider + Clone>(
     )
     .await;
 
-    let mut creator_group = creator
-        .create_group(Default::default(), Default::default(), None)
-        .await
-        .unwrap();
-
+    let mut creator_group = creator.group_builder().unwrap().build().await.unwrap();
     let mut receiver_clients = Vec::new();
     let mut commit_builder = creator_group.commit_builder();
 

--- a/mls-rs/src/tree_kem/tree_index.rs
+++ b/mls-rs/src/tree_kem/tree_index.rs
@@ -181,7 +181,7 @@ impl TreeIndex {
             let in_use_cred_type_unsupported_by_new_leaf = self
                 .credential_type_counters
                 .iter()
-                .filter_map(|(cred_type, counters)| Some(*cred_type).filter(|_| counters.used > 0))
+                .filter_map(|(cred_type, counters)| (counters.used > 0).then_some(*cred_type))
                 .find(|cred_type| !leaf_node.capabilities.credentials.contains(cred_type));
 
             if in_use_cred_type_unsupported_by_new_leaf.is_some() {

--- a/mls-rs/test_harness_integration/src/main.rs
+++ b/mls-rs/test_harness_integration/src/main.rs
@@ -215,12 +215,10 @@ impl MlsClient for MlsClientImpl {
 
         let group = client
             .client
-            .create_group_with_id(
-                request.group_id,
-                ExtensionList::default(),
-                Default::default(),
-                None,
-            )
+            .group_builder()
+            .map_err(abort)?
+            .with_group_id(request.group_id)
+            .build()
             .map_err(abort)?;
 
         client.group = Some(group);

--- a/mls-rs/tests/client_tests.rs
+++ b/mls-rs/tests/client_tests.rs
@@ -197,15 +197,7 @@ async fn test_create(
         .unwrap();
 
     // Alice creates a group and adds bob
-    let mut alice_group = alice
-        .create_group_with_id(
-            b"group".to_vec(),
-            Default::default(),
-            Default::default(),
-            None,
-        )
-        .await
-        .unwrap();
+    let mut alice_group = alice.group_builder().unwrap().build().await.unwrap();
 
     let welcome = &alice_group
         .commit_builder()
@@ -522,16 +514,7 @@ async fn external_commits_work(
     _encrypt_controls: bool,
 ) {
     let creator = generate_client(cipher_suite, protocol_version, 0, false).await;
-
-    let creator_group = creator
-        .create_group_with_id(
-            b"group".to_vec(),
-            Default::default(),
-            Default::default(),
-            None,
-        )
-        .await
-        .unwrap();
+    let creator_group = creator.group_builder().unwrap().build().await.unwrap();
 
     const PARTICIPANT_COUNT: usize = 10;
 
@@ -640,10 +623,7 @@ async fn reinit_works() {
     let bob1 = generate_client(suite1, version, 2, Default::default()).await;
 
     // Create a group with 2 parties
-    let mut alice_group = alice1
-        .create_group(Default::default(), Default::default(), None)
-        .await
-        .unwrap();
+    let mut alice_group = alice1.group_builder().unwrap().build().await.unwrap();
     let kp = bob1
         .generate_key_package_message(Default::default(), Default::default(), None)
         .await
@@ -905,10 +885,7 @@ async fn can_process_external_commit_if_pending_commit() {
     let alice = generate_default_client(0).await;
     let bob = generate_default_client(1).await;
 
-    let mut alice_group = alice
-        .create_group(Default::default(), Default::default(), None)
-        .await
-        .unwrap();
+    let mut alice_group = alice.group_builder().unwrap().build().await.unwrap();
 
     alice_group
         .commit_builder()


### PR DESCRIPTION
No behavior change. Introduces a public GroupBuilder API via `Client::group_builder()` that lets callers configure group creation parameters (group ID, extensions, timestamp) through chainable methods, replacing the previous internal Group::new with many positional arguments.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.
