### PR TITLE
feat: Expose the leaf slot count of an ExportedTree

### DIFF
--- a/mls-rs/src/group/exported_tree.rs
+++ b/mls-rs/src/group/exported_tree.rs
@@ -96,6 +96,15 @@ impl<'a> ExportedTree<'a> {
         Ok(parent)
     }
 
+    /// Returns the number of leaf slots in the tree, counting blanks.
+    ///
+    /// Leaf indices run from `0` to `total_leaf_count() - 1`, so this is the
+    /// bound for [`get_leaf`](Self::get_leaf). Use [`roster`](Self::roster)
+    /// to iterate the occupied leaves only.
+    pub fn total_leaf_count(&self) -> u32 {
+        self.0.total_leaf_count()
+    }
+
     /// Returns the leaf node at the given `LeafIndex`, or `None` if the
     /// leaf slot is blank. Returns an error if the index is out of range.
     pub fn get_leaf(&self, index: LeafIndex) -> Result<Option<&LeafNode>, MlsError> {
@@ -151,6 +160,13 @@ mod tests {
         let tree = ExportedTree::new(nodes.clone());
 
         assert_eq!(tree.nodes().len(), nodes.len());
+
+        // Four leaf slots (node indices 0, 2, 4, 6), one of them blank, so
+        // the count exceeds the roster by exactly the blank at leaf index 1.
+        assert_eq!(tree.total_leaf_count(), 4);
+        assert!(tree.get_leaf(LeafIndex::unchecked(3)).unwrap().is_some());
+        assert!(tree.get_leaf(LeafIndex::unchecked(4)).is_err());
+        assert_eq!(tree.roster().members_iter().count(), 3);
 
         let leaf_a = tree.get_leaf(LeafIndex::unchecked(0)).unwrap().unwrap();
         assert_eq!(leaf_a, nodes[0].as_leaf().unwrap());


### PR DESCRIPTION
### Issues:

No associated issue.

### Description of changes:

Reading the leaf slot count of an `ExportedTree` currently costs either a full copy of the
tree (`NodeVec::from(tree).total_leaf_count()` consumes it and calls `into_owned()`) or
re-deriving `ceil(len / 2)` from `nodes()`, which asks callers to know that MLS stores
leaves at even indices. This forwards the existing `NodeVec::total_leaf_count()` through the
borrow the tree already holds, giving the bound for `get_leaf()` with no allocation.

Same motivation as #372: the data is right there, only the borrow was missing.

`occupied_leaf_count()` is deliberately not forwarded — it is gated on
`custom_proposal + tree_index`, and `roster().members_iter().count()` already answers it.

### Testing:

Extended `test_exported_tree_accessors` over the existing 4-slot test tree: asserts the count,
that the last valid `LeafIndex` resolves, that one past it errors, and that the roster reports
3 occupied. Ran the full crate test suite, clippy (`--all-features` and the bare-bones lane),
and `cargo fmt --check`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT license.



---
_Recreation of #379, which was auto-closed when my fork was accidentally made private (permanently detaching it from the fork network). Identical commits (head d6356b4)._
