### PR TITLE
feat: Expose a commit's by-reference proposals on MlsMessage

### DIFF
--- a/mls-rs/src/client.rs
+++ b/mls-rs/src/client.rs
@@ -931,6 +931,11 @@ mod tests {
     use assert_matches::assert_matches;
 
     #[cfg(feature = "by_ref_proposal")]
+    use crate::crypto::test_utils::test_cipher_suite_provider;
+    #[cfg(feature = "by_ref_proposal")]
+    use crate::key_package::test_utils::test_key_package_message;
+
+    #[cfg(feature = "by_ref_proposal")]
     use crate::group::message_processor::ProposalMessageDescription;
     #[cfg(feature = "by_ref_proposal")]
     use crate::group::proposal::Proposal;
@@ -1165,6 +1170,65 @@ mod tests {
         let leaf_node = external_commit.commit_path_leaf_node().unwrap();
 
         assert_eq!(leaf_node.signing_identity, bob_identity);
+    }
+
+    #[cfg(feature = "by_ref_proposal")]
+    #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]
+    async fn commit_proposals_by_reference_are_readable_from_the_message() {
+        let mut alice_group = test_group(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE).await;
+
+        let bob_key_package =
+            test_key_package_message(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "bob").await;
+
+        // A proposal sent as its own message is not a commit, so nothing is reported.
+        let proposal_message = alice_group
+            .group
+            .propose_add(bob_key_package, vec![])
+            .await
+            .unwrap();
+
+        assert!(proposal_message.proposals_by_reference().is_empty());
+
+        // Committing with the proposal cached carries it by reference, not by value.
+        let commit_output = alice_group.group.commit(vec![]).await.unwrap();
+
+        assert!(commit_output.commit_message.proposals_by_value().is_empty());
+
+        let refs = commit_output.commit_message.proposals_by_reference();
+        assert_eq!(refs.len(), 1);
+
+        // The reference is the hash the proposal message itself resolves to.
+        let cipher_suite = test_cipher_suite_provider(TEST_CIPHER_SUITE);
+
+        let expected = proposal_message
+            .into_proposal_reference(&cipher_suite)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(refs[0].as_slice(), expected.as_slice());
+
+        // A commit carrying its proposals inline reports them by value only.
+        alice_group.apply_pending_commit().await.unwrap();
+
+        let carol_key_package =
+            test_key_package_message(TEST_PROTOCOL_VERSION, TEST_CIPHER_SUITE, "carol").await;
+
+        let commit_output = alice_group
+            .group
+            .commit_builder()
+            .add_member(carol_key_package)
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+
+        assert!(commit_output
+            .commit_message
+            .proposals_by_reference()
+            .is_empty());
+
+        assert_eq!(commit_output.commit_message.proposals_by_value().len(), 1);
     }
 
     #[maybe_async::test(not(mls_build_async), async(mls_build_async, crate::futures_test))]

--- a/mls-rs/src/group/framing.rs
+++ b/mls-rs/src/group/framing.rs
@@ -560,6 +560,21 @@ impl MlsMessage {
         }
     }
 
+    /// If this is a plaintext commit message, return the references of all proposals
+    /// committed by reference. Each reference identifies a proposal that was previously
+    /// sent as its own message. If this is not a plaintext or not a commit, this returns
+    /// an empty list.
+    #[cfg(feature = "by_ref_proposal")]
+    pub fn proposals_by_reference(&self) -> Vec<&ProposalRef> {
+        match &self.payload {
+            MlsMessagePayload::Plain(plaintext) => match &plaintext.content.content {
+                Content::Commit(commit) => Self::find_reference_proposals(commit),
+                _ => Vec::new(),
+            },
+            _ => Vec::new(),
+        }
+    }
+
     /// If this is a welcome message, return key package references of all members who can
     /// join using this message.
     pub fn welcome_key_package_references(&self) -> Vec<&KeyPackageRef> {
@@ -624,6 +639,18 @@ impl MlsMessage {
             .iter()
             .filter_map(|p| match p {
                 ProposalOrRef::Proposal(p) => Some(p.as_ref()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "by_ref_proposal")]
+    fn find_reference_proposals(commit: &Commit) -> Vec<&ProposalRef> {
+        commit
+            .proposals
+            .iter()
+            .filter_map(|p| match p {
+                ProposalOrRef::Reference(r) => Some(r),
                 _ => None,
             })
             .collect()


### PR DESCRIPTION
### Issues:

Resolves #377

### Description of changes:

A commit names its proposals by value or by reference. `MlsMessage::proposals_by_value()` returns
the first kind; `Commit` and `ProposalOrRef` are `pub(crate)`, so no public API reaches the second,
not even a count. A commit whose operations are all by reference then reports an empty proposal
set, which a delivery service authorizing by proposal set cannot distinguish from a plain key
rotation.

This adds `MlsMessage::proposals_by_reference()`, mirroring the shape of `proposals_by_value()`:
the `ProposalRef` of every by-reference entry for a plaintext commit, empty for anything else.

### Call-outs:

`ProposalRef` is already public under `by_ref_proposal` (`mls_rs::mls_rules::ProposalRef`), so no
new types are exposed; the accessor is gated on the same feature. `ExternalGroup::get_cached_proposals()`
(#340) covers resolving references for a service that tracks group state; a stateless DS inspecting
only public framing can't use it, so today we hand-decode the proposal vector ourselves and this
lets us delete that. Happy to narrow the return to a count if you prefer.

### Testing:

New unit test commits a cached proposal and asserts the accessor returns its ref, matching
`into_proposal_reference()` of the proposal message (and empty for an all-by-value commit and a
non-commit message). Ran the full crate test suite, clippy (`--all-features` and the bare-bones
feature lane), and `cargo fmt --check`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.



---
_Recreation of #378, which was auto-closed when my fork was accidentally made private (permanently detaching it from the fork network). Identical commits (head df34e12)._
